### PR TITLE
Welcome message, login command, fix hallucinated names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ From within Claude Code, run:
 /plugin marketplace add activeloopai/deeplake-claude-code-plugins
 /plugin install deeplake-hivemind@deeplake-claude-code-plugins
 /reload-plugins
+/deeplake-hivemind:login
 ```
 
 ### From source (development)
@@ -27,31 +28,25 @@ From within Claude Code, run:
 npm install
 npm run build
 claude --plugin-dir /path/to/deeplake-claude-code-plugins
+/deeplake-hivemind:login
 ```
 
 ## Authentication
 
-On first session start, the plugin automatically triggers a browser-based login via the OAuth Device Authorization Flow (RFC 8628). No manual token setup required.
+After installing the plugin, run `/deeplake-hivemind:login` to authenticate. This opens a browser for SSO login via the OAuth Device Authorization Flow (RFC 8628).
 
-1. The plugin detects no credentials at `~/.deeplake/credentials.json`
-2. Opens your browser to sign in at Deeplake
-3. Polls for the token and saves it locally (permissions: 0600)
+1. Run `/deeplake-hivemind:login` in Claude Code
+2. Browser opens — sign in at Deeplake
+3. Select your organization
+4. Credentials saved to `~/.deeplake/credentials.json` (permissions: 0600)
 
-To re-login or switch organizations, use the commands injected at session start:
+On subsequent sessions, the plugin detects existing credentials and connects automatically.
 
-```bash
-# Re-login
-node "<auth-cmd-path>" login
+To re-login or switch organizations:
 
-# List and switch organizations
-node "<auth-cmd-path>" org list
-node "<auth-cmd-path>" org switch <name-or-id>
-
-# Invite members
-node "<auth-cmd-path>" invite <email> <ADMIN|WRITE|READ>
 ```
-
-The exact `<auth-cmd-path>` is injected into Claude's context at session start.
+/deeplake-hivemind:login
+```
 
 Alternatively, set environment variables directly:
 
@@ -60,16 +55,6 @@ export DEEPLAKE_TOKEN=your-token
 export DEEPLAKE_ORG_ID=your-org-id
 export DEEPLAKE_WORKSPACE_ID=default   # optional
 ```
-
-Or add to `~/.claude/settings.json`:
-
-```json
-{
-  "env": {
-    "DEEPLAKE_TOKEN": "your-token",
-    "DEEPLAKE_ORG_ID": "your-org-id"
-  }
-}
 ```
 
 ## ⚠️ Data Collection Notice
@@ -102,6 +87,16 @@ To opt out of capture: `export DEEPLAKE_CAPTURE=false`
 | `DEEPLAKE_MEMORY_PATH` | `~/.deeplake/memory` | Path that triggers interception |
 | `DEEPLAKE_CAPTURE` | `true` | Set to `false` to disable capture |
 | `DEEPLAKE_DEBUG` | — | Set to `1` for verbose hook debug logs |
+
+### Debug mode and capture control
+
+```bash
+# Enable debug logging (writes to ~/.deeplake/hook-debug.log)
+DEEPLAKE_DEBUG=1 claude
+
+# Disable session capture
+DEEPLAKE_CAPTURE=false claude
+```
 
 ## Usage
 

--- a/bundle/commands/auth-login.js
+++ b/bundle/commands/auth-login.js
@@ -170,7 +170,7 @@ Logged in as: ${userName}
     orgId = orgs[0].id;
     orgName = orgs[0].name;
     process.stderr.write(`
-Using: ${orgName} (switch with /deeplake:deeplake-org)
+Using: ${orgName}
 `);
   }
   const tokenName = `deeplake-plugin-${(/* @__PURE__ */ new Date()).toISOString().slice(0, 10)}`;
@@ -191,6 +191,17 @@ Using: ${orgName} (switch with /deeplake:deeplake-org)
   };
   saveCredentials(creds);
   process.stderr.write(`
+\u{1F41D} Welcome to Deeplake Hivemind!
+
+Your Claude Code agents can now talk to each other and share memory across sessions, teammates, and machines.
+
+Get started:
+  1. Verify sync: spin up multiple sessions and confirm agents share context (try it across machines too)
+  2. Invite a teammate: ask Claude Code to add them to your org
+  3. Switch orgs: ask Claude Code to list or switch your organizations
+
+One brain for every agent on your team.
+
 Credentials saved to ${CREDS_PATH}
 `);
   return creds;

--- a/bundle/session-start.js
+++ b/bundle/session-start.js
@@ -804,7 +804,7 @@ async function main() {
 
 Logged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})` : `${resolvedContext}
 
-\u26A0\uFE0F Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake:deeplake-login.`;
+\u26A0\uFE0F Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake-hivemind:login to authenticate.`;
   console.log(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "SessionStart",

--- a/skills/deeplake-memory/SKILL.md
+++ b/skills/deeplake-memory/SKILL.md
@@ -47,6 +47,13 @@ The auth command path is injected at session start. Use the exact path from the 
 
 If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 
-## Debugging
+## Getting Started
 
-Set `DEEPLAKE_DEBUG=1` to enable verbose logging to `~/.deeplake/hook-debug.log`.
+After installing the plugin:
+1. Run `/deeplake-hivemind:login` to authenticate
+2. Start using memory — ask questions, Claude automatically captures and searches
+
+## Configuration
+
+- `DEEPLAKE_DEBUG=1 claude` — enable verbose logging to `~/.deeplake/hook-debug.log`
+- `DEEPLAKE_CAPTURE=false claude` — disable session capture

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -259,7 +259,7 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
     // Default to first org — Claude can switch later
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    process.stderr.write(`\nUsing: ${orgName} (switch with /deeplake:deeplake-org)\n`);
+    process.stderr.write(`\nUsing: ${orgName}\n`);
   }
 
   // Step 4: Exchange for long-lived API token
@@ -283,7 +283,21 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
     savedAt: new Date().toISOString(),
   };
   saveCredentials(creds);
-  process.stderr.write(`\nCredentials saved to ${CREDS_PATH}\n`);
+
+  process.stderr.write(`
+🐝 Welcome to Deeplake Hivemind!
+
+Your Claude Code agents can now talk to each other and share memory across sessions, teammates, and machines.
+
+Get started:
+  1. Verify sync: spin up multiple sessions and confirm agents share context (try it across machines too)
+  2. Invite a teammate: ask Claude Code to add them to your org
+  3. Switch orgs: ask Claude Code to list or switch your organizations
+
+One brain for every agent on your team.
+
+Credentials saved to ${CREDS_PATH}
+`);
 
   return creds;
 }

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -132,7 +132,7 @@ async function main(): Promise<void> {
   const resolvedContext = context.replace(/DEEPLAKE_AUTH_CMD/g, AUTH_CMD);
   const additionalContext = creds?.token
     ? `${resolvedContext}\n\nLogged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})`
-    : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake:deeplake-login.`;
+    : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake-hivemind:login to authenticate.`;
 
   console.log(JSON.stringify({
     hookSpecificOutput: {


### PR DESCRIPTION
## Summary
- 🐝 Welcome message after successful SSO login
- `/deeplake-hivemind:login` command (follows codex pattern)
- Fix hallucinated `/deeplake:deeplake-org` and `/deeplake:deeplake-login` references
- README updated with login command and debug/capture docs
- Skill updated with Getting Started section

## Test plan
- [ ] Fresh install → `/deeplake-hivemind:login` → SSO opens → welcome message shows
- [ ] Session start without creds → context says "run /deeplake-hivemind:login"
- [ ] No `/deeplake:deeplake-org` hallucination after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)