### PR TITLE
Add 120s timeout for SessionStart hook (SSO login needs time)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bundle/session-start.js\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bundle/session-start.js\"",
+            "timeout": 120
           }
         ]
       }


### PR DESCRIPTION
Default hook timeout kills the device flow auth before user can complete browser login. 120s gives enough time for SSO.

## Summary

<!-- What does this PR do? -->

## Version Bump

> **To trigger a release**, bump `"version"` in `package.json` before merging.
>
> | Change type     | Version bump          | Example              |
> | --------------- | --------------------- | -------------------- |
> | Bug fix         | patch (1.2.0 → 1.2.1) | `"version": "1.2.1"` |
> | New feature     | minor (1.2.0 → 1.3.0) | `"version": "1.3.0"` |
> | Breaking change | major (1.2.0 → 2.0.0) | `"version": "2.0.0"` |
>
> If you don't bump the version, no release will be created.

## Test plan

- [ ] Tests pass locally (`npm test`)
- [ ] Relevant new tests added
- [ ] Version bumped in `package.json`, or no release needed for this change
