### PR TITLE
Fix plugin install: remove duplicate hooks reference

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "deeplake-hivemind",
   "description": "Cloud-backed persistent memory powered by Deeplake — read, write, and share memory across Claude Code sessions and agents",
   "version": "0.1.0",
-  "hooks": "./hooks/hooks.json",
+
   "author": {
     "name": "Activeloop",
     "url": "https://deeplake.ai"


### PR DESCRIPTION
## Summary
- Removes `"hooks": "./hooks/hooks.json"` from plugin.json
- `hooks/hooks.json` is auto-loaded by Claude Code convention — the explicit reference causes "Duplicate hooks file detected" error during `/reload-plugins`

## Test plan
- [ ] `/plugin install deeplake-hivemind@deeplake-claude-code-plugins`
- [ ] `/reload-plugins` — no errors
- [ ] `/doctor` — no plugin errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)