### PR TITLE
Fix rename regressions: auto-update, version display, org after login

### DIFF
--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -342,7 +342,7 @@ Organization management \u2014 each argument is SEPARATE (do NOT quote subcomman
 LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 
 Debugging: Set DEEPLAKE_DEBUG=1 to enable verbose logging to ~/.deeplake/hook-debug.log`;
-var GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/deeplake-claude-code-plugins/main/package.json";
+var GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/hivemind/main/package.json";
 var VERSION_CHECK_TIMEOUT = 3e3;
 function getInstalledVersion() {
   try {
@@ -410,7 +410,7 @@ async function main() {
   const input = await readStdin();
   let creds = loadCredentials();
   if (!creds?.token) {
-    log3("no credentials found \u2014 run /deeplake-hivemind:login to authenticate");
+    log3("no credentials found \u2014 run /hivemind:login to authenticate");
   } else {
     log3(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
     if (creds.token && !creds.userName) {
@@ -451,32 +451,35 @@ async function main() {
           log3(`autoupdate: updating ${current} \u2192 ${latest}`);
           try {
             const scopes = ["user", "project", "local", "managed"];
-            const cmd = scopes.map((s) => `claude plugin update deeplake-hivemind@deeplake-claude-code-plugins --scope ${s} 2>/dev/null`).join("; ");
+            const cmd = scopes.map((s) => `claude plugin update hivemind@hivemind --scope ${s} 2>/dev/null`).join("; ");
             execSync2(cmd, { stdio: "ignore", timeout: 6e4 });
             updateNotice = `
 
-\u2705 Deeplake Hivemind auto-updated: ${current} \u2192 ${latest}. Run /reload-plugins to apply.`;
-            process.stderr.write(`\u2705 Deeplake Hivemind auto-updated: ${current} \u2192 ${latest}. Run /reload-plugins to apply.
+\u2705 Hivemind auto-updated: ${current} \u2192 ${latest}. Run /reload-plugins to apply.`;
+            process.stderr.write(`\u2705 Hivemind auto-updated: ${current} \u2192 ${latest}. Run /reload-plugins to apply.
 `);
             log3(`autoupdate succeeded: ${current} \u2192 ${latest}`);
           } catch (e) {
             updateNotice = `
 
-\u2B06\uFE0F Deeplake Hivemind update available: ${current} \u2192 ${latest}. Auto-update failed \u2014 run /deeplake-hivemind:update to upgrade manually.`;
-            process.stderr.write(`\u2B06\uFE0F Deeplake Hivemind update available: ${current} \u2192 ${latest}. Auto-update failed \u2014 run /deeplake-hivemind:update to upgrade manually.
+\u2B06\uFE0F Hivemind update available: ${current} \u2192 ${latest}. Auto-update failed \u2014 run /hivemind:update to upgrade manually.`;
+            process.stderr.write(`\u2B06\uFE0F Hivemind update available: ${current} \u2192 ${latest}. Auto-update failed \u2014 run /hivemind:update to upgrade manually.
 `);
             log3(`autoupdate failed: ${e.message}`);
           }
         } else {
           updateNotice = `
 
-\u2B06\uFE0F Deeplake Hivemind update available: ${current} \u2192 ${latest}. Run /deeplake-hivemind:update to upgrade.`;
-          process.stderr.write(`\u2B06\uFE0F Deeplake Hivemind update available: ${current} \u2192 ${latest}. Run /deeplake-hivemind:update to upgrade.
+\u2B06\uFE0F Hivemind update available: ${current} \u2192 ${latest}. Run /hivemind:update to upgrade.`;
+          process.stderr.write(`\u2B06\uFE0F Hivemind update available: ${current} \u2192 ${latest}. Run /hivemind:update to upgrade.
 `);
           log3(`update available (autoupdate off): ${current} \u2192 ${latest}`);
         }
       } else {
         log3(`version up to date: ${current}`);
+        updateNotice = `
+
+\u2705 Hivemind v${current} (up to date)`;
       }
     }
   } catch (e) {
@@ -487,7 +490,7 @@ async function main() {
 
 Logged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})${updateNotice}` : `${resolvedContext}
 
-\u26A0\uFE0F Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake-hivemind:login to authenticate.${updateNotice}`;
+\u26A0\uFE0F Not logged in to Deeplake. Memory search will not work. Ask the user to run /hivemind:login to authenticate.${updateNotice}`;
   console.log(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "SessionStart",

--- a/claude-code/commands/login.md
+++ b/claude-code/commands/login.md
@@ -9,9 +9,11 @@ Run:
 node "${CLAUDE_PLUGIN_ROOT}/bundle/commands/auth-login.js" login
 ```
 
-If login succeeds, show this welcome message:
+If login succeeds, show this welcome message. Include the organization name from the command output:
 
 🐝 Welcome to Hivemind!
+
+Current org: **{org name from output}**
 
 Your Claude Code agents can now talk to each other and share memory across sessions, teammates, and machines.
 

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -51,7 +51,7 @@ LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty 
 
 Debugging: Set DEEPLAKE_DEBUG=1 to enable verbose logging to ~/.deeplake/hook-debug.log`;
 
-const GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/deeplake-claude-code-plugins/main/package.json";
+const GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/hivemind/main/package.json";
 const VERSION_CHECK_TIMEOUT = 3000; // 3s — don't block session start
 
 function getInstalledVersion(): string | null {
@@ -143,7 +143,7 @@ async function main(): Promise<void> {
   let creds = loadCredentials();
 
   if (!creds?.token) {
-    log("no credentials found — run /deeplake-hivemind:login to authenticate");
+    log("no credentials found — run /hivemind:login to authenticate");
   } else {
     log(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
     // Backfill userName if missing (for users who logged in before this field was added)
@@ -190,24 +190,25 @@ async function main(): Promise<void> {
           try {
             const scopes = ["user", "project", "local", "managed"];
             const cmd = scopes
-              .map(s => `claude plugin update deeplake-hivemind@deeplake-claude-code-plugins --scope ${s} 2>/dev/null`)
+              .map(s => `claude plugin update hivemind@hivemind --scope ${s} 2>/dev/null`)
               .join("; ");
             execSync(cmd, { stdio: "ignore", timeout: 60_000 });
-            updateNotice = `\n\n✅ Deeplake Hivemind auto-updated: ${current} → ${latest}. Run /reload-plugins to apply.`;
-            process.stderr.write(`✅ Deeplake Hivemind auto-updated: ${current} → ${latest}. Run /reload-plugins to apply.\n`);
+            updateNotice = `\n\n✅ Hivemind auto-updated: ${current} → ${latest}. Run /reload-plugins to apply.`;
+            process.stderr.write(`✅ Hivemind auto-updated: ${current} → ${latest}. Run /reload-plugins to apply.\n`);
             log(`autoupdate succeeded: ${current} → ${latest}`);
           } catch (e: any) {
-            updateNotice = `\n\n⬆️ Deeplake Hivemind update available: ${current} → ${latest}. Auto-update failed — run /deeplake-hivemind:update to upgrade manually.`;
-            process.stderr.write(`⬆️ Deeplake Hivemind update available: ${current} → ${latest}. Auto-update failed — run /deeplake-hivemind:update to upgrade manually.\n`);
+            updateNotice = `\n\n⬆️ Hivemind update available: ${current} → ${latest}. Auto-update failed — run /hivemind:update to upgrade manually.`;
+            process.stderr.write(`⬆️ Hivemind update available: ${current} → ${latest}. Auto-update failed — run /hivemind:update to upgrade manually.\n`);
             log(`autoupdate failed: ${e.message}`);
           }
         } else {
-          updateNotice = `\n\n⬆️ Deeplake Hivemind update available: ${current} → ${latest}. Run /deeplake-hivemind:update to upgrade.`;
-          process.stderr.write(`⬆️ Deeplake Hivemind update available: ${current} → ${latest}. Run /deeplake-hivemind:update to upgrade.\n`);
+          updateNotice = `\n\n⬆️ Hivemind update available: ${current} → ${latest}. Run /hivemind:update to upgrade.`;
+          process.stderr.write(`⬆️ Hivemind update available: ${current} → ${latest}. Run /hivemind:update to upgrade.\n`);
           log(`update available (autoupdate off): ${current} → ${latest}`);
         }
       } else {
         log(`version up to date: ${current}`);
+        updateNotice = `\n\n✅ Hivemind v${current} (up to date)`;
       }
     }
   } catch (e: any) {
@@ -217,7 +218,7 @@ async function main(): Promise<void> {
   const resolvedContext = context.replace(/DEEPLAKE_AUTH_CMD/g, AUTH_CMD);
   const additionalContext = creds?.token
     ? `${resolvedContext}\n\nLogged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})${updateNotice}`
-    : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /deeplake-hivemind:login to authenticate.${updateNotice}`;
+    : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /hivemind:login to authenticate.${updateNotice}`;
 
   console.log(JSON.stringify({
     hookSpecificOutput: {


### PR DESCRIPTION
## Fixes

1. **Auto-update broken** — `GITHUB_RAW_PKG` still pointed to `activeloopai/deeplake-claude-code-plugins`, now `activeloopai/hivemind`
2. **Update command wrong** — `deeplake-hivemind@deeplake-claude-code-plugins` → `hivemind@hivemind`
3. **Old branding** — `Deeplake Hivemind` → `Hivemind` in all notices
4. **Old command refs** — `/deeplake-hivemind:login` → `/hivemind:login` in context injection
5. **No version display when up to date** — now shows `✅ Hivemind vX.Y.Z (up to date)`
6. **Org not shown after login** — login.md now tells agent to include org name from output