### PR TITLE
fix: capture table fallback + schema column renames

### DIFF
--- a/bundle/capture.js
+++ b/bundle/capture.js
@@ -131,7 +131,7 @@ var DeeplakeApi = class {
     const lud = row.lastUpdateDate ?? ts;
     const exists = await this.query(`SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`);
     if (exists.length > 0) {
-      let setClauses = `content = E'\\\\x${hex}', content_text = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
+      let setClauses = `content = E'\\\\x${hex}', summary = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
       if (row.project !== void 0)
         setClauses += `, project = '${sqlStr(row.project)}'`;
       if (row.description !== void 0)
@@ -139,7 +139,7 @@ var DeeplakeApi = class {
       await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(row.path)}'`);
     } else {
       const id = randomUUID();
-      let cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date";
+      let cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date";
       let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'\\\\x${hex}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
       if (row.project !== void 0) {
         cols += ", project";
@@ -181,10 +181,10 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log2(`table "${tbl}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, content_text TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, summary TEXT NOT NULL DEFAULT '', author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${tbl}" created`);
     } else {
-      for (const col of ["project", "description", "creation_date", "last_update_date"]) {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
         try {
           await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
           log2(`added column "${col}" to "${tbl}"`);
@@ -193,12 +193,12 @@ var DeeplakeApi = class {
       }
     }
   }
-  /** Create the sessions table (uses JSONB for content_text since every row is a JSON event). */
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
     const tables = await this.listTables();
     if (!tables.includes(name)) {
       log2(`table "${name}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content_text JSONB, mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${name}" created`);
     }
   }
@@ -274,7 +274,7 @@ async function main() {
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
-  const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, content_text, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`;
+  const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, '${sqlStr(config.userName)}', ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`;
   try {
     await api.query(insertSql);
   } catch (e) {

--- a/bundle/capture.js
+++ b/bundle/capture.js
@@ -274,7 +274,18 @@ async function main() {
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
-  await api.query(`INSERT INTO "${sessionsTable}" (id, path, filename, content_text, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`);
+  const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, content_text, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`;
+  try {
+    await api.query(insertSql);
+  } catch (e) {
+    if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
+      log3("table missing, creating and retrying");
+      await api.ensureSessionsTable(sessionsTable);
+      await api.query(insertSql);
+    } else {
+      throw e;
+    }
+  }
   log3("capture ok \u2192 cloud");
 }
 main().catch((e) => {

--- a/bundle/pre-tool-use.js
+++ b/bundle/pre-tool-use.js
@@ -139,7 +139,7 @@ var DeeplakeApi = class {
     const lud = row.lastUpdateDate ?? ts;
     const exists = await this.query(`SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`);
     if (exists.length > 0) {
-      let setClauses = `content = E'\\\\x${hex}', content_text = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
+      let setClauses = `content = E'\\\\x${hex}', summary = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
       if (row.project !== void 0)
         setClauses += `, project = '${sqlStr(row.project)}'`;
       if (row.description !== void 0)
@@ -147,7 +147,7 @@ var DeeplakeApi = class {
       await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(row.path)}'`);
     } else {
       const id = randomUUID();
-      let cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date";
+      let cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date";
       let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'\\\\x${hex}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
       if (row.project !== void 0) {
         cols += ", project";
@@ -189,10 +189,10 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log2(`table "${tbl}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, content_text TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, summary TEXT NOT NULL DEFAULT '', author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${tbl}" created`);
     } else {
-      for (const col of ["project", "description", "creation_date", "last_update_date"]) {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
         try {
           await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
           log2(`added column "${col}" to "${tbl}"`);
@@ -201,12 +201,12 @@ var DeeplakeApi = class {
       }
     }
   }
-  /** Create the sessions table (uses JSONB for content_text since every row is a JSON event). */
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
     const tables = await this.listTables();
     if (!tables.includes(name)) {
       log2(`table "${name}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content_text JSONB, mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${name}" created`);
     }
   }
@@ -444,14 +444,14 @@ async function main() {
       if (input.tool_name === "Read") {
         const virtualPath = rewritePaths(input.tool_input.file_path ?? "");
         log3(`direct read: ${virtualPath}`);
-        const rows = await api.query(`SELECT content_text FROM "${table}" WHERE path = '${sqlStr(virtualPath)}' LIMIT 1`);
-        if (rows.length > 0 && rows[0]["content_text"]) {
+        const rows = await api.query(`SELECT summary FROM "${table}" WHERE path = '${sqlStr(virtualPath)}' LIMIT 1`);
+        if (rows.length > 0 && rows[0]["summary"]) {
           console.log(JSON.stringify({
             hookSpecificOutput: {
               hookEventName: "PreToolUse",
               permissionDecision: "allow",
               updatedInput: {
-                command: `echo ${JSON.stringify(rows[0]["content_text"])}`,
+                command: `echo ${JSON.stringify(rows[0]["summary"])}`,
                 description: `[DeepLake direct] cat ${virtualPath}`
               }
             }
@@ -462,15 +462,15 @@ async function main() {
         const pattern = input.tool_input.pattern ?? "";
         const ignoreCase = !!input.tool_input["-i"];
         log3(`direct grep: ${pattern}`);
-        const pathRows = await api.query(`SELECT path FROM "${table}" WHERE content_text ${ignoreCase ? "ILIKE" : "LIKE"} '%${sqlStr(pattern)}%' LIMIT 10`);
+        const pathRows = await api.query(`SELECT path FROM "${table}" WHERE summary ${ignoreCase ? "ILIKE" : "LIKE"} '%${sqlStr(pattern)}%' LIMIT 10`);
         if (pathRows.length > 0) {
           const allResults = [];
           for (const pr of pathRows.slice(0, 5)) {
             const p = pr["path"];
-            const contentRows = await api.query(`SELECT content_text FROM "${table}" WHERE path = '${sqlStr(p)}' LIMIT 1`);
-            if (!contentRows[0]?.["content_text"])
+            const contentRows = await api.query(`SELECT summary FROM "${table}" WHERE path = '${sqlStr(p)}' LIMIT 1`);
+            if (!contentRows[0]?.["summary"])
               continue;
-            const text = contentRows[0]["content_text"];
+            const text = contentRows[0]["summary"];
             const re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), ignoreCase ? "i" : "");
             const matches = text.split("\n").filter((line) => re.test(line)).slice(0, 5).map((line) => `${p}:${line.slice(0, 300)}`);
             allResults.push(...matches);

--- a/bundle/session-start.js
+++ b/bundle/session-start.js
@@ -143,7 +143,7 @@ var DeeplakeApi = class {
     const lud = row.lastUpdateDate ?? ts;
     const exists = await this.query(`SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`);
     if (exists.length > 0) {
-      let setClauses = `content = E'\\\\x${hex}', content_text = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
+      let setClauses = `content = E'\\\\x${hex}', summary = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
       if (row.project !== void 0)
         setClauses += `, project = '${sqlStr(row.project)}'`;
       if (row.description !== void 0)
@@ -151,7 +151,7 @@ var DeeplakeApi = class {
       await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(row.path)}'`);
     } else {
       const id = randomUUID();
-      let cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date";
+      let cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date";
       let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'\\\\x${hex}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
       if (row.project !== void 0) {
         cols += ", project";
@@ -193,10 +193,10 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log2(`table "${tbl}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, content_text TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, summary TEXT NOT NULL DEFAULT '', author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${tbl}" created`);
     } else {
-      for (const col of ["project", "description", "creation_date", "last_update_date"]) {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
         try {
           await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
           log2(`added column "${col}" to "${tbl}"`);
@@ -205,12 +205,12 @@ var DeeplakeApi = class {
       }
     }
   }
-  /** Create the sessions table (uses JSONB for content_text since every row is a JSON event). */
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
     const tables = await this.listTables();
     if (!tables.includes(name)) {
       log2(`table "${name}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content_text JSONB, mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${name}" created`);
     }
   }
@@ -320,7 +320,7 @@ async function createPlaceholder(api, table, sessionId, cwd, userName, orgName, 
   ].join("\n");
   const hex = Buffer.from(content, "utf-8").toString("hex");
   const filename = `${sessionId}.md`;
-  await api.query(`INSERT INTO "${table}" (id, path, filename, content, content_text, mime_type, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', E'\\\\x${hex}', E'${sqlStr(content)}', 'text/markdown', ${Buffer.byteLength(content, "utf-8")}, '${sqlStr(projectName)}', 'in progress', '${now}', '${now}')`);
+  await api.query(`INSERT INTO "${table}" (id, path, filename, content, summary, author, mime_type, size_bytes, project, description, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', E'\\\\x${hex}', E'${sqlStr(content)}', '${sqlStr(userName)}', 'text/markdown', ${Buffer.byteLength(content, "utf-8")}, '${sqlStr(projectName)}', 'in progress', '${now}', '${now}')`);
   wikiLog(`SessionStart: created placeholder for ${sessionId} (${cwd})`);
 }
 async function main() {

--- a/bundle/shell/deeplake-shell.js
+++ b/bundle/shell/deeplake-shell.js
@@ -66834,7 +66834,7 @@ var DeeplakeApi = class {
     const lud = row.lastUpdateDate ?? ts3;
     const exists = await this.query(`SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`);
     if (exists.length > 0) {
-      let setClauses = `content = E'\\\\x${hex}', content_text = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
+      let setClauses = `content = E'\\\\x${hex}', summary = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
       if (row.project !== void 0)
         setClauses += `, project = '${sqlStr(row.project)}'`;
       if (row.description !== void 0)
@@ -66842,7 +66842,7 @@ var DeeplakeApi = class {
       await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(row.path)}'`);
     } else {
       const id = randomUUID();
-      let cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date";
+      let cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date";
       let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'\\\\x${hex}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
       if (row.project !== void 0) {
         cols += ", project";
@@ -66884,10 +66884,10 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log2(`table "${tbl}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, content_text TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content BYTEA NOT NULL DEFAULT ''::bytea, summary TEXT NOT NULL DEFAULT '', author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${tbl}" created`);
     } else {
-      for (const col of ["project", "description", "creation_date", "last_update_date"]) {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
         try {
           await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
           log2(`added column "${col}" to "${tbl}"`);
@@ -66896,12 +66896,12 @@ var DeeplakeApi = class {
       }
     }
   }
-  /** Create the sessions table (uses JSONB for content_text since every row is a JSON event). */
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
     const tables = await this.listTables();
     if (!tables.includes(name)) {
       log2(`table "${name}" not found, creating`);
-      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', content_text JSONB, mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
       log2(`table "${name}" created`);
     }
   }
@@ -67089,7 +67089,7 @@ var DeeplakeFs = class _DeeplakeFs {
       const cd = r10.creationDate ?? ts3;
       const lud = r10.lastUpdateDate ?? ts3;
       if (this.flushed.has(r10.path)) {
-        let setClauses = `filename = '${fname}', content = E'\\\\x${hex}', content_text = E'${text}', mime_type = '${mime}', size_bytes = ${r10.sizeBytes}, last_update_date = '${sqlStr(lud)}'`;
+        let setClauses = `filename = '${fname}', content = E'\\\\x${hex}', summary = E'${text}', mime_type = '${mime}', size_bytes = ${r10.sizeBytes}, last_update_date = '${sqlStr(lud)}'`;
         if (r10.project !== void 0)
           setClauses += `, project = '${sqlStr(r10.project)}'`;
         if (r10.description !== void 0)
@@ -67097,7 +67097,7 @@ var DeeplakeFs = class _DeeplakeFs {
         await this.client.query(`UPDATE "${this.table}" SET ${setClauses} WHERE path = '${p22}'`);
       } else {
         const id = randomUUID2();
-        const cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date" + (r10.project !== void 0 ? ", project" : "") + (r10.description !== void 0 ? ", description" : "");
+        const cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date" + (r10.project !== void 0 ? ", project" : "") + (r10.description !== void 0 ? ", description" : "");
         const vals = `'${id}', '${p22}', '${fname}', E'\\\\x${hex}', E'${text}', '${mime}', ${r10.sizeBytes}, '${sqlStr(cd)}', '${sqlStr(lud)}'` + (r10.project !== void 0 ? `, '${sqlStr(r10.project)}'` : "") + (r10.description !== void 0 ? `, '${sqlStr(r10.description)}'` : "");
         await this.client.query(`INSERT INTO "${this.table}" (${cols}) VALUES (${vals})`);
         this.flushed.add(r10.path);
@@ -67149,10 +67149,10 @@ var DeeplakeFs = class _DeeplakeFs {
       return pend.content;
     }
     if (this.sessionPaths.has(p22) && this.sessionsTable) {
-      const rows2 = await this.client.query(`SELECT content_text FROM "${this.sessionsTable}" WHERE path = '${sqlStr(p22)}' ORDER BY creation_date ASC`);
+      const rows2 = await this.client.query(`SELECT message FROM "${this.sessionsTable}" WHERE path = '${sqlStr(p22)}' ORDER BY creation_date ASC`);
       if (rows2.length === 0)
         throw fsErr("ENOENT", "no such file or directory", p22);
-      const text = rows2.map((r10) => typeof r10["content_text"] === "string" ? r10["content_text"] : JSON.stringify(r10["content_text"])).join("\n");
+      const text = rows2.map((r10) => typeof r10["message"] === "string" ? r10["message"] : JSON.stringify(r10["message"])).join("\n");
       const buf2 = Buffer.from(text, "utf-8");
       this.files.set(p22, buf2);
       return buf2;
@@ -67169,9 +67169,9 @@ var DeeplakeFs = class _DeeplakeFs {
     if (this.dirs.has(p22) && !this.files.has(p22))
       throw fsErr("EISDIR", "illegal operation on a directory", p22);
     if (p22 === "/index.md" && !this.files.has(p22)) {
-      const realRows = await this.client.query(`SELECT content_text FROM "${this.table}" WHERE path = '${sqlStr("/index.md")}' LIMIT 1`);
-      if (realRows.length > 0 && realRows[0]["content_text"]) {
-        const text2 = realRows[0]["content_text"];
+      const realRows = await this.client.query(`SELECT summary FROM "${this.table}" WHERE path = '${sqlStr("/index.md")}' LIMIT 1`);
+      if (realRows.length > 0 && realRows[0]["summary"]) {
+        const text2 = realRows[0]["summary"];
         const buf2 = Buffer.from(text2, "utf-8");
         this.files.set(p22, buf2);
         return text2;
@@ -67184,19 +67184,19 @@ var DeeplakeFs = class _DeeplakeFs {
     if (pend)
       return pend.contentText || pend.content.toString("utf-8");
     if (this.sessionPaths.has(p22) && this.sessionsTable) {
-      const rows2 = await this.client.query(`SELECT content_text FROM "${this.sessionsTable}" WHERE path = '${sqlStr(p22)}' ORDER BY creation_date ASC`);
+      const rows2 = await this.client.query(`SELECT message FROM "${this.sessionsTable}" WHERE path = '${sqlStr(p22)}' ORDER BY creation_date ASC`);
       if (rows2.length === 0)
         throw fsErr("ENOENT", "no such file or directory", p22);
-      const text2 = rows2.map((r10) => typeof r10["content_text"] === "string" ? r10["content_text"] : JSON.stringify(r10["content_text"])).join("\n");
+      const text2 = rows2.map((r10) => typeof r10["message"] === "string" ? r10["message"] : JSON.stringify(r10["message"])).join("\n");
       const buf2 = Buffer.from(text2, "utf-8");
       this.files.set(p22, buf2);
       return text2;
     }
-    const rows = await this.client.query(`SELECT content_text, content FROM "${this.table}" WHERE path = '${sqlStr(p22)}' LIMIT 1`);
+    const rows = await this.client.query(`SELECT summary, content FROM "${this.table}" WHERE path = '${sqlStr(p22)}' LIMIT 1`);
     if (rows.length === 0)
       throw fsErr("ENOENT", "no such file or directory", p22);
     const row = rows[0];
-    const text = row["content_text"];
+    const text = row["summary"];
     if (text && text.length > 0) {
       const buf2 = Buffer.from(text, "utf-8");
       this.files.set(p22, buf2);
@@ -67261,7 +67261,7 @@ var DeeplakeFs = class _DeeplakeFs {
     if (this.files.has(p22) || await this.exists(p22).catch(() => false)) {
       const addHex = Buffer.from(add, "utf-8").toString("hex");
       const ts3 = (/* @__PURE__ */ new Date()).toISOString();
-      await this.client.query(`UPDATE "${this.table}" SET content_text = content_text || E'${sqlStr(add)}', content = content || E'\\\\x${addHex}', size_bytes = size_bytes + ${Buffer.byteLength(add, "utf-8")}, last_update_date = '${ts3}' WHERE path = '${sqlStr(p22)}'`);
+      await this.client.query(`UPDATE "${this.table}" SET summary = summary || E'${sqlStr(add)}', content = content || E'\\\\x${addHex}', size_bytes = size_bytes + ${Buffer.byteLength(add, "utf-8")}, last_update_date = '${ts3}' WHERE path = '${sqlStr(p22)}'`);
       const m26 = this.meta.get(p22);
       if (m26) {
         m26.size += Buffer.byteLength(add, "utf-8");
@@ -68445,7 +68445,7 @@ function createGrepCommand(client, fs3, table) {
     let candidates = [];
     try {
       const bm25 = await Promise.race([
-        client.query(`SELECT path FROM "${table}" WHERE content_text <#> '${sqlStr(pattern)}' LIMIT 50`),
+        client.query(`SELECT path FROM "${table}" WHERE summary <#> '${sqlStr(pattern)}' LIMIT 50`),
         new Promise((_16, reject) => setTimeout(() => reject(new Error("timeout")), 3e3))
       ]);
       candidates = bm25.map((r10) => r10["path"]).filter(Boolean);

--- a/bundle/wiki-worker.js
+++ b/bundle/wiki-worker.js
@@ -55,12 +55,12 @@ async function main() {
   try {
     wlog("fetching session events");
     await query(`SELECT deeplake_sync_table('${cfg.sessionsTable}')`);
-    const rows = await query(`SELECT content_text, creation_date FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc(`/sessions/%${cfg.sessionId}%`)}' ORDER BY creation_date ASC`);
+    const rows = await query(`SELECT message, creation_date FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc(`/sessions/%${cfg.sessionId}%`)}' ORDER BY creation_date ASC`);
     if (rows.length === 0) {
       wlog("no session events found \u2014 exiting");
       return;
     }
-    const jsonlContent = rows.map((r) => typeof r.content_text === "string" ? r.content_text : JSON.stringify(r.content_text)).join("\n");
+    const jsonlContent = rows.map((r) => typeof r.message === "string" ? r.message : JSON.stringify(r.message)).join("\n");
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
@@ -69,9 +69,9 @@ async function main() {
     let prevOffset = 0;
     try {
       await query(`SELECT deeplake_sync_table('${cfg.memoryTable}')`);
-      const sumRows = await query(`SELECT content_text FROM "${cfg.memoryTable}" WHERE path = '${esc(`/summaries/${cfg.userName}/${cfg.sessionId}.md`)}' LIMIT 1`);
-      if (sumRows.length > 0 && sumRows[0]["content_text"]) {
-        const existing = sumRows[0]["content_text"];
+      const sumRows = await query(`SELECT summary FROM "${cfg.memoryTable}" WHERE path = '${esc(`/summaries/${cfg.userName}/${cfg.sessionId}.md`)}' LIMIT 1`);
+      if (sumRows.length > 0 && sumRows[0]["summary"]) {
+        const existing = sumRows[0]["summary"];
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
@@ -110,10 +110,10 @@ async function main() {
         await query(`SELECT deeplake_sync_table('${cfg.memoryTable}')`);
         const existing = await query(`SELECT path FROM "${cfg.memoryTable}" WHERE path = '${esc(vpath)}' LIMIT 1`);
         if (existing.length > 0) {
-          await query(`UPDATE "${cfg.memoryTable}" SET content = E'\\\\x${hex}', content_text = E'${esc(text)}', size_bytes = ${Buffer.byteLength(text)}, last_update_date = '${ts}' WHERE path = '${esc(vpath)}'`);
+          await query(`UPDATE "${cfg.memoryTable}" SET content = E'\\\\x${hex}', summary = E'${esc(text)}', size_bytes = ${Buffer.byteLength(text)}, last_update_date = '${ts}' WHERE path = '${esc(vpath)}'`);
         } else {
           const id = crypto.randomUUID();
-          await query(`INSERT INTO "${cfg.memoryTable}" (id, path, filename, content, content_text, mime_type, size_bytes, project, creation_date, last_update_date) VALUES ('${id}', '${esc(vpath)}', '${esc(fname)}', E'\\\\x${hex}', E'${esc(text)}', 'text/markdown', ${Buffer.byteLength(text)}, '${esc(cfg.project)}', '${ts}', '${ts}')`);
+          await query(`INSERT INTO "${cfg.memoryTable}" (id, path, filename, content, summary, author, mime_type, size_bytes, project, creation_date, last_update_date) VALUES ('${id}', '${esc(vpath)}', '${esc(fname)}', E'\\\\x${hex}', E'${esc(text)}', '${esc(cfg.userName)}', 'text/markdown', ${Buffer.byteLength(text)}, '${esc(cfg.project)}', '${ts}', '${ts}')`);
         }
         wlog(`uploaded ${vpath}`);
         try {

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -82,7 +82,7 @@ export class DeeplakeApi {
       `SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`
     );
     if (exists.length > 0) {
-      let setClauses = `content = E'\\\\x${hex}', content_text = E'${sqlStr(row.contentText)}', ` +
+      let setClauses = `content = E'\\\\x${hex}', summary = E'${sqlStr(row.contentText)}', ` +
         `mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
       if (row.project !== undefined) setClauses += `, project = '${sqlStr(row.project)}'`;
       if (row.description !== undefined) setClauses += `, description = '${sqlStr(row.description)}'`;
@@ -91,7 +91,7 @@ export class DeeplakeApi {
       );
     } else {
       const id = randomUUID();
-      let cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date";
+      let cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date";
       let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'\\\\x${hex}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
       if (row.project !== undefined) { cols += ", project"; vals += `, '${sqlStr(row.project)}'`; }
       if (row.description !== undefined) { cols += ", description"; vals += `, '${sqlStr(row.description)}'`; }
@@ -143,7 +143,8 @@ export class DeeplakeApi {
           `path TEXT NOT NULL DEFAULT '', ` +
           `filename TEXT NOT NULL DEFAULT '', ` +
           `content BYTEA NOT NULL DEFAULT ''::bytea, ` +
-          `content_text TEXT NOT NULL DEFAULT '', ` +
+          `summary TEXT NOT NULL DEFAULT '', ` +
+          `author TEXT NOT NULL DEFAULT '', ` +
           `mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', ` +
           `size_bytes BIGINT NOT NULL DEFAULT 0, ` +
           `project TEXT NOT NULL DEFAULT '', ` +
@@ -155,7 +156,7 @@ export class DeeplakeApi {
       log(`table "${tbl}" created`);
     } else {
       // Migrate: add new columns if missing on existing tables
-      for (const col of ["project", "description", "creation_date", "last_update_date"]) {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
         try {
           await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
           log(`added column "${col}" to "${tbl}"`);
@@ -166,7 +167,7 @@ export class DeeplakeApi {
     }
   }
 
-  /** Create the sessions table (uses JSONB for content_text since every row is a JSON event). */
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name: string): Promise<void> {
     const tables = await this.listTables();
     if (!tables.includes(name)) {
@@ -176,7 +177,8 @@ export class DeeplakeApi {
           `id TEXT NOT NULL DEFAULT '', ` +
           `path TEXT NOT NULL DEFAULT '', ` +
           `filename TEXT NOT NULL DEFAULT '', ` +
-          `content_text JSONB, ` +
+          `message JSONB, ` +
+          `author TEXT NOT NULL DEFAULT '', ` +
           `mime_type TEXT NOT NULL DEFAULT 'application/json', ` +
           `size_bytes BIGINT NOT NULL DEFAULT 0, ` +
           `project TEXT NOT NULL DEFAULT '', ` +

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -118,8 +118,8 @@ async function main(): Promise<void> {
   const jsonForSql = line.replace(/'/g, "''");
 
   const insertSql =
-    `INSERT INTO "${sessionsTable}" (id, path, filename, content_text, size_bytes, project, description, creation_date, last_update_date) ` +
-    `VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ` +
+    `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, creation_date, last_update_date) ` +
+    `VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, '${sqlStr(config.userName)}', ` +
     `${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`;
 
   try {

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -117,11 +117,24 @@ async function main(): Promise<void> {
   // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.
   const jsonForSql = line.replace(/'/g, "''");
 
-  await api.query(
+  const insertSql =
     `INSERT INTO "${sessionsTable}" (id, path, filename, content_text, size_bytes, project, description, creation_date, last_update_date) ` +
     `VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ` +
-    `${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`
-  );
+    `${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', '${ts}', '${ts}')`;
+
+  try {
+    await api.query(insertSql);
+  } catch (e: any) {
+    // Fallback: table might not exist (session-start failed or org switched mid-session).
+    // Create it and retry once.
+    if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
+      log("table missing, creating and retrying");
+      await api.ensureSessionsTable(sessionsTable);
+      await api.query(insertSql);
+    } else {
+      throw e;
+    }
+  }
 
   log("capture ok → cloud");
 }

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -198,15 +198,15 @@ async function main(): Promise<void> {
         const virtualPath = rewritePaths((input.tool_input.file_path as string) ?? "");
         log(`direct read: ${virtualPath}`);
         const rows = await api.query(
-          `SELECT content_text FROM "${table}" WHERE path = '${sqlStr(virtualPath)}' LIMIT 1`
+          `SELECT summary FROM "${table}" WHERE path = '${sqlStr(virtualPath)}' LIMIT 1`
         );
-        if (rows.length > 0 && rows[0]["content_text"]) {
+        if (rows.length > 0 && rows[0]["summary"]) {
           console.log(JSON.stringify({
             hookSpecificOutput: {
               hookEventName: "PreToolUse",
               permissionDecision: "allow",
               updatedInput: {
-                command: `echo ${JSON.stringify(rows[0]["content_text"])}`,
+                command: `echo ${JSON.stringify(rows[0]["summary"])}`,
                 description: `[DeepLake direct] cat ${virtualPath}`,
               },
             },
@@ -219,7 +219,7 @@ async function main(): Promise<void> {
         log(`direct grep: ${pattern}`);
         // Only fetch paths first (fast), then fetch content for matches
         const pathRows = await api.query(
-          `SELECT path FROM "${table}" WHERE content_text ${ignoreCase ? "ILIKE" : "LIKE"} '%${sqlStr(pattern)}%' LIMIT 10`
+          `SELECT path FROM "${table}" WHERE summary ${ignoreCase ? "ILIKE" : "LIKE"} '%${sqlStr(pattern)}%' LIMIT 10`
         );
         if (pathRows.length > 0) {
           // Fetch content for matched files and extract matching lines
@@ -227,10 +227,10 @@ async function main(): Promise<void> {
           for (const pr of pathRows.slice(0, 5)) {
             const p = pr["path"] as string;
             const contentRows = await api.query(
-              `SELECT content_text FROM "${table}" WHERE path = '${sqlStr(p)}' LIMIT 1`
+              `SELECT summary FROM "${table}" WHERE path = '${sqlStr(p)}' LIMIT 1`
             );
-            if (!contentRows[0]?.["content_text"]) continue;
-            const text = contentRows[0]["content_text"] as string;
+            if (!contentRows[0]?.["summary"]) continue;
+            const text = contentRows[0]["summary"] as string;
             const re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), ignoreCase ? "i" : "");
             const matches = text.split("\n")
               .filter(line => re.test(line))

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -117,8 +117,8 @@ async function createPlaceholder(api: DeeplakeApi, table: string, sessionId: str
   const filename = `${sessionId}.md`;
 
   await api.query(
-    `INSERT INTO "${table}" (id, path, filename, content, content_text, mime_type, size_bytes, project, description, creation_date, last_update_date) ` +
-    `VALUES ('${crypto.randomUUID()}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', E'\\\\x${hex}', E'${sqlStr(content)}', 'text/markdown', ` +
+    `INSERT INTO "${table}" (id, path, filename, content, summary, author, mime_type, size_bytes, project, description, creation_date, last_update_date) ` +
+    `VALUES ('${crypto.randomUUID()}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', E'\\\\x${hex}', E'${sqlStr(content)}', '${sqlStr(userName)}', 'text/markdown', ` +
     `${Buffer.byteLength(content, "utf-8")}, '${sqlStr(projectName)}', 'in progress', '${now}', '${now}')`
   );
 

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -86,7 +86,7 @@ async function main(): Promise<void> {
     wlog("fetching session events");
     await query(`SELECT deeplake_sync_table('${cfg.sessionsTable}')`);
     const rows = await query(
-      `SELECT content_text, creation_date FROM "${cfg.sessionsTable}" ` +
+      `SELECT message, creation_date FROM "${cfg.sessionsTable}" ` +
       `WHERE path LIKE '${esc(`/sessions/%${cfg.sessionId}%`)}' ORDER BY creation_date ASC`
     );
 
@@ -95,9 +95,9 @@ async function main(): Promise<void> {
       return;
     }
 
-    // Reconstruct JSONL from individual rows (content_text is JSONB — may be object or string)
+    // Reconstruct JSONL from individual rows (message is JSONB — may be object or string)
     const jsonlContent = rows
-      .map(r => typeof r.content_text === "string" ? r.content_text : JSON.stringify(r.content_text))
+      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
       .join("\n");
     const jsonlLines = rows.length;
 
@@ -118,11 +118,11 @@ async function main(): Promise<void> {
     try {
       await query(`SELECT deeplake_sync_table('${cfg.memoryTable}')`);
       const sumRows = await query(
-        `SELECT content_text FROM "${cfg.memoryTable}" ` +
+        `SELECT summary FROM "${cfg.memoryTable}" ` +
         `WHERE path = '${esc(`/summaries/${cfg.userName}/${cfg.sessionId}.md`)}' LIMIT 1`
       );
-      if (sumRows.length > 0 && sumRows[0]["content_text"]) {
-        const existing = sumRows[0]["content_text"] as string;
+      if (sumRows.length > 0 && sumRows[0]["summary"]) {
+        const existing = sumRows[0]["summary"] as string;
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
@@ -174,15 +174,15 @@ async function main(): Promise<void> {
         if (existing.length > 0) {
           await query(
             `UPDATE "${cfg.memoryTable}" SET ` +
-            `content = E'\\\\x${hex}', content_text = E'${esc(text)}', ` +
+            `content = E'\\\\x${hex}', summary = E'${esc(text)}', ` +
             `size_bytes = ${Buffer.byteLength(text)}, last_update_date = '${ts}' ` +
             `WHERE path = '${esc(vpath)}'`
           );
         } else {
           const id = crypto.randomUUID();
           await query(
-            `INSERT INTO "${cfg.memoryTable}" (id, path, filename, content, content_text, mime_type, size_bytes, project, creation_date, last_update_date) ` +
-            `VALUES ('${id}', '${esc(vpath)}', '${esc(fname)}', E'\\\\x${hex}', E'${esc(text)}', 'text/markdown', ` +
+            `INSERT INTO "${cfg.memoryTable}" (id, path, filename, content, summary, author, mime_type, size_bytes, project, creation_date, last_update_date) ` +
+            `VALUES ('${id}', '${esc(vpath)}', '${esc(fname)}', E'\\\\x${hex}', E'${esc(text)}', '${esc(cfg.userName)}', 'text/markdown', ` +
             `${Buffer.byteLength(text)}, '${esc(cfg.project)}', '${ts}', '${ts}')`
           );
         }

--- a/src/shell/deeplake-fs.ts
+++ b/src/shell/deeplake-fs.ts
@@ -218,7 +218,7 @@ export class DeeplakeFs implements IFileSystem {
       const cd = r.creationDate ?? ts;
       const lud = r.lastUpdateDate ?? ts;
       if (this.flushed.has(r.path)) {
-        let setClauses = `filename = '${fname}', content = E'\\\\x${hex}', content_text = E'${text}', ` +
+        let setClauses = `filename = '${fname}', content = E'\\\\x${hex}', summary = E'${text}', ` +
           `mime_type = '${mime}', size_bytes = ${r.sizeBytes}, last_update_date = '${esc(lud)}'`;
         if (r.project !== undefined) setClauses += `, project = '${esc(r.project)}'`;
         if (r.description !== undefined) setClauses += `, description = '${esc(r.description)}'`;
@@ -227,7 +227,7 @@ export class DeeplakeFs implements IFileSystem {
         );
       } else {
         const id = randomUUID();
-        const cols = "id, path, filename, content, content_text, mime_type, size_bytes, creation_date, last_update_date" +
+        const cols = "id, path, filename, content, summary, mime_type, size_bytes, creation_date, last_update_date" +
           (r.project !== undefined ? ", project" : "") +
           (r.description !== undefined ? ", description" : "");
         const vals = `'${id}', '${p}', '${fname}', E'\\\\x${hex}', E'${text}', '${mime}', ${r.sizeBytes}, '${esc(cd)}', '${esc(lud)}'` +
@@ -294,10 +294,10 @@ export class DeeplakeFs implements IFileSystem {
     // 3. Session files: concatenate rows from sessions table
     if (this.sessionPaths.has(p) && this.sessionsTable) {
       const rows = await this.client.query(
-        `SELECT content_text FROM "${this.sessionsTable}" WHERE path = '${esc(p)}' ORDER BY creation_date ASC`
+        `SELECT message FROM "${this.sessionsTable}" WHERE path = '${esc(p)}' ORDER BY creation_date ASC`
       );
       if (rows.length === 0) throw fsErr("ENOENT", "no such file or directory", p);
-      const text = rows.map(r => typeof r["content_text"] === "string" ? r["content_text"] : JSON.stringify(r["content_text"])).join("\n");
+      const text = rows.map(r => typeof r["message"] === "string" ? r["message"] : JSON.stringify(r["message"])).join("\n");
       const buf = Buffer.from(text, "utf-8");
       this.files.set(p, buf);
       return buf;
@@ -321,10 +321,10 @@ export class DeeplakeFs implements IFileSystem {
     if (p === "/index.md" && !this.files.has(p)) {
       // Check if a real /index.md row exists in the table
       const realRows = await this.client.query(
-        `SELECT content_text FROM "${this.table}" WHERE path = '${esc("/index.md")}' LIMIT 1`
+        `SELECT summary FROM "${this.table}" WHERE path = '${esc("/index.md")}' LIMIT 1`
       );
-      if (realRows.length > 0 && realRows[0]["content_text"]) {
-        const text = realRows[0]["content_text"] as string;
+      if (realRows.length > 0 && realRows[0]["summary"]) {
+        const text = realRows[0]["summary"] as string;
         const buf = Buffer.from(text, "utf-8");
         this.files.set(p, buf);
         return text;
@@ -342,22 +342,22 @@ export class DeeplakeFs implements IFileSystem {
     // Session files: concatenate rows from sessions table, ordered by creation_date
     if (this.sessionPaths.has(p) && this.sessionsTable) {
       const rows = await this.client.query(
-        `SELECT content_text FROM "${this.sessionsTable}" WHERE path = '${esc(p)}' ORDER BY creation_date ASC`
+        `SELECT message FROM "${this.sessionsTable}" WHERE path = '${esc(p)}' ORDER BY creation_date ASC`
       );
       if (rows.length === 0) throw fsErr("ENOENT", "no such file or directory", p);
-      const text = rows.map(r => typeof r["content_text"] === "string" ? r["content_text"] : JSON.stringify(r["content_text"])).join("\n");
+      const text = rows.map(r => typeof r["message"] === "string" ? r["message"] : JSON.stringify(r["message"])).join("\n");
       const buf = Buffer.from(text, "utf-8");
       this.files.set(p, buf);
       return text;
     }
 
-    // For text files prefer content_text (avoids decoding binary column)
+    // For text files prefer summary column (avoids decoding binary column)
     const rows = await this.client.query(
-      `SELECT content_text, content FROM "${this.table}" WHERE path = '${esc(p)}' LIMIT 1`
+      `SELECT summary, content FROM "${this.table}" WHERE path = '${esc(p)}' LIMIT 1`
     );
     if (rows.length === 0) throw fsErr("ENOENT", "no such file or directory", p);
     const row = rows[0];
-    const text = row["content_text"] as string;
+    const text = row["summary"] as string;
     if (text && text.length > 0) {
       const buf = Buffer.from(text, "utf-8");
       this.files.set(p, buf);
@@ -428,7 +428,7 @@ export class DeeplakeFs implements IFileSystem {
       const ts = new Date().toISOString();
       await this.client.query(
         `UPDATE "${this.table}" SET ` +
-        `content_text = content_text || E'${esc(add)}', ` +
+        `summary = summary || E'${esc(add)}', ` +
         `content = content || E'\\\\x${addHex}', ` +
         `size_bytes = size_bytes + ${Buffer.byteLength(add, "utf-8")}, ` +
         `last_update_date = '${ts}' ` +

--- a/src/shell/grep-interceptor.ts
+++ b/src/shell/grep-interceptor.ts
@@ -55,7 +55,7 @@ export function createGrepCommand(
 
     try {
       const bm25 = await Promise.race([
-        client.query(`SELECT path FROM "${table}" WHERE content_text <#> '${esc(pattern)}' LIMIT 50`),
+        client.query(`SELECT path FROM "${table}" WHERE summary <#> '${esc(pattern)}' LIMIT 50`),
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 3000)),
       ]);
       candidates = bm25.map(r => r["path"] as string).filter(Boolean);

--- a/tests/capture.test.ts
+++ b/tests/capture.test.ts
@@ -237,6 +237,92 @@ describe("placeholder creation", () => {
   });
 });
 
+// ── INSERT SQL structure (mirrors capture.ts) ───────────────────────────────
+
+function buildInsertSql(
+  sessionsTable: string, sessionPath: string, filename: string,
+  jsonForSql: string, lineBytes: number, userName: string,
+  projectName: string, hookEvent: string, ts: string,
+): string {
+  return (
+    `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, creation_date, last_update_date) ` +
+    `VALUES ('test-id', '${sessionPath}', '${filename}', '${jsonForSql}'::jsonb, '${userName}', ` +
+    `${lineBytes}, '${projectName}', '${hookEvent}', '${ts}', '${ts}')`
+  );
+}
+
+describe("INSERT SQL structure", () => {
+  it("uses message column (not content_text) for sessions table", () => {
+    const sql = buildInsertSql("sessions", "/sessions/u/s.jsonl", "s.jsonl", "{}", 2, "alice", "proj", "UserPromptSubmit", "2026-01-01T00:00:00Z");
+    expect(sql).toContain("message");
+    expect(sql).not.toContain("content_text");
+  });
+
+  it("includes author column with username", () => {
+    const sql = buildInsertSql("sessions", "/sessions/u/s.jsonl", "s.jsonl", "{}", 2, "alice", "proj", "Stop", "2026-01-01T00:00:00Z");
+    expect(sql).toContain("author");
+    expect(sql).toContain("'alice'");
+  });
+
+  it("casts message value to jsonb", () => {
+    const sql = buildInsertSql("sessions", "/p", "f", '{"type":"user_message"}', 22, "u", "p", "UserPromptSubmit", "t");
+    expect(sql).toContain("::jsonb");
+  });
+
+  it("uses the correct table name", () => {
+    const sql = buildInsertSql("my_sessions", "/p", "f", "{}", 2, "u", "p", "Stop", "t");
+    expect(sql).toContain('"my_sessions"');
+  });
+});
+
+// ── Capture fallback logic ──────────────────────────────────────────────────
+
+describe("capture fallback", () => {
+  it("detects permission denied as retriable error", () => {
+    const msg = 'Query failed: 400: {"error":"SQL error: permission denied for table sessions"}';
+    expect(msg.includes("permission denied")).toBe(true);
+  });
+
+  it("detects table not found as retriable error", () => {
+    const msg = 'Query failed: 400: {"error":"table sessions does not exist"}';
+    expect(msg.includes("does not exist")).toBe(true);
+  });
+
+  it("does not retry on unrelated errors", () => {
+    const msg = 'Query failed: 400: {"error":"syntax error at or near SELECT"}';
+    expect(msg.includes("permission denied")).toBe(false);
+    expect(msg.includes("does not exist")).toBe(false);
+  });
+});
+
+// ── Placeholder SQL uses summary column and author ──────────────────────────
+
+function buildPlaceholderSql(
+  table: string, summaryPath: string, filename: string,
+  hex: string, content: string, userName: string,
+  projectName: string, now: string,
+): string {
+  return (
+    `INSERT INTO "${table}" (id, path, filename, content, summary, author, mime_type, size_bytes, project, description, creation_date, last_update_date) ` +
+    `VALUES ('test-id', '${summaryPath}', '${filename}', E'\\\\x${hex}', E'${content}', '${userName}', 'text/markdown', ` +
+    `${content.length}, '${projectName}', 'in progress', '${now}', '${now}')`
+  );
+}
+
+describe("placeholder SQL structure", () => {
+  it("uses summary column (not content_text) for memory table", () => {
+    const sql = buildPlaceholderSql("memory", "/summaries/u/s1.md", "s1.md", "abc", "# Session", "alice", "proj", "2026-01-01T00:00:00Z");
+    expect(sql).toContain("summary");
+    expect(sql).not.toContain("content_text");
+  });
+
+  it("includes author column with username", () => {
+    const sql = buildPlaceholderSql("memory", "/summaries/u/s1.md", "s1.md", "abc", "# Session", "bob", "proj", "2026-01-01T00:00:00Z");
+    expect(sql).toContain("author");
+    expect(sql).toContain("'bob'");
+  });
+});
+
 // ── Wiki worker prompt template substitution ──────────────────────────────────
 
 describe("prompt template substitution", () => {

--- a/tests/deeplake-fs.test.ts
+++ b/tests/deeplake-fs.test.ts
@@ -4,7 +4,7 @@ import { DeeplakeFs, isText, guessMime } from "../src/shell/deeplake-fs.js";
 // ── Mock ManagedClient ────────────────────────────────────────────────────────
 type Row = {
   id: string; path: string; filename: string; content: Buffer;
-  content_text: string; mime_type: string; size_bytes: number;
+  summary: string; mime_type: string; size_bytes: number;
   project: string; description: string; creation_date: string; last_update_date: string;
 };
 
@@ -14,7 +14,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
     path,
     filename: path.split("/").pop()!,
     content,
-    content_text: isText(content) ? content.toString("utf-8") : "",
+    summary: isText(content) ? content.toString("utf-8") : "",
     mime_type: guessMime(path.split("/").pop()!),
     size_bytes: content.length,
     project: "",
@@ -38,11 +38,11 @@ function makeClient(seed: Record<string, Buffer> = {}) {
         // Return hex-encoded content like PostgreSQL BYTEA
         return row ? [{ content: `\\x${row.content.toString("hex")}` }] : [];
       }
-      // Read: SELECT content_text, content FROM ... WHERE path = '...'
-      if (sql.includes("SELECT content_text, content")) {
+      // Read: SELECT summary, content FROM ... WHERE path = '...'
+      if (sql.includes("SELECT summary, content")) {
         const match = sql.match(/path = '([^']+)'/);
         const row = match ? rows.find(r => r.path === match[1]) : undefined;
-        return row ? [{ content_text: row.content_text, content: `\\x${row.content.toString("hex")}` }] : [];
+        return row ? [{ summary: row.summary, content: `\\x${row.content.toString("hex")}` }] : [];
       }
       // Virtual index: SELECT path, project, description, creation_date, last_update_date FROM ... WHERE path LIKE '/summaries/%'
       if (sql.includes("SELECT path, project, description, creation_date, last_update_date")) {
@@ -78,7 +78,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
         }
         return [];
       }
-      // UPDATE — distinguish append (content_text || ) from full overwrite (content_text = E'...')
+      // UPDATE — distinguish append (summary || ) from full overwrite (summary = E'...')
       if (sql.startsWith("UPDATE")) {
         const match = sql.match(/WHERE path = '([^']+)'/);
         if (match) {
@@ -90,25 +90,25 @@ function makeClient(seed: Record<string, Buffer> = {}) {
             const ludMatch2 = sql.match(/last_update_date = '([^']+)'/);
             if (ludMatch2) row.last_update_date = ludMatch2[1];
 
-            if (sql.includes("content_text = content_text ||")) {
+            if (sql.includes("summary = summary ||")) {
               // appendFile: SQL-level concat
               const hexMatch = sql.match(/content \|\| E'\\\\x([0-9a-f]*)'/);
               if (hexMatch) {
                 const appendBuf = Buffer.from(hexMatch[1], "hex");
                 row.content = Buffer.concat([row.content, appendBuf]);
-                row.content_text += appendBuf.toString("utf-8");
+                row.summary += appendBuf.toString("utf-8");
                 row.size_bytes = row.content.length;
               }
             } else {
               // Full overwrite UPDATE (_doFlush for existing paths)
               const hexMatch = sql.match(/content = E'\\\\x([0-9a-f]*)'/);
-              const textMatch = sql.match(/content_text = E'((?:[^']|'')*)'/);
+              const textMatch = sql.match(/summary = E'((?:[^']|'')*)'/);
               if (hexMatch) {
                 row.content = Buffer.from(hexMatch[1], "hex");
                 row.size_bytes = row.content.length;
               }
               if (textMatch) {
-                row.content_text = textMatch[1].replace(/''/g, "'");
+                row.summary = textMatch[1].replace(/''/g, "'");
               }
             }
             // Handle new metadata columns in any UPDATE
@@ -139,7 +139,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
             const path = pathMatch[1];
             const filename = path.split("/").pop()!;
             const content = hexMatch ? Buffer.from(hexMatch[1], "hex") : Buffer.alloc(0);
-            const content_text = textMatch?.[1]?.replace(/''/g, "'") ?? "";
+            const summary = textMatch?.[1]?.replace(/''/g, "'") ?? "";
             const id = idMatch?.[1] ?? "";
             // Parse columns and values positionally
             const colsPart = sql.match(/\(([^)]+)\)\s+VALUES/)?.[1] ?? "";
@@ -178,7 +178,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
             // Remove existing row if any (upsert)
             const idx = rows.findIndex(r => r.path === path);
             if (idx >= 0) rows.splice(idx, 1);
-            rows.push({ id, path, filename, content, content_text, mime_type: "text/plain", size_bytes: content.length, project, description, creation_date, last_update_date });
+            rows.push({ id, path, filename, content, summary, mime_type: "text/plain", size_bytes: content.length, project, description, creation_date, last_update_date });
           }
         }
         return [];
@@ -259,13 +259,13 @@ describe("DeeplakeFs bootstrap", () => {
 
 // ── Text reads ────────────────────────────────────────────────────────────────
 describe("readFile", () => {
-  it("reads text via content_text SQL column", async () => {
+  it("reads text via summary SQL column", async () => {
     const { fs, client } = await makeFs({ "/memory/hello.txt": "hello" });
     const content = await fs.readFile("/memory/hello.txt");
     expect(content).toBe("hello");
-    // Should use the content_text+content SELECT, not content-only SELECT
+    // Should use the summary+content SELECT, not content-only SELECT
     const calls = (client.query.mock.calls as [string][]);
-    expect(calls.some(c => (c[0] as string).includes("content_text, content"))).toBe(true);
+    expect(calls.some(c => (c[0] as string).includes("summary, content"))).toBe(true);
   });
 
   it("throws ENOENT for missing file", async () => {
@@ -338,7 +338,7 @@ describe("writeFile", () => {
     expect(await fs.readFile("/memory/a.txt")).toBe("new");
   });
 
-  it("stores contentText='' for binary files (INSERT has empty E'' for content_text)", async () => {
+  it("stores contentText='' for binary files (INSERT has empty E'' for summary)", async () => {
     const { fs, client } = await makeFs({});
     const binary = Buffer.from([0x89, 0x50, 0x00, 0x01]);
     // Write 10 to trigger flush
@@ -348,7 +348,7 @@ describe("writeFile", () => {
     const insertCalls = (client.query.mock.calls as [string][])
       .filter(c => (c[0] as string).startsWith("INSERT") && (c[0] as string).includes("img.png"));
     expect(insertCalls.length).toBe(1);
-    // content_text should be E'' (empty string) for binary
+    // summary should be E'' (empty string) for binary
     expect(insertCalls[0][0]).toMatch(/E'\\\\x[0-9a-f]+', E''/);
   });
 });
@@ -564,7 +564,7 @@ describe("flush upsert", () => {
     // id should be preserved
     const row = client._rows.find(r => r.path === "/memory/existing.txt")!;
     expect(row.id).toBe(originalId);
-    expect(row.content_text).toBe("new");
+    expect(row.summary).toBe("new");
   });
 
   it("UPDATE includes last_update_date", async () => {
@@ -590,7 +590,7 @@ describe("flush upsert", () => {
 
     const row = client._rows.find(r => r.path === "/memory/stable.txt")!;
     expect(row.id).toBe(originalId);
-    expect(row.content_text).toBe("v3");
+    expect(row.summary).toBe("v3");
   });
 
   it("new file after delete gets a new id", async () => {
@@ -604,7 +604,7 @@ describe("flush upsert", () => {
 
     const row = client._rows.find(r => r.path === "/memory/recycle.txt")!;
     expect(row.id).not.toBe(originalId);
-    expect(row.content_text).toBe("second");
+    expect(row.summary).toBe("second");
   });
 });
 
@@ -640,7 +640,7 @@ describe("appendFile upsert", () => {
 
     const row = client._rows.find(r => r.path === "/memory/log.txt")!;
     expect(row.id).toBe(originalId);
-    expect(row.content_text).toBe("line0\nline1\nline2\nline3\nline4\n");
+    expect(row.summary).toBe("line0\nline1\nline2\nline3\nline4\n");
   });
 });
 
@@ -776,7 +776,7 @@ describe("virtual index.md", () => {
     // Manually insert a legacy row (no username dir)
     client._rows.push({
       id: "legacy", path: "/summaries/old-sess.md", filename: "old-sess.md",
-      content: Buffer.from("# Old"), content_text: "# Old", mime_type: "text/markdown",
+      content: Buffer.from("# Old"), summary: "# Old", mime_type: "text/markdown",
       size_bytes: 5, project: "proj-a", description: "Legacy", creation_date: "2026-04-01", last_update_date: "2026-04-01",
     });
     const content = await fs.readFile("/index.md");

--- a/tests/real-table-test.mjs
+++ b/tests/real-table-test.mjs
@@ -63,7 +63,7 @@ try {
     `path TEXT NOT NULL DEFAULT '', ` +
     `filename TEXT NOT NULL DEFAULT '', ` +
     `content BYTEA NOT NULL DEFAULT ''::bytea, ` +
-    `content_text TEXT NOT NULL DEFAULT '', ` +
+    `summary TEXT NOT NULL DEFAULT '', ` +
     `mime_type TEXT NOT NULL DEFAULT 'application/octet-stream', ` +
     `size_bytes BIGINT NOT NULL DEFAULT 0, ` +
     `timestamp TEXT NOT NULL DEFAULT ''` +
@@ -78,14 +78,14 @@ try {
   const text1 = "hello world";
   const hex1 = Buffer.from(text1).toString("hex");
   await query(
-    `INSERT INTO "${TABLE}" (id, path, filename, content, content_text, mime_type, size_bytes, timestamp) ` +
+    `INSERT INTO "${TABLE}" (id, path, filename, content, summary, mime_type, size_bytes, timestamp) ` +
     `VALUES ('${id1}', '/test/file1.txt', 'file1.txt', E'\\\\x${hex1}', E'${esc(text1)}', 'text/plain', ${Buffer.byteLength(text1)}, '${ts1}')`
   );
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows1 = await query(`SELECT id, path, content_text, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
+  const rows1 = await query(`SELECT id, path, summary, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
   assert(rows1.length === 1, "row inserted");
   assert(rows1[0].id === id1, `id matches (${rows1[0].id})`);
-  assert(rows1[0].content_text === text1, "content_text matches");
+  assert(rows1[0].summary === text1, "summary matches");
   assert(rows1[0].timestamp === ts1, "timestamp matches");
 
   // ── Test 2: UPDATE existing row (preserves id, updates timestamp) ──────────
@@ -95,15 +95,15 @@ try {
   const text2 = "updated content";
   const hex2 = Buffer.from(text2).toString("hex");
   await query(
-    `UPDATE "${TABLE}" SET content = E'\\\\x${hex2}', content_text = E'${esc(text2)}', ` +
+    `UPDATE "${TABLE}" SET content = E'\\\\x${hex2}', summary = E'${esc(text2)}', ` +
     `mime_type = 'text/plain', size_bytes = ${Buffer.byteLength(text2)}, timestamp = '${ts2}' ` +
     `WHERE path = '/test/file1.txt'`
   );
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows2 = await query(`SELECT id, content_text, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
+  const rows2 = await query(`SELECT id, summary, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
   assert(rows2.length === 1, "still one row");
   assert(rows2[0].id === id1, `id preserved after UPDATE (${rows2[0].id})`);
-  assert(rows2[0].content_text === text2, "content_text updated");
+  assert(rows2[0].summary === text2, "summary updated");
   assert(rows2[0].timestamp === ts2, `timestamp updated (${rows2[0].timestamp})`);
 
   // ── Test 3: appendFile UPDATE (concat content, update timestamp) ───────────
@@ -114,17 +114,17 @@ try {
   const appendHex = Buffer.from(append).toString("hex");
   await query(
     `UPDATE "${TABLE}" SET ` +
-    `content_text = content_text || E'${esc(append)}', ` +
+    `summary = summary || E'${esc(append)}', ` +
     `content = content || E'\\\\x${appendHex}', ` +
     `size_bytes = size_bytes + ${Buffer.byteLength(append)}, ` +
     `timestamp = '${ts3}' ` +
     `WHERE path = '/test/file1.txt'`
   );
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows3 = await query(`SELECT id, content_text, size_bytes, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
+  const rows3 = await query(`SELECT id, summary, size_bytes, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
   assert(rows3.length === 1, "still one row");
   assert(rows3[0].id === id1, `id preserved after append (${rows3[0].id})`);
-  assert(rows3[0].content_text === text2 + append, `content_text concatenated`);
+  assert(rows3[0].summary === text2 + append, `summary concatenated`);
   assert(rows3[0].timestamp === ts3, `timestamp updated (${rows3[0].timestamp})`);
 
   // ── Test 4: SELECT check before upsert (path exists) ──────────────────────
@@ -143,15 +143,15 @@ try {
   const check5 = await query(`SELECT path FROM "${TABLE}" WHERE path = '/test/file1.txt' LIMIT 1`);
   if (check5.length > 0) {
     await query(
-      `UPDATE "${TABLE}" SET content = E'\\\\x${hex5}', content_text = E'${esc(text5)}', ` +
+      `UPDATE "${TABLE}" SET content = E'\\\\x${hex5}', summary = E'${esc(text5)}', ` +
       `mime_type = 'text/plain', size_bytes = ${Buffer.byteLength(text5)}, timestamp = '${ts5}' ` +
       `WHERE path = '/test/file1.txt'`
     );
   }
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows5 = await query(`SELECT id, content_text, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
+  const rows5 = await query(`SELECT id, summary, timestamp FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
   assert(rows5[0].id === id1, `id still preserved through upsert (${rows5[0].id})`);
-  assert(rows5[0].content_text === text5, "content replaced via upsert");
+  assert(rows5[0].summary === text5, "content replaced via upsert");
   assert(rows5[0].timestamp === ts5, "timestamp refreshed via upsert");
 
   // ── Test 6: Full upsert flow — SELECT then INSERT for new path ─────────────
@@ -163,15 +163,15 @@ try {
   const check6 = await query(`SELECT path FROM "${TABLE}" WHERE path = '/test/file2.txt' LIMIT 1`);
   if (check6.length === 0) {
     await query(
-      `INSERT INTO "${TABLE}" (id, path, filename, content, content_text, mime_type, size_bytes, timestamp) ` +
+      `INSERT INTO "${TABLE}" (id, path, filename, content, summary, mime_type, size_bytes, timestamp) ` +
       `VALUES ('${id6}', '/test/file2.txt', 'file2.txt', E'\\\\x${hex6}', E'${esc(text6)}', 'text/plain', ${Buffer.byteLength(text6)}, '${ts6}')`
     );
   }
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows6 = await query(`SELECT id, content_text, timestamp FROM "${TABLE}" WHERE path = '/test/file2.txt'`);
+  const rows6 = await query(`SELECT id, summary, timestamp FROM "${TABLE}" WHERE path = '/test/file2.txt'`);
   assert(rows6.length === 1, "new row inserted");
   assert(rows6[0].id === id6, `new id assigned (${rows6[0].id})`);
-  assert(rows6[0].content_text === text6, "content correct");
+  assert(rows6[0].summary === text6, "content correct");
 
   // ── Test 7: Multiple updates preserve same id ──────────────────────────────
   console.log("\nTest 7: Multiple sequential updates preserve same id");
@@ -180,15 +180,15 @@ try {
     const txt = `update-${i}`;
     const hx = Buffer.from(txt).toString("hex");
     await query(
-      `UPDATE "${TABLE}" SET content = E'\\\\x${hx}', content_text = E'${esc(txt)}', ` +
+      `UPDATE "${TABLE}" SET content = E'\\\\x${hx}', summary = E'${esc(txt)}', ` +
       `size_bytes = ${Buffer.byteLength(txt)}, timestamp = '${ts}' ` +
       `WHERE path = '/test/file1.txt'`
     );
   }
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
-  const rows7 = await query(`SELECT id, content_text FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
+  const rows7 = await query(`SELECT id, summary FROM "${TABLE}" WHERE path = '/test/file1.txt'`);
   assert(rows7[0].id === id1, `id still original after 3 updates (${rows7[0].id})`);
-  assert(rows7[0].content_text === "update-2", "content is from last update");
+  assert(rows7[0].summary === "update-2", "content is from last update");
 
   // ── Test 8: DELETE then re-INSERT gets new id ──────────────────────────────
   console.log("\nTest 8: After DELETE, re-INSERT gets a new id");
@@ -197,7 +197,7 @@ try {
   const id8 = randomUUID();
   const ts8 = new Date().toISOString();
   await query(
-    `INSERT INTO "${TABLE}" (id, path, filename, content, content_text, mime_type, size_bytes, timestamp) ` +
+    `INSERT INTO "${TABLE}" (id, path, filename, content, summary, mime_type, size_bytes, timestamp) ` +
     `VALUES ('${id8}', '/test/file2.txt', 'file2.txt', E'\\\\x${hex6}', E'${esc(text6)}', 'text/plain', ${Buffer.byteLength(text6)}, '${ts8}')`
   );
   await query(`SELECT deeplake_sync_table('${TABLE}')`);
@@ -207,7 +207,7 @@ try {
   // ── Test 9: UPDATE on non-existent path is a no-op ─────────────────────────
   console.log("\nTest 9: UPDATE on non-existent path is a no-op");
   await query(
-    `UPDATE "${TABLE}" SET content_text = E'ghost', timestamp = '${new Date().toISOString()}' ` +
+    `UPDATE "${TABLE}" SET summary = E'ghost', timestamp = '${new Date().toISOString()}' ` +
     `WHERE path = '/test/does-not-exist.txt'`
   );
   await query(`SELECT deeplake_sync_table('${TABLE}')`);

--- a/tests/session-summary.test.ts
+++ b/tests/session-summary.test.ts
@@ -4,7 +4,7 @@ import { DeeplakeFs, isText, guessMime } from "../src/shell/deeplake-fs.js";
 // ── Mock client (same pattern as deeplake-fs.test.ts) ────────────────────────
 type Row = {
   id: string; path: string; filename: string; content: Buffer;
-  content_text: string; mime_type: string; size_bytes: number;
+  summary: string; mime_type: string; size_bytes: number;
   project: string; description: string; creation_date: string; last_update_date: string;
 };
 
@@ -14,7 +14,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
     path,
     filename: path.split("/").pop()!,
     content,
-    content_text: isText(content) ? content.toString("utf-8") : "",
+    summary: isText(content) ? content.toString("utf-8") : "",
     mime_type: guessMime(path.split("/").pop()!),
     size_bytes: content.length,
     project: "",
@@ -34,10 +34,10 @@ function makeClient(seed: Record<string, Buffer> = {}) {
         const row = match ? rows.find(r => r.path === match[1]) : undefined;
         return row ? [{ content: `\\x${row.content.toString("hex")}` }] : [];
       }
-      if (sql.includes("SELECT content_text, content")) {
+      if (sql.includes("SELECT summary, content")) {
         const match = sql.match(/path = '([^']+)'/);
         const row = match ? rows.find(r => r.path === match[1]) : undefined;
-        return row ? [{ content_text: row.content_text, content: `\\x${row.content.toString("hex")}` }] : [];
+        return row ? [{ summary: row.summary, content: `\\x${row.content.toString("hex")}` }] : [];
       }
       if (sql.includes("SELECT path, project, description, creation_date, last_update_date")) {
         return rows
@@ -70,19 +70,19 @@ function makeClient(seed: Record<string, Buffer> = {}) {
             if (ludMatch) row.last_update_date = ludMatch[1];
             const cdMatch = sql.match(/creation_date = '([^']+)'/);
             if (cdMatch) row.creation_date = cdMatch[1];
-            if (sql.includes("content_text = content_text ||")) {
+            if (sql.includes("summary = summary ||")) {
               const hexMatch = sql.match(/content \|\| E'\\\\x([0-9a-f]*)'/);
               if (hexMatch) {
                 const appendBuf = Buffer.from(hexMatch[1], "hex");
                 row.content = Buffer.concat([row.content, appendBuf]);
-                row.content_text += appendBuf.toString("utf-8");
+                row.summary += appendBuf.toString("utf-8");
                 row.size_bytes = row.content.length;
               }
             } else {
               const hexMatch = sql.match(/content = E'\\\\x([0-9a-f]*)'/);
-              const textMatch = sql.match(/content_text = E'((?:[^']|'')*)'/);
+              const textMatch = sql.match(/summary = E'((?:[^']|'')*)'/);
               if (hexMatch) { row.content = Buffer.from(hexMatch[1], "hex"); row.size_bytes = row.content.length; }
-              if (textMatch) { row.content_text = textMatch[1].replace(/''/g, "'"); }
+              if (textMatch) { row.summary = textMatch[1].replace(/''/g, "'"); }
             }
             const projMatch = sql.match(/project = '([^']*)'/);
             if (projMatch) row.project = projMatch[1];
@@ -101,7 +101,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
           if (pathMatch) {
             const path = pathMatch[1];
             const content = hexMatch ? Buffer.from(hexMatch[1], "hex") : Buffer.alloc(0);
-            const content_text = textMatch?.[1]?.replace(/''/g, "'") ?? "";
+            const summary = textMatch?.[1]?.replace(/''/g, "'") ?? "";
             const colsPart = sql.match(/\(([^)]+)\)\s+VALUES/)?.[1] ?? "";
             const colsList = colsPart.split(",").map(c => c.trim());
             const valsStr = valuesMatch[1];
@@ -129,7 +129,7 @@ function makeClient(seed: Record<string, Buffer> = {}) {
             if (idx >= 0) rows.splice(idx, 1);
             rows.push({
               id: colMap["id"] ?? "", path, filename: path.split("/").pop()!,
-              content, content_text, mime_type: "text/plain", size_bytes: content.length,
+              content, summary, mime_type: "text/plain", size_bytes: content.length,
               project: colMap["project"] ?? "", description: colMap["description"] ?? "",
               creation_date: colMap["creation_date"] ?? "", last_update_date: colMap["last_update_date"] ?? "",
             });
@@ -231,7 +231,7 @@ describe("session summary — no global paths", () => {
 
       const row = client._rows.find(r => r.path.endsWith(`/${sessionId}.md`) && r.path.startsWith("/summaries/"));
       expect(row).toBeDefined();
-      const content = row!.content_text;
+      const content = row!.summary;
 
       // Must NOT contain the global path
       expect(content).not.toContain(globalPath);
@@ -257,7 +257,7 @@ describe("session summary — Source field structure", () => {
     const sessionId = "abc-123-def";
     await createPlaceholder(fs, sessionId, "/some/deep/path/my-repo", "alice", "acme-corp", "prod");
 
-    const content = client._rows.find(r => r.path.endsWith(`/${sessionId}.md`) && r.path.startsWith("/summaries/"))!.content_text;
+    const content = client._rows.find(r => r.path.endsWith(`/${sessionId}.md`) && r.path.startsWith("/summaries/"))!.summary;
     expect(content).toContain("- **Source**: /sessions/alice/alice_acme-corp_prod_abc-123-def.jsonl");
   });
 });
@@ -313,11 +313,11 @@ describe("session summary — resumed sessions update last_update_date", () => {
     // description must be extracted from What Happened section
     expect(rowAfterEnd.description).toBe("Fixed authentication bug in the login flow. Added retry logic for token refresh.");
     // content must be the full summary
-    expect(rowAfterEnd.content_text).toContain("## What Happened");
-    expect(rowAfterEnd.content_text).toContain("## Key Facts");
+    expect(rowAfterEnd.summary).toContain("## What Happened");
+    expect(rowAfterEnd.summary).toContain("## Key Facts");
     // No global path
-    expect(rowAfterEnd.content_text).not.toContain("/home/user/projects/my-app");
-    expect(rowAfterEnd.content_text).toContain("- **Project**: my-app");
+    expect(rowAfterEnd.summary).not.toContain("/home/user/projects/my-app");
+    expect(rowAfterEnd.summary).toContain("- **Project**: my-app");
   });
 
   it("resumed session (second follow-up) updates again", async () => {
@@ -361,7 +361,7 @@ describe("session summary — resumed sessions update last_update_date", () => {
     const rowFinal = client._rows.find(r => r.path.endsWith(`/${sessionId}.md`) && r.path.startsWith("/summaries/"))!;
     const date3 = rowFinal.last_update_date;
     expect(date3).not.toBe(date2);
-    expect(rowFinal.content_text).toContain("rate limiting");
+    expect(rowFinal.summary).toContain("rate limiting");
     expect(rowFinal.description).toContain("auth middleware");
   });
 });

--- a/tests/sessions-table.test.ts
+++ b/tests/sessions-table.test.ts
@@ -5,7 +5,7 @@ import { DeeplakeFs, isText, guessMime } from "../src/shell/deeplake-fs.js";
 
 interface Row {
   path: string;
-  content_text: string;
+  text_content: string;
   size_bytes: number;
   mime_type: string;
   creation_date: string;
@@ -37,22 +37,22 @@ function makeClient(memoryRows: Row[] = [], sessionRows: Row[] = []) {
       }
 
       // Read session rows ordered by creation_date
-      if (sql.includes("SELECT content_text") && isSessionsQuery && sql.includes("ORDER BY creation_date")) {
+      if (sql.includes("SELECT message") && isSessionsQuery && sql.includes("ORDER BY creation_date")) {
         const pathMatch = sql.match(/path = '([^']+)'/);
         if (pathMatch) {
           return sessionRows
             .filter(r => r.path === pathMatch[1])
             .sort((a, b) => a.creation_date.localeCompare(b.creation_date))
-            .map(r => ({ content_text: r.content_text, creation_date: r.creation_date }));
+            .map(r => ({ message: r.text_content, creation_date: r.creation_date }));
         }
       }
 
       // Read from memory table
-      if (sql.includes("SELECT content_text, content") && !isSessionsQuery) {
+      if (sql.includes("SELECT summary, content") && !isSessionsQuery) {
         const pathMatch = sql.match(/path = '([^']+)'/);
         if (pathMatch) {
           const row = memoryRows.find(r => r.path === pathMatch[1]);
-          return row ? [{ content_text: row.content_text, content: "" }] : [];
+          return row ? [{ summary: row.text_content, content: "" }] : [];
         }
       }
 
@@ -61,7 +61,7 @@ function makeClient(memoryRows: Row[] = [], sessionRows: Row[] = []) {
         const pathMatch = sql.match(/path = '([^']+)'/);
         if (pathMatch) {
           const row = memoryRows.find(r => r.path === pathMatch[1]);
-          return row ? [{ content: `\\x${Buffer.from(row.content_text).toString("hex")}` }] : [];
+          return row ? [{ content: `\\x${Buffer.from(row.text_content).toString("hex")}` }] : [];
         }
       }
 
@@ -88,9 +88,9 @@ function makeClient(memoryRows: Row[] = [], sessionRows: Row[] = []) {
 describe("DeeplakeFs — sessions table multi-row read", () => {
   it("reads session file by concatenating rows ordered by creation_date", async () => {
     const sessionRows: Row[] = [
-      { path: "/sessions/alice/alice_org_default_s1.jsonl", content_text: '{"type":"user_message","content":"hello"}', size_bytes: 40, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
-      { path: "/sessions/alice/alice_org_default_s1.jsonl", content_text: '{"type":"tool_call","tool_name":"Read"}', size_bytes: 38, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
-      { path: "/sessions/alice/alice_org_default_s1.jsonl", content_text: '{"type":"assistant_message","content":"done"}', size_bytes: 44, mime_type: "application/json", creation_date: "2026-01-01T00:00:03Z" },
+      { path: "/sessions/alice/alice_org_default_s1.jsonl", text_content: '{"type":"user_message","content":"hello"}', size_bytes: 40, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/alice/alice_org_default_s1.jsonl", text_content: '{"type":"tool_call","tool_name":"Read"}', size_bytes: 38, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
+      { path: "/sessions/alice/alice_org_default_s1.jsonl", text_content: '{"type":"assistant_message","content":"done"}', size_bytes: 44, mime_type: "application/json", creation_date: "2026-01-01T00:00:03Z" },
     ];
 
     const client = makeClient([], sessionRows);
@@ -106,9 +106,9 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
 
   it("preserves creation_date ordering even if inserted out of order", async () => {
     const sessionRows: Row[] = [
-      { path: "/sessions/u/s1.jsonl", content_text: '{"seq":3}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:03Z" },
-      { path: "/sessions/u/s1.jsonl", content_text: '{"seq":1}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
-      { path: "/sessions/u/s1.jsonl", content_text: '{"seq":2}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: '{"seq":3}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:03Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: '{"seq":1}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: '{"seq":2}', size_bytes: 9, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
     ];
 
     const client = makeClient([], sessionRows);
@@ -121,9 +121,9 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
     expect(JSON.parse(lines[2]).seq).toBe(3);
   });
 
-  it("handles JSONB content_text (object instead of string)", async () => {
+  it("handles JSONB message (object instead of string)", async () => {
     const sessionRows: Row[] = [
-      { path: "/sessions/u/s1.jsonl", content_text: { type: "user_message", content: "hi" } as unknown as string, size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: { type: "user_message", content: "hi" } as unknown as string, size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
     ];
 
     const client = makeClient([], sessionRows);
@@ -137,8 +137,8 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
 
   it("lists session files in directory listing", async () => {
     const sessionRows: Row[] = [
-      { path: "/sessions/alice/s1.jsonl", content_text: "{}", size_bytes: 2, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
-      { path: "/sessions/alice/s2.jsonl", content_text: "{}", size_bytes: 2, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
+      { path: "/sessions/alice/s1.jsonl", text_content: "{}", size_bytes: 2, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/alice/s2.jsonl", text_content: "{}", size_bytes: 2, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
     ];
 
     const client = makeClient([], sessionRows);
@@ -151,10 +151,10 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
 
   it("session paths don't conflict with memory table paths", async () => {
     const memoryRows: Row[] = [
-      { path: "/summaries/alice/s1.md", content_text: "# Summary", size_bytes: 9, mime_type: "text/markdown", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/summaries/alice/s1.md", text_content: "# Summary", size_bytes: 9, mime_type: "text/markdown", creation_date: "2026-01-01T00:00:01Z" },
     ];
     const sessionRows: Row[] = [
-      { path: "/sessions/alice/s1.jsonl", content_text: '{"type":"user_message"}', size_bytes: 22, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/alice/s1.jsonl", text_content: '{"type":"user_message"}', size_bytes: 22, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
     ];
 
     const client = makeClient(memoryRows, sessionRows);
@@ -169,7 +169,7 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
 
   it("works without sessions table (backwards compatible)", async () => {
     const memoryRows: Row[] = [
-      { path: "/test.txt", content_text: "hello", size_bytes: 5, mime_type: "text/plain", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/test.txt", text_content: "hello", size_bytes: 5, mime_type: "text/plain", creation_date: "2026-01-01T00:00:01Z" },
     ];
 
     const client = makeClient(memoryRows);
@@ -184,9 +184,9 @@ describe("DeeplakeFs — sessions table multi-row read", () => {
 describe("DeeplakeFs — multiple sessions in same table", () => {
   it("different sessions have independent content", async () => {
     const sessionRows: Row[] = [
-      { path: "/sessions/u/s1.jsonl", content_text: '{"session":"s1","msg":"hello"}', size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
-      { path: "/sessions/u/s1.jsonl", content_text: '{"session":"s1","msg":"world"}', size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
-      { path: "/sessions/u/s2.jsonl", content_text: '{"session":"s2","msg":"foo"}', size_bytes: 28, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: '{"session":"s1","msg":"hello"}', size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
+      { path: "/sessions/u/s1.jsonl", text_content: '{"session":"s1","msg":"world"}', size_bytes: 30, mime_type: "application/json", creation_date: "2026-01-01T00:00:02Z" },
+      { path: "/sessions/u/s2.jsonl", text_content: '{"session":"s2","msg":"foo"}', size_bytes: 28, mime_type: "application/json", creation_date: "2026-01-01T00:00:01Z" },
     ];
 
     const client = makeClient([], sessionRows);
@@ -205,7 +205,7 @@ describe("DeeplakeFs — multiple sessions in same table", () => {
 });
 
 describe("ensureSessionsTable schema", () => {
-  it("creates table with JSONB content_text column", async () => {
+  it("creates table with JSONB message column", async () => {
     const client = {
       query: vi.fn().mockResolvedValue([]),
       listTables: vi.fn().mockResolvedValue([]),
@@ -231,9 +231,49 @@ describe("ensureSessionsTable schema", () => {
 
     const createSql = queryCalls.find(s => s.includes("CREATE TABLE"));
     expect(createSql).toBeDefined();
-    expect(createSql).toContain("content_text JSONB");
+    expect(createSql).toContain("message JSONB");
+    expect(createSql).toContain("author TEXT");
     expect(createSql).toContain("application/json");
     // Should NOT have content BYTEA column (sessions don't need binary)
     expect(createSql).not.toContain("BYTEA");
+    // Should NOT use old column name
+    expect(createSql).not.toContain("content_text");
+  });
+
+  it("memory table uses summary column (not content_text)", async () => {
+    const { DeeplakeApi } = await import("../src/deeplake-api.js");
+    const api = new DeeplakeApi("token", "https://api.test", "org", "ws", "memory");
+    const queryCalls: string[] = [];
+    api.query = vi.fn().mockImplementation(async (sql: string) => {
+      queryCalls.push(sql);
+      return [];
+    }) as typeof api.query;
+    api.listTables = vi.fn().mockResolvedValue([]) as typeof api.listTables;
+
+    await api.ensureTable();
+
+    const createSql = queryCalls.find(s => s.includes("CREATE TABLE"));
+    expect(createSql).toBeDefined();
+    expect(createSql).toContain("summary TEXT");
+    expect(createSql).toContain("author TEXT");
+    expect(createSql).not.toContain("content_text");
+  });
+
+  it("memory table migration adds author column", async () => {
+    const { DeeplakeApi } = await import("../src/deeplake-api.js");
+    const api = new DeeplakeApi("token", "https://api.test", "org", "ws", "memory");
+    const queryCalls: string[] = [];
+    api.query = vi.fn().mockImplementation(async (sql: string) => {
+      queryCalls.push(sql);
+      return [];
+    }) as typeof api.query;
+    // Table already exists
+    api.listTables = vi.fn().mockResolvedValue(["memory"]) as typeof api.listTables;
+
+    await api.ensureTable();
+
+    const alterCalls = queryCalls.filter(s => s.includes("ALTER TABLE"));
+    const authorAlter = alterCalls.find(s => s.includes("author"));
+    expect(authorAlter).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- **Capture fallback**: if INSERT fails because the sessions table doesn't exist (session-start failed or org switched mid-session), create the table and retry once
- **Column renames**: `content_text` → `summary` (memory table), `content_text` → `message` (sessions table) for clarity
- **Author column**: added to both tables to track which user created each row

## Test plan
- [ ] Verify capture works when sessions table doesn't exist (fallback creates it)
- [ ] Verify existing sessions/memory reads work with renamed columns
- [ ] Run `npm test` — all 163 tests pass