### PR TITLE
Fix org command syntax: separate args, ask role before invite

### DIFF
--- a/bundle/session-start.js
+++ b/bundle/session-start.js
@@ -251,12 +251,16 @@ SEARCH STRATEGY: Always read index.md first. Then read specific summaries. Only 
 
 Search command: Grep pattern="keyword" path="~/.deeplake/memory"
 
-Organization management (DEEPLAKE_AUTH_CMD will be replaced with actual path below):
-- Switch org: node "DEEPLAKE_AUTH_CMD" org switch <name-or-id>
-- List orgs: node "DEEPLAKE_AUTH_CMD" org list
-- Invite member: node "DEEPLAKE_AUTH_CMD" invite <email> <ADMIN|WRITE|READ>
-- List members: node "DEEPLAKE_AUTH_CMD" members
-- Re-login: node "DEEPLAKE_AUTH_CMD" login
+Organization management \u2014 each argument is SEPARATE (do NOT quote subcommands together):
+- node "DEEPLAKE_AUTH_CMD" login                              \u2014 SSO login
+- node "DEEPLAKE_AUTH_CMD" whoami                             \u2014 show current user/org
+- node "DEEPLAKE_AUTH_CMD" org list                           \u2014 list organizations
+- node "DEEPLAKE_AUTH_CMD" org switch <name-or-id>            \u2014 switch organization
+- node "DEEPLAKE_AUTH_CMD" workspaces                         \u2014 list workspaces
+- node "DEEPLAKE_AUTH_CMD" workspace <id>                     \u2014 switch workspace
+- node "DEEPLAKE_AUTH_CMD" invite <email> <ADMIN|WRITE|READ>  \u2014 invite member (ALWAYS ask user which role before inviting)
+- node "DEEPLAKE_AUTH_CMD" members                            \u2014 list members
+- node "DEEPLAKE_AUTH_CMD" remove <user-id>                   \u2014 remove member
 
 LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 

--- a/skills/deeplake-memory/SKILL.md
+++ b/skills/deeplake-memory/SKILL.md
@@ -37,11 +37,15 @@ Do NOT jump straight to reading raw JSONL files. Always start with index.md and 
 ## Organization Management
 
 The auth command path is injected at session start. Use the exact path from the session context. Each argument is separate — do NOT quote subcommands together:
+- `node "<AUTH_CMD>" login` — SSO login
+- `node "<AUTH_CMD>" whoami` — show current user/org
 - `node "<AUTH_CMD>" org list` — list organizations
 - `node "<AUTH_CMD>" org switch <name-or-id>` — switch organization
+- `node "<AUTH_CMD>" workspaces` — list workspaces
+- `node "<AUTH_CMD>" workspace <id>` — switch workspace
 - `node "<AUTH_CMD>" invite <email> <ADMIN|WRITE|READ>` — invite member (ALWAYS ask user which role first)
 - `node "<AUTH_CMD>" members` — list members
-- `node "<AUTH_CMD>" login` — re-login
+- `node "<AUTH_CMD>" remove <user-id>` — remove member
 - `node "<AUTH_CMD>" --help` — show all commands
 
 ## Limits

--- a/skills/deeplake-memory/SKILL.md
+++ b/skills/deeplake-memory/SKILL.md
@@ -36,12 +36,13 @@ Do NOT jump straight to reading raw JSONL files. Always start with index.md and 
 
 ## Organization Management
 
-The auth command path is injected at session start. Use the exact path from the session context. Commands:
-- `org list` — list organizations
-- `org switch <name-or-id>` — switch organization
-- `invite <email> <ADMIN|WRITE|READ>` — invite member
-- `members` — list members
-- `login` — re-login
+The auth command path is injected at session start. Use the exact path from the session context. Each argument is separate — do NOT quote subcommands together:
+- `node "<AUTH_CMD>" org list` — list organizations
+- `node "<AUTH_CMD>" org switch <name-or-id>` — switch organization
+- `node "<AUTH_CMD>" invite <email> <ADMIN|WRITE|READ>` — invite member (ALWAYS ask user which role first)
+- `node "<AUTH_CMD>" members` — list members
+- `node "<AUTH_CMD>" login` — re-login
+- `node "<AUTH_CMD>" --help` — show all commands
 
 ## Limits
 

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -36,12 +36,16 @@ SEARCH STRATEGY: Always read index.md first. Then read specific summaries. Only 
 
 Search command: Grep pattern="keyword" path="~/.deeplake/memory"
 
-Organization management (DEEPLAKE_AUTH_CMD will be replaced with actual path below):
-- Switch org: node "DEEPLAKE_AUTH_CMD" org switch <name-or-id>
-- List orgs: node "DEEPLAKE_AUTH_CMD" org list
-- Invite member: node "DEEPLAKE_AUTH_CMD" invite <email> <ADMIN|WRITE|READ>
-- List members: node "DEEPLAKE_AUTH_CMD" members
-- Re-login: node "DEEPLAKE_AUTH_CMD" login
+Organization management — each argument is SEPARATE (do NOT quote subcommands together):
+- node "DEEPLAKE_AUTH_CMD" login                              — SSO login
+- node "DEEPLAKE_AUTH_CMD" whoami                             — show current user/org
+- node "DEEPLAKE_AUTH_CMD" org list                           — list organizations
+- node "DEEPLAKE_AUTH_CMD" org switch <name-or-id>            — switch organization
+- node "DEEPLAKE_AUTH_CMD" workspaces                         — list workspaces
+- node "DEEPLAKE_AUTH_CMD" workspace <id>                     — switch workspace
+- node "DEEPLAKE_AUTH_CMD" invite <email> <ADMIN|WRITE|READ>  — invite member (ALWAYS ask user which role before inviting)
+- node "DEEPLAKE_AUTH_CMD" members                            — list members
+- node "DEEPLAKE_AUTH_CMD" remove <user-id>                   — remove member
 
 LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 


### PR DESCRIPTION
## Summary
- Clarify that CLI arguments must be separate (do NOT quote subcommands like `"org switch"`)
- Add all missing commands: `whoami`, `workspaces`, `workspace`, `remove`
- Invite: always ask user which role (ADMIN/WRITE/READ) before inviting
- Add `--help` flag for self-discovery
- Verified all formats against `deeplake-api` source (`InviteMemberRequest`: `{username, access_mode}`)

## Problem
Claude tried 3 different syntaxes before getting `org switch` right:
1. `switch-org cc-new` — wrong command name
2. `"org switch" cc-new` — quoted as one arg
3. `org switch cc-new` — correct

## Test plan
- [x] Verified CLI arg parsing in `auth-login.ts` (`process.argv.slice(2)`)
- [x] Verified API endpoint format against `deeplake-api` source
- [x] Real-world test: ask Claude to switch org and invite member

🤖 Generated with [Claude Code](https://claude.com/claude-code)