### PR TITLE
Fix SSO login in hook context: auth output to stderr, JSON to stdout

### DIFF
--- a/bundle/commands/auth-login.js
+++ b/bundle/commands/auth-login.js
@@ -105,14 +105,14 @@ Open this URL: ${code.verification_uri_complete}`,
     `Or visit ${code.verification_uri} and enter code: ${code.user_code}`,
     opened ? "\nBrowser opened. Waiting for sign in..." : "\nWaiting for sign in..."
   ].join("\n");
-  console.log(msg);
+  process.stderr.write(msg + "\n");
   const interval = Math.max(code.interval || 5, 5) * 1e3;
   const deadline = Date.now() + code.expires_in * 1e3;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, interval));
     const result = await pollForToken(code.device_code, apiUrl);
     if (result) {
-      console.log("\nAuthentication successful!");
+      process.stderr.write("\nAuthentication successful!\n");
       return { token: result.access_token, expiresIn: result.expires_in };
     }
   }
@@ -152,22 +152,26 @@ async function login(apiUrl = DEFAULT_API_URL) {
   const { token: authToken } = await deviceFlowLogin(apiUrl);
   const user = await apiGet("/me", authToken, apiUrl);
   const userName = user.name || (user.email ? user.email.split("@")[0] : "user");
-  console.log(`
-Logged in as: ${userName}`);
+  process.stderr.write(`
+Logged in as: ${userName}
+`);
   const orgs = await listOrgs(authToken, apiUrl);
   let orgId;
   let orgName;
   if (orgs.length === 1) {
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`Organization: ${orgName}`);
+    process.stderr.write(`Organization: ${orgName}
+`);
   } else {
-    console.log("\nOrganizations:");
-    orgs.forEach((org, i) => console.log(`  ${i + 1}. ${org.name}`));
+    process.stderr.write("\nOrganizations:\n");
+    orgs.forEach((org, i) => process.stderr.write(`  ${i + 1}. ${org.name}
+`));
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`
-Using: ${orgName} (switch with /deeplake:deeplake-org)`);
+    process.stderr.write(`
+Using: ${orgName} (switch with /deeplake:deeplake-org)
+`);
   }
   const tokenName = `deeplake-plugin-${(/* @__PURE__ */ new Date()).toISOString().slice(0, 10)}`;
   const tokenData = await apiPost("/users/me/tokens", {
@@ -186,8 +190,9 @@ Using: ${orgName} (switch with /deeplake:deeplake-org)`);
     savedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
   saveCredentials(creds);
-  console.log(`
-Credentials saved to ${CREDS_PATH}`);
+  process.stderr.write(`
+Credentials saved to ${CREDS_PATH}
+`);
   return creds;
 }
 

--- a/bundle/session-start.js
+++ b/bundle/session-start.js
@@ -100,14 +100,14 @@ Open this URL: ${code.verification_uri_complete}`,
     `Or visit ${code.verification_uri} and enter code: ${code.user_code}`,
     opened ? "\nBrowser opened. Waiting for sign in..." : "\nWaiting for sign in..."
   ].join("\n");
-  console.log(msg);
+  process.stderr.write(msg + "\n");
   const interval = Math.max(code.interval || 5, 5) * 1e3;
   const deadline = Date.now() + code.expires_in * 1e3;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, interval));
     const result = await pollForToken(code.device_code, apiUrl);
     if (result) {
-      console.log("\nAuthentication successful!");
+      process.stderr.write("\nAuthentication successful!\n");
       return { token: result.access_token, expiresIn: result.expires_in };
     }
   }
@@ -121,22 +121,26 @@ async function login(apiUrl = DEFAULT_API_URL) {
   const { token: authToken } = await deviceFlowLogin(apiUrl);
   const user = await apiGet("/me", authToken, apiUrl);
   const userName = user.name || (user.email ? user.email.split("@")[0] : "user");
-  console.log(`
-Logged in as: ${userName}`);
+  process.stderr.write(`
+Logged in as: ${userName}
+`);
   const orgs = await listOrgs(authToken, apiUrl);
   let orgId;
   let orgName;
   if (orgs.length === 1) {
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`Organization: ${orgName}`);
+    process.stderr.write(`Organization: ${orgName}
+`);
   } else {
-    console.log("\nOrganizations:");
-    orgs.forEach((org, i) => console.log(`  ${i + 1}. ${org.name}`));
+    process.stderr.write("\nOrganizations:\n");
+    orgs.forEach((org, i) => process.stderr.write(`  ${i + 1}. ${org.name}
+`));
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`
-Using: ${orgName} (switch with /deeplake:deeplake-org)`);
+    process.stderr.write(`
+Using: ${orgName} (switch with /deeplake:deeplake-org)
+`);
   }
   const tokenName = `deeplake-plugin-${(/* @__PURE__ */ new Date()).toISOString().slice(0, 10)}`;
   const tokenData = await apiPost("/users/me/tokens", {
@@ -155,8 +159,9 @@ Using: ${orgName} (switch with /deeplake:deeplake-org)`);
     savedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
   saveCredentials(creds);
-  console.log(`
-Credentials saved to ${CREDS_PATH}`);
+  process.stderr.write(`
+Credentials saved to ${CREDS_PATH}
+`);
   return creds;
 }
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -157,7 +157,7 @@ export async function deviceFlowLogin(apiUrl = DEFAULT_API_URL): Promise<{ token
   ].join("\n");
 
   // Return the message and polling function for the caller to handle
-  console.log(msg);
+  process.stderr.write(msg + "\n");
 
   const interval = Math.max(code.interval || 5, 5) * 1000;
   const deadline = Date.now() + code.expires_in * 1000;
@@ -166,7 +166,7 @@ export async function deviceFlowLogin(apiUrl = DEFAULT_API_URL): Promise<{ token
     await new Promise(r => setTimeout(r, interval));
     const result = await pollForToken(code.device_code, apiUrl);
     if (result) {
-      console.log("\nAuthentication successful!");
+      process.stderr.write("\nAuthentication successful!\n");
       return { token: result.access_token, expiresIn: result.expires_in };
     }
   }
@@ -238,7 +238,7 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
   // Step 2: Get user info
   const user = await apiGet("/me", authToken, apiUrl) as { id: string; name: string; email?: string };
   const userName = user.name || (user.email ? user.email.split("@")[0] : "user");
-  console.log(`\nLogged in as: ${userName}`);
+  process.stderr.write(`\nLogged in as: ${userName}\n`);
 
   // Step 3: List orgs and select
   const orgs = await listOrgs(authToken, apiUrl);
@@ -248,14 +248,14 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
   if (orgs.length === 1) {
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`Organization: ${orgName}`);
+    process.stderr.write(`Organization: ${orgName}\n`);
   } else {
-    console.log("\nOrganizations:");
-    orgs.forEach((org, i) => console.log(`  ${i + 1}. ${org.name}`));
+    process.stderr.write("\nOrganizations:\n");
+    orgs.forEach((org, i) => process.stderr.write(`  ${i + 1}. ${org.name}\n`));
     // Default to first org — Claude can switch later
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    console.log(`\nUsing: ${orgName} (switch with /deeplake:deeplake-org)`);
+    process.stderr.write(`\nUsing: ${orgName} (switch with /deeplake:deeplake-org)\n`);
   }
 
   // Step 4: Exchange for long-lived API token
@@ -279,7 +279,7 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
     savedAt: new Date().toISOString(),
   };
   saveCredentials(creds);
-  console.log(`\nCredentials saved to ${CREDS_PATH}`);
+  process.stderr.write(`\nCredentials saved to ${CREDS_PATH}\n`);
 
   return creds;
 }


### PR DESCRIPTION
Auth flow was printing login prompts to stdout which corrupted the JSON that Claude Code expects from hooks. Now all auth messages go to stderr (visible in terminal) while only the JSON context goes to stdout.

## Summary

<!-- What does this PR do? -->

## Version Bump

> **To trigger a release**, bump `"version"` in `package.json` before merging.
>
> | Change type     | Version bump          | Example              |
> | --------------- | --------------------- | -------------------- |
> | Bug fix         | patch (1.2.0 → 1.2.1) | `"version": "1.2.1"` |
> | New feature     | minor (1.2.0 → 1.3.0) | `"version": "1.3.0"` |
> | Breaking change | major (1.2.0 → 2.0.0) | `"version": "2.0.0"` |
>
> If you don't bump the version, no release will be created.

## Test plan

- [ ] Tests pass locally (`npm test`)
- [ ] Relevant new tests added
- [ ] Version bumped in `package.json`, or no release needed for this change
