### PR TITLE
Add session prune command

### DIFF
--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -193,6 +193,406 @@ Using: ${orgName}
   return creds;
 }
 
+// dist/src/config.js
+import { readFileSync as readFileSync2, existsSync as existsSync2 } from "node:fs";
+import { join as join2 } from "node:path";
+import { homedir as homedir2, userInfo } from "node:os";
+function loadConfig() {
+  const home = homedir2();
+  const credPath = join2(home, ".deeplake", "credentials.json");
+  let creds = null;
+  if (existsSync2(credPath)) {
+    try {
+      creds = JSON.parse(readFileSync2(credPath, "utf-8"));
+    } catch {
+      return null;
+    }
+  }
+  const token = process.env.DEEPLAKE_TOKEN ?? creds?.token;
+  const orgId = process.env.DEEPLAKE_ORG_ID ?? creds?.orgId;
+  if (!token || !orgId)
+    return null;
+  return {
+    token,
+    orgId,
+    orgName: creds?.orgName ?? orgId,
+    userName: creds?.userName || userInfo().username || "unknown",
+    workspaceId: process.env.DEEPLAKE_WORKSPACE_ID ?? creds?.workspaceId ?? "default",
+    apiUrl: process.env.DEEPLAKE_API_URL ?? creds?.apiUrl ?? "https://api.deeplake.ai",
+    tableName: process.env.DEEPLAKE_TABLE ?? "memory",
+    sessionsTableName: process.env.DEEPLAKE_SESSIONS_TABLE ?? "sessions",
+    memoryPath: process.env.DEEPLAKE_MEMORY_PATH ?? join2(home, ".deeplake", "memory")
+  };
+}
+
+// dist/src/deeplake-api.js
+import { randomUUID } from "node:crypto";
+
+// dist/src/utils/debug.js
+import { appendFileSync } from "node:fs";
+import { join as join3 } from "node:path";
+import { homedir as homedir3 } from "node:os";
+var DEBUG = process.env.DEEPLAKE_DEBUG === "1";
+var LOG = join3(homedir3(), ".deeplake", "hook-debug.log");
+function log(tag, msg) {
+  if (!DEBUG)
+    return;
+  appendFileSync(LOG, `${(/* @__PURE__ */ new Date()).toISOString()} [${tag}] ${msg}
+`);
+}
+
+// dist/src/utils/sql.js
+function sqlStr(value) {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "''").replace(/\0/g, "").replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+}
+
+// dist/src/deeplake-api.js
+var log2 = (msg) => log("sdk", msg);
+var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
+var MAX_RETRIES = 3;
+var BASE_DELAY_MS = 500;
+var MAX_CONCURRENCY = 5;
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+var Semaphore = class {
+  max;
+  waiting = [];
+  active = 0;
+  constructor(max) {
+    this.max = max;
+  }
+  async acquire() {
+    if (this.active < this.max) {
+      this.active++;
+      return;
+    }
+    await new Promise((resolve) => this.waiting.push(resolve));
+  }
+  release() {
+    this.active--;
+    const next = this.waiting.shift();
+    if (next) {
+      this.active++;
+      next();
+    }
+  }
+};
+var DeeplakeApi = class {
+  token;
+  apiUrl;
+  orgId;
+  workspaceId;
+  tableName;
+  _pendingRows = [];
+  _sem = new Semaphore(MAX_CONCURRENCY);
+  constructor(token, apiUrl, orgId, workspaceId, tableName) {
+    this.token = token;
+    this.apiUrl = apiUrl;
+    this.orgId = orgId;
+    this.workspaceId = workspaceId;
+    this.tableName = tableName;
+  }
+  /** Execute SQL with retry on transient errors and bounded concurrency. */
+  async query(sql) {
+    await this._sem.acquire();
+    try {
+      return await this._queryWithRetry(sql);
+    } finally {
+      this._sem.release();
+    }
+  }
+  async _queryWithRetry(sql) {
+    let lastError;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      let resp;
+      try {
+        resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables/query`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            "Content-Type": "application/json",
+            "X-Activeloop-Org-Id": this.orgId
+          },
+          body: JSON.stringify({ query: sql })
+        });
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e));
+        if (attempt < MAX_RETRIES) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
+          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep(delay);
+          continue;
+        }
+        throw lastError;
+      }
+      if (resp.ok) {
+        const raw = await resp.json();
+        if (!raw?.rows || !raw?.columns)
+          return [];
+        return raw.rows.map((row) => Object.fromEntries(raw.columns.map((col, i) => [col, row[i]])));
+      }
+      const text = await resp.text().catch(() => "");
+      if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
+        const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
+        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep(delay);
+        continue;
+      }
+      throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
+    }
+    throw lastError ?? new Error("Query failed: max retries exceeded");
+  }
+  // ── Writes ──────────────────────────────────────────────────────────────────
+  /** Queue rows for writing. Call commit() to flush. */
+  appendRows(rows) {
+    this._pendingRows.push(...rows);
+  }
+  /** Flush pending rows via SQL. */
+  async commit() {
+    if (this._pendingRows.length === 0)
+      return;
+    const rows = this._pendingRows;
+    this._pendingRows = [];
+    const CONCURRENCY = 10;
+    for (let i = 0; i < rows.length; i += CONCURRENCY) {
+      const chunk = rows.slice(i, i + CONCURRENCY);
+      await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
+    }
+    log2(`commit: ${rows.length} rows`);
+  }
+  async upsertRowSql(row) {
+    const ts = (/* @__PURE__ */ new Date()).toISOString();
+    const cd = row.creationDate ?? ts;
+    const lud = row.lastUpdateDate ?? ts;
+    const exists = await this.query(`SELECT path FROM "${this.tableName}" WHERE path = '${sqlStr(row.path)}' LIMIT 1`);
+    if (exists.length > 0) {
+      let setClauses = `summary = E'${sqlStr(row.contentText)}', mime_type = '${sqlStr(row.mimeType)}', size_bytes = ${row.sizeBytes}, last_update_date = '${lud}'`;
+      if (row.project !== void 0)
+        setClauses += `, project = '${sqlStr(row.project)}'`;
+      if (row.description !== void 0)
+        setClauses += `, description = '${sqlStr(row.description)}'`;
+      await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(row.path)}'`);
+    } else {
+      const id = randomUUID();
+      let cols = "id, path, filename, summary, mime_type, size_bytes, creation_date, last_update_date";
+      let vals = `'${id}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', E'${sqlStr(row.contentText)}', '${sqlStr(row.mimeType)}', ${row.sizeBytes}, '${cd}', '${lud}'`;
+      if (row.project !== void 0) {
+        cols += ", project";
+        vals += `, '${sqlStr(row.project)}'`;
+      }
+      if (row.description !== void 0) {
+        cols += ", description";
+        vals += `, '${sqlStr(row.description)}'`;
+      }
+      await this.query(`INSERT INTO "${this.tableName}" (${cols}) VALUES (${vals})`);
+    }
+  }
+  /** Update specific columns on a row by path. */
+  async updateColumns(path, columns) {
+    const setClauses = Object.entries(columns).map(([col, val]) => typeof val === "number" ? `${col} = ${val}` : `${col} = '${sqlStr(String(val))}'`).join(", ");
+    await this.query(`UPDATE "${this.tableName}" SET ${setClauses} WHERE path = '${sqlStr(path)}'`);
+  }
+  // ── Convenience ─────────────────────────────────────────────────────────────
+  /** Create a BM25 search index on a column. */
+  async createIndex(column) {
+    await this.query(`CREATE INDEX IF NOT EXISTS idx_${sqlStr(column)}_bm25 ON "${this.tableName}" USING deeplake_index ("${column}")`);
+  }
+  /** List all tables in the workspace (with retry). */
+  async listTables() {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            "X-Activeloop-Org-Id": this.orgId
+          }
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          return (data.tables ?? []).map((t) => t.table_name);
+        }
+        if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
+          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          continue;
+        }
+        return [];
+      } catch {
+        if (attempt < MAX_RETRIES) {
+          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          continue;
+        }
+        return [];
+      }
+    }
+    return [];
+  }
+  /** Create the memory table if it doesn't already exist. Migrate columns on existing tables. */
+  async ensureTable(name) {
+    const tbl = name ?? this.tableName;
+    const tables = await this.listTables();
+    if (!tables.includes(tbl)) {
+      log2(`table "${tbl}" not found, creating`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      log2(`table "${tbl}" created`);
+    } else {
+      for (const col of ["project", "description", "creation_date", "last_update_date", "author"]) {
+        try {
+          await this.query(`ALTER TABLE "${tbl}" ADD COLUMN ${col} TEXT NOT NULL DEFAULT ''`);
+          log2(`added column "${col}" to "${tbl}"`);
+        } catch {
+        }
+      }
+    }
+  }
+  /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
+  async ensureSessionsTable(name) {
+    const tables = await this.listTables();
+    if (!tables.includes(name)) {
+      log2(`table "${name}" not found, creating`);
+      await this.query(`CREATE TABLE IF NOT EXISTS "${name}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`);
+      log2(`table "${name}" created`);
+    }
+  }
+};
+
+// dist/src/commands/session-prune.js
+import { createInterface } from "node:readline";
+function parseArgs(argv) {
+  let before;
+  let sessionId;
+  let all = false;
+  let yes = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--before" && argv[i + 1]) {
+      before = argv[++i];
+    } else if (arg === "--session-id" && argv[i + 1]) {
+      sessionId = argv[++i];
+    } else if (arg === "--all") {
+      all = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      yes = true;
+    }
+  }
+  return { before, sessionId, all, yes };
+}
+function confirm(message) {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    rl.question(`${message} [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}
+function extractSessionId(path) {
+  const filename = path.split("/").pop() ?? "";
+  const base = filename.replace(/\.jsonl$/, "");
+  const parts = base.split("_");
+  return parts.length >= 4 ? parts.slice(3).join("_") : base;
+}
+async function listSessions(api, sessionsTable, author) {
+  const rows = await api.query(`SELECT path, COUNT(*) as cnt, MIN(creation_date) as first_event, MAX(creation_date) as last_event, MAX(project) as project FROM "${sessionsTable}" WHERE author = '${sqlStr(author)}' GROUP BY path ORDER BY first_event DESC`);
+  return rows.map((r) => ({
+    path: String(r.path),
+    rowCount: Number(r.cnt),
+    firstEvent: String(r.first_event),
+    lastEvent: String(r.last_event),
+    project: String(r.project ?? "")
+  }));
+}
+async function deleteSessions(config, sessionPaths) {
+  if (sessionPaths.length === 0)
+    return { sessionsDeleted: 0, summariesDeleted: 0 };
+  const sessionsApi = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.sessionsTableName);
+  const memoryApi = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+  let sessionsDeleted = 0;
+  let summariesDeleted = 0;
+  for (const sessionPath of sessionPaths) {
+    await sessionsApi.query(`DELETE FROM "${config.sessionsTableName}" WHERE path = '${sqlStr(sessionPath)}'`);
+    sessionsDeleted++;
+    const sessionId = extractSessionId(sessionPath);
+    const summaryPath = `/summaries/${config.userName}/${sessionId}.md`;
+    const existing = await memoryApi.query(`SELECT path FROM "${config.tableName}" WHERE path = '${sqlStr(summaryPath)}' LIMIT 1`);
+    if (existing.length > 0) {
+      await memoryApi.query(`DELETE FROM "${config.tableName}" WHERE path = '${sqlStr(summaryPath)}'`);
+      summariesDeleted++;
+    }
+  }
+  return { sessionsDeleted, summariesDeleted };
+}
+async function sessionPrune(argv) {
+  const config = loadConfig();
+  if (!config) {
+    console.error("Not logged in. Run: deeplake login");
+    process.exit(1);
+  }
+  const { before, sessionId, all, yes } = parseArgs(argv);
+  const author = config.userName;
+  const sessionsApi = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.sessionsTableName);
+  const sessions = await listSessions(sessionsApi, config.sessionsTableName, author);
+  if (sessions.length === 0) {
+    console.log(`No sessions found for author "${author}".`);
+    return;
+  }
+  let targets;
+  if (sessionId) {
+    targets = sessions.filter((s) => extractSessionId(s.path) === sessionId);
+    if (targets.length === 0) {
+      console.error(`Session not found: ${sessionId}`);
+      console.error(`
+Your sessions:`);
+      for (const s of sessions.slice(0, 10)) {
+        console.error(`  ${extractSessionId(s.path)}  ${s.firstEvent.slice(0, 10)}  ${s.project}`);
+      }
+      process.exit(1);
+    }
+  } else if (before) {
+    const cutoff = new Date(before);
+    if (isNaN(cutoff.getTime())) {
+      console.error(`Invalid date: ${before}`);
+      process.exit(1);
+    }
+    targets = sessions.filter((s) => new Date(s.lastEvent) < cutoff);
+  } else if (all) {
+    targets = sessions;
+  } else {
+    console.log(`Sessions for "${author}" (${sessions.length} total):
+`);
+    console.log("  Session ID".padEnd(42) + "Date".padEnd(14) + "Events".padEnd(10) + "Project");
+    console.log("  " + "\u2500".repeat(80));
+    for (const s of sessions) {
+      const id = extractSessionId(s.path);
+      const date = s.firstEvent.slice(0, 10);
+      console.log(`  ${id.padEnd(40)}${date.padEnd(14)}${String(s.rowCount).padEnd(10)}${s.project}`);
+    }
+    console.log(`
+To delete, use: --all, --before <date>, or --session-id <id>`);
+    return;
+  }
+  if (targets.length === 0) {
+    console.log("No sessions match the given criteria.");
+    return;
+  }
+  console.log(`Will delete ${targets.length} session(s) for "${author}":
+`);
+  for (const s of targets) {
+    const id = extractSessionId(s.path);
+    console.log(`  ${id}  ${s.firstEvent.slice(0, 10)}  ${s.rowCount} events  ${s.project}`);
+  }
+  console.log();
+  if (!yes) {
+    const ok = await confirm("Proceed with deletion?");
+    if (!ok) {
+      console.log("Aborted.");
+      return;
+    }
+  }
+  const { sessionsDeleted, summariesDeleted } = await deleteSessions(config, targets.map((t) => t.path));
+  console.log(`Deleted ${sessionsDeleted} session(s) and ${summariesDeleted} summary file(s).`);
+}
+
 // dist/src/commands/auth-login.js
 async function main() {
   const args = process.argv.slice(2);
@@ -303,6 +703,15 @@ async function main() {
       console.log(`Removed user ${userId}`);
       break;
     }
+    case "sessions": {
+      const sub = args[1];
+      if (sub === "prune") {
+        await sessionPrune(args.slice(2));
+      } else {
+        console.log("Usage: sessions prune [--all | --before <date> | --session-id <id>] [--yes]");
+      }
+      break;
+    }
     case "autoupdate": {
       if (!creds) {
         console.log("Not logged in.");
@@ -323,7 +732,7 @@ async function main() {
       break;
     }
     default:
-      console.log("Commands: login, whoami, org list, org switch, workspaces, workspace, invite, members, remove, autoupdate");
+      console.log("Commands: login, whoami, org list, org switch, workspaces, workspace, sessions prune, invite, members, remove, autoupdate");
   }
 }
 main().catch((e) => {

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -487,10 +487,8 @@ function confirm(message) {
   });
 }
 function extractSessionId(path) {
-  const filename = path.split("/").pop() ?? "";
-  const base = filename.replace(/\.jsonl$/, "");
-  const parts = base.split("_");
-  return parts.length >= 4 ? parts.slice(3).join("_") : base;
+  const m = path.match(/\/sessions\/[^/]+\/[^/]+_([^.]+)\.jsonl$/);
+  return m ? m[1] : path.split("/").pop()?.replace(/\.jsonl$/, "") ?? path;
 }
 async function listSessions(api, sessionsTable, author) {
   const rows = await api.query(`SELECT path, COUNT(*) as cnt, MIN(creation_date) as first_event, MAX(creation_date) as last_event, MAX(project) as project FROM "${sessionsTable}" WHERE author = '${sqlStr(author)}' GROUP BY path ORDER BY first_event DESC`);

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -38,7 +38,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js
 function T1(n24) {
   let t6 = 0;
   return n24.includes("i") && (t6 |= y.CASE_INSENSITIVE), n24.includes("m") && (t6 |= y.MULTILINE), n24.includes("s") && (t6 |= y.DOTALL), t6;
@@ -51,7 +51,7 @@ function b1(n24, t6 = "") {
 }
 var g, u, a, b, w, O, R1, I, F, X, P, _, m, v, U, z, V, L, $, j, N, E, W, Y, M, c, q, D, K, Z, d, n1, r1, a1, o1, l1, h1, u1, c1, p1, f1, g1, A1, w1, E1, d1, O1, C1, m1, S1, x, H, Q, J, t1, e1, s1, y, B, i1;
 var init_chunk_YNYSPYQ5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js"() {
     g = class n {
       static FOLD_CASE = 1;
       static LITERAL = 2;
@@ -2970,13 +2970,13 @@ var init_chunk_YNYSPYQ5 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js
 function v2(r10) {
   return r10 instanceof c2 || r10 instanceof a2 || r10 instanceof i;
 }
 var n15, c2, a2, i, u2, x2, d2, p, l, h, m2, b2, $2, f, C;
 var init_chunk_GFQRA5P5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js"() {
     n15 = class extends Error {
       stdout;
       stderr;
@@ -3090,7 +3090,7 @@ var init_chunk_GFQRA5P5 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js
 function $3(e6, t6) {
   for (; t6 < e6.length; ) {
     if (e6[t6] === "\\" && e6[t6 + 1] === `
@@ -8494,7 +8494,7 @@ async function Ve(e6, t6, r10 = false) {
 }
 var Re, w2, p2, pe, Bt, Dr, xr, _r, ve, Qe, Ze, Qt, Ue, Zt, Ut, Ht, G, Tr, Fr, zr, V2, Yr, dn, oe, yn, xi, as, Le, ys, kt;
 var init_chunk_FEIOJCZD = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js"() {
     init_chunk_YNYSPYQ5();
     init_chunk_GFQRA5P5();
     Re = ["=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "|=", "^="];
@@ -9839,7 +9839,7 @@ var init_chunk_FEIOJCZD = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js
 import * as i2 from "node:fs";
 import * as o from "node:path";
 function c3(t6) {
@@ -9873,14 +9873,14 @@ function v4(t6, e6) {
   return c3(p3(n24, e6));
 }
 var init_chunk_XHM67O4N = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js
 var r, e2, o2, a3;
 var init_chunk_CWQS3NFK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js"() {
     r = globalThis.SharedArrayBuffer;
     e2 = globalThis.Atomics;
     o2 = performance.now.bind(performance);
@@ -9888,10 +9888,10 @@ var init_chunk_CWQS3NFK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js
 var h3, e3, i3, j2, k2, l2, m4, n16, o3, p4, g2, q3, r2;
 var init_chunk_DXB73IDG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js"() {
     h3 = Object.create;
     e3 = Object.defineProperty;
     i3 = Object.getOwnPropertyDescriptor;
@@ -9916,7 +9916,7 @@ var init_chunk_DXB73IDG = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js
 function v5() {
   let a15 = [{ prop: "Function", target: globalThis, violationType: "function_constructor", strategy: "throw", reason: "Function constructor allows arbitrary code execution" }, { prop: "eval", target: globalThis, violationType: "eval", strategy: "throw", reason: "eval() allows arbitrary code execution" }, { prop: "setTimeout", target: globalThis, violationType: "setTimeout", strategy: "throw", reason: "setTimeout with string argument allows code execution" }, { prop: "setInterval", target: globalThis, violationType: "setInterval", strategy: "throw", reason: "setInterval with string argument allows code execution" }, { prop: "setImmediate", target: globalThis, violationType: "setImmediate", strategy: "throw", reason: "setImmediate could be used to escape sandbox context" }, { prop: "env", target: process, violationType: "process_env", strategy: "throw", reason: "process.env could leak sensitive environment variables", allowedKeys: /* @__PURE__ */ new Set(["NODE_V8_COVERAGE", "NODE_DEBUG", "NODE_DEBUG_NATIVE", "NODE_COMPILE_CACHE", "WATCH_REPORT_DEPENDENCIES", "FORCE_COLOR", "DEBUG", "UNDICI_NO_FG", "JEST_WORKER_ID", "__MINIMATCH_TESTING_PLATFORM__", "LOG_TOKENS", "LOG_STREAM"]) }, { prop: "binding", target: process, violationType: "process_binding", strategy: "throw", reason: "process.binding provides access to native Node.js modules" }, { prop: "_linkedBinding", target: process, violationType: "process_binding", strategy: "throw", reason: "process._linkedBinding provides access to native Node.js modules" }, { prop: "dlopen", target: process, violationType: "process_dlopen", strategy: "throw", reason: "process.dlopen allows loading native addons" }, { prop: "getBuiltinModule", target: process, violationType: "process_get_builtin_module", strategy: "throw", reason: "process.getBuiltinModule allows loading native Node.js modules (fs, child_process, vm)" }, { prop: "exit", target: process, violationType: "process_exit", strategy: "throw", reason: "process.exit could terminate the interpreter" }, { prop: "abort", target: process, violationType: "process_exit", strategy: "throw", reason: "process.abort could crash the interpreter" }, { prop: "kill", target: process, violationType: "process_kill", strategy: "throw", reason: "process.kill could signal other processes" }, { prop: "setuid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setuid could escalate privileges" }, { prop: "setgid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setgid could escalate privileges" }, { prop: "seteuid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.seteuid could escalate effective user privileges" }, { prop: "setegid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setegid could escalate effective group privileges" }, { prop: "initgroups", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.initgroups could modify supplementary group IDs" }, { prop: "setgroups", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setgroups could modify supplementary group IDs" }, { prop: "umask", target: process, violationType: "process_umask", strategy: "throw", reason: "process.umask could modify file creation permissions" }, { prop: "argv", target: process, violationType: "process_argv", strategy: "throw", reason: "process.argv may contain secrets in CLI arguments" }, { prop: "cwd", target: process, violationType: "process_chdir", strategy: "throw", reason: "process.cwd could disclose real host working directory path" }, { prop: "chdir", target: process, violationType: "process_chdir", strategy: "throw", reason: "process.chdir could confuse the interpreter's CWD tracking" }, { prop: "report", target: process, violationType: "process_report", strategy: "throw", reason: "process.report could disclose full environment, host paths, and system info" }, { prop: "loadEnvFile", target: process, violationType: "process_env", strategy: "throw", reason: "process.loadEnvFile could load env files bypassing env proxy" }, { prop: "setUncaughtExceptionCaptureCallback", target: process, violationType: "process_exception_handler", strategy: "throw", reason: "setUncaughtExceptionCaptureCallback could intercept security errors" }, { prop: "send", target: process, violationType: "process_send", strategy: "throw", reason: "process.send could communicate with parent process in IPC contexts" }, { prop: "channel", target: process, violationType: "process_channel", strategy: "throw", reason: "process.channel could access IPC channel to parent process" }, { prop: "cpuUsage", target: process, violationType: "process_timing", strategy: "throw", reason: "process.cpuUsage could enable timing side-channel attacks" }, { prop: "memoryUsage", target: process, violationType: "process_timing", strategy: "throw", reason: "process.memoryUsage could enable timing side-channel attacks" }, { prop: "hrtime", target: process, violationType: "process_timing", strategy: "throw", reason: "process.hrtime could enable timing side-channel attacks" }, { prop: "WeakRef", target: globalThis, violationType: "weak_ref", strategy: "throw", reason: "WeakRef could be used to leak references outside sandbox" }, { prop: "FinalizationRegistry", target: globalThis, violationType: "finalization_registry", strategy: "throw", reason: "FinalizationRegistry could be used to leak references outside sandbox" }, { prop: "Reflect", target: globalThis, violationType: "reflect", strategy: "freeze", reason: "Reflect provides introspection capabilities" }, { prop: "Proxy", target: globalThis, violationType: "proxy", strategy: "throw", reason: "Proxy allows intercepting and modifying object behavior" }, { prop: "WebAssembly", target: globalThis, violationType: "webassembly", strategy: "throw", reason: "WebAssembly allows executing arbitrary compiled code" }, { prop: "SharedArrayBuffer", target: globalThis, violationType: "shared_array_buffer", strategy: "throw", reason: "SharedArrayBuffer could enable side-channel communication or timing attacks" }, { prop: "Atomics", target: globalThis, violationType: "atomics", strategy: "throw", reason: "Atomics could enable side-channel communication or timing attacks" }, { prop: "performance", target: globalThis, violationType: "performance_timing", strategy: "throw", reason: "performance.now() provides sub-millisecond timing for side-channel attacks" }, { prop: "stdout", target: process, violationType: "process_stdout", strategy: "throw", reason: "process.stdout could bypass interpreter output to write to host stdout" }, { prop: "stderr", target: process, violationType: "process_stderr", strategy: "throw", reason: "process.stderr could bypass interpreter output to write to host stderr" }, { prop: "__defineGetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__defineGetter__ allows prototype pollution via getter injection" }, { prop: "__defineSetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__defineSetter__ allows prototype pollution via setter injection" }, { prop: "__lookupGetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__lookupGetter__ enables introspection for prototype pollution attacks" }, { prop: "__lookupSetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__lookupSetter__ enables introspection for prototype pollution attacks" }, { prop: "JSON", target: globalThis, violationType: "json_mutation", strategy: "freeze", reason: "Freeze JSON to prevent mutation of parsing/serialization" }, { prop: "Math", target: globalThis, violationType: "math_mutation", strategy: "freeze", reason: "Freeze Math to prevent mutation of math utilities" }];
   try {
@@ -9963,7 +9963,7 @@ function E2(a15) {
 }
 var f2, x4, k3, d3, u3, T2, m5, _2;
 var init_chunk_5QMZ5MUS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js"() {
     init_chunk_DXB73IDG();
     f2 = typeof __BROWSER__ < "u" && __BROWSER__;
     x4 = null;
@@ -10513,13 +10513,13 @@ This is a defense-in-depth measure and indicates a bug in just-bash. Please repo
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js
 function l3(t6) {
   return typeof t6 != "function" ? t6 : _2.bindCurrentContext(t6);
 }
 var i4, r3, s, T3, b3, u4;
 var init_chunk_A5O5YHGN = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js"() {
     init_chunk_5QMZ5MUS();
     i4 = globalThis.setTimeout.bind(globalThis);
     r3 = globalThis.clearTimeout.bind(globalThis);
@@ -10530,7 +10530,7 @@ var init_chunk_A5O5YHGN = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js
 function n17(e6) {
   return `'${e6.replace(/'/g, "'\\''")}'`;
 }
@@ -10538,11 +10538,11 @@ function r4(e6) {
   return e6.map(n17).join(" ");
 }
 var init_chunk_IPJHKYVM = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js
 function r5(e6) {
   return Object.assign(/* @__PURE__ */ Object.create(null), Object.fromEntries(e6));
 }
@@ -10553,11 +10553,11 @@ function c4(...e6) {
   return Object.assign(/* @__PURE__ */ Object.create(null), ...e6);
 }
 var init_chunk_OJDRYQWQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js
 function a5(t6, e6, n24) {
   if (!t6 || _2.isInSandboxedContext()) return;
   let r10 = `${e6} ${n24} attempted outside defense context`;
@@ -10573,12 +10573,12 @@ function d4(t6, e6, n24, r10) {
   return t6 ? _2.bindCurrentContext(o14) : o14;
 }
 var init_chunk_24IMIIXA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js"() {
     init_chunk_5QMZ5MUS();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js
 function a6(r10, s10, t6) {
   if (!r10) return r10;
   let e6 = r10.replace(/\n\s+at\s.*/g, "");
@@ -10591,20 +10591,20 @@ function i5(r10) {
   return a6(r10, true, true);
 }
 var init_chunk_3THT3N7L = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js
 function n20(e6) {
   return e6 instanceof Error ? e6.message : String(e6);
 }
 var init_chunk_44UOCSGV = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js
 function n21(r10) {
   let s10 = "", e6 = 0;
   for (; e6 < r10.length; ) if (r10[e6] === "\\") {
@@ -10699,7 +10699,7 @@ function n21(r10) {
 }
 var c5, f3;
 var init_chunk_GCTKCWKD = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js"() {
     c5 = { name: "echo", async execute(r10, s10) {
       let e6 = false, o14 = s10.xpgEcho ?? false, a15 = 0;
       for (; a15 < r10.length; ) {
@@ -10722,20 +10722,20 @@ var init_chunk_GCTKCWKD = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js
 var echo_O45JWWI2_exports = {};
 __export(echo_O45JWWI2_exports, {
   echoCommand: () => c5,
   flagsForFuzzing: () => f3
 });
 var init_echo_O45JWWI2 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js"() {
     init_chunk_GCTKCWKD();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js
 async function y3(t6, n24, s10) {
   let { cmdName: r10, allowStdinMarker: f11 = true, stopOnError: a15 = false, batchSize: u12 = 100 } = s10;
   if (n24.length === 0) return { files: [{ filename: "", content: t6.stdin }], stderr: "", exitCode: 0 };
@@ -10762,11 +10762,11 @@ async function b4(t6, n24, s10) {
   return r10.exitCode !== 0 ? { ok: false, error: { stdout: "", stderr: r10.stderr, exitCode: r10.exitCode } } : { ok: true, content: r10.files.map((a15) => a15.content).join("") };
 }
 var init_chunk_7L36YK2X = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js
 function s2(t6) {
   let e6 = `${t6.name} - ${t6.summary}
 
@@ -10815,11 +10815,11 @@ function r6(t6, e6) {
 `, exitCode: 1 };
 }
 var init_chunk_74CEPOFO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js
 function x6(a15, i11, d15) {
   let g17 = /* @__PURE__ */ new Map(), h18 = /* @__PURE__ */ new Map();
   for (let [t6, e6] of Object.entries(d15)) {
@@ -10876,12 +10876,12 @@ function x6(a15, i11, d15) {
   return { ok: true, result: { flags: s10, positional: b26 } };
 }
 var init_chunk_HWKDQ44K = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js"() {
     init_chunk_74CEPOFO();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js
 function y4(n24, s10) {
   let e6 = n24.split(`
 `), r10 = n24.endsWith(`
@@ -10892,7 +10892,7 @@ function y4(n24, s10) {
 }
 var b5, g3, F3, w4;
 var init_chunk_TXBZCHCQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -10914,14 +10914,14 @@ var init_chunk_TXBZCHCQ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js
 var cat_RDUMLXKC_exports = {};
 __export(cat_RDUMLXKC_exports, {
   catCommand: () => F3,
   flagsForFuzzing: () => w4
 });
 var init_cat_RDUMLXKC = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js"() {
     init_chunk_TXBZCHCQ();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -10930,7 +10930,7 @@ var init_cat_RDUMLXKC = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js
 function i6(t6, l7, e6) {
   let c15 = t6;
   e6 >= 0 && c15.length > e6 && (c15 = c15.slice(0, e6));
@@ -11021,13 +11021,13 @@ function r7(t6) {
   return l7;
 }
 var init_chunk_EEXR5ZDP = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js"() {
   }
 });
 
-// node_modules/sprintf-js/src/sprintf.js
+// ../../../node_modules/sprintf-js/src/sprintf.js
 var require_sprintf = __commonJS({
-  "node_modules/sprintf-js/src/sprintf.js"(exports) {
+  "../../../node_modules/sprintf-js/src/sprintf.js"(exports) {
     !(function() {
       "use strict";
       var re9 = {
@@ -11228,7 +11228,7 @@ var require_sprintf = __commonJS({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js
 function P3(t6, s10, r10) {
   let e6 = new Date(s10 * 1e3), a15 = "", n24 = 0;
   for (; n24 < t6.length; ) if (t6[n24] === "%" && n24 + 1 < t6.length) {
@@ -11707,7 +11707,7 @@ function ae2(t6) {
 }
 var import_sprintf_js, X3, de2, d5, he2;
 var init_chunk_T56QNPHK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js"() {
     init_chunk_EEXR5ZDP();
     init_chunk_GFQRA5P5();
     init_chunk_44UOCSGV();
@@ -11766,14 +11766,14 @@ var init_chunk_T56QNPHK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js
 var printf_CX64KX2P_exports = {};
 __export(printf_CX64KX2P_exports, {
   flagsForFuzzing: () => he2,
   printfCommand: () => de2
 });
 var init_printf_CX64KX2P = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js"() {
     init_chunk_T56QNPHK();
     init_chunk_EEXR5ZDP();
     init_chunk_GFQRA5P5();
@@ -11783,10 +11783,10 @@ var init_printf_CX64KX2P = __esm({
   }
 });
 
-// node_modules/balanced-match/dist/esm/index.js
+// ../../../node_modules/balanced-match/dist/esm/index.js
 var balanced, maybeMatch, range;
 var init_esm = __esm({
-  "node_modules/balanced-match/dist/esm/index.js"() {
+  "../../../node_modules/balanced-match/dist/esm/index.js"() {
     balanced = (a15, b26, str) => {
       const ma3 = a15 instanceof RegExp ? maybeMatch(a15, str) : a15;
       const mb = b26 instanceof RegExp ? maybeMatch(b26, str) : b26;
@@ -11841,7 +11841,7 @@ var init_esm = __esm({
   }
 });
 
-// node_modules/brace-expansion/dist/esm/index.js
+// ../../../node_modules/brace-expansion/dist/esm/index.js
 function numeric(str) {
   return !isNaN(str) ? parseInt(str, 10) : str.charCodeAt(0);
 }
@@ -11986,7 +11986,7 @@ function expand_(str, max, isTop) {
 }
 var escSlash, escOpen, escClose, escComma, escPeriod, escSlashPattern, escOpenPattern, escClosePattern, escCommaPattern, escPeriodPattern, slashPattern, openPattern, closePattern, commaPattern, periodPattern, EXPANSION_MAX;
 var init_esm2 = __esm({
-  "node_modules/brace-expansion/dist/esm/index.js"() {
+  "../../../node_modules/brace-expansion/dist/esm/index.js"() {
     init_esm();
     escSlash = "\0SLASH" + Math.random() + "\0";
     escOpen = "\0OPEN" + Math.random() + "\0";
@@ -12007,10 +12007,10 @@ var init_esm2 = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/assert-valid-pattern.js
+// ../../../node_modules/minimatch/dist/esm/assert-valid-pattern.js
 var MAX_PATTERN_LENGTH, assertValidPattern;
 var init_assert_valid_pattern = __esm({
-  "node_modules/minimatch/dist/esm/assert-valid-pattern.js"() {
+  "../../../node_modules/minimatch/dist/esm/assert-valid-pattern.js"() {
     MAX_PATTERN_LENGTH = 1024 * 64;
     assertValidPattern = (pattern) => {
       if (typeof pattern !== "string") {
@@ -12023,10 +12023,10 @@ var init_assert_valid_pattern = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/brace-expressions.js
+// ../../../node_modules/minimatch/dist/esm/brace-expressions.js
 var posixClasses, braceEscape, regexpEscape, rangesToString, parseClass;
 var init_brace_expressions = __esm({
-  "node_modules/minimatch/dist/esm/brace-expressions.js"() {
+  "../../../node_modules/minimatch/dist/esm/brace-expressions.js"() {
     posixClasses = {
       "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true],
       "[:alpha:]": ["\\p{L}\\p{Nl}", true],
@@ -12137,10 +12137,10 @@ var init_brace_expressions = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/unescape.js
+// ../../../node_modules/minimatch/dist/esm/unescape.js
 var unescape;
 var init_unescape = __esm({
-  "node_modules/minimatch/dist/esm/unescape.js"() {
+  "../../../node_modules/minimatch/dist/esm/unescape.js"() {
     unescape = (s10, { windowsPathsNoEscape = false, magicalBraces = true } = {}) => {
       if (magicalBraces) {
         return windowsPathsNoEscape ? s10.replace(/\[([^/\\])\]/g, "$1") : s10.replace(/((?!\\).|^)\[([^/\\])\]/g, "$1$2").replace(/\\([^/])/g, "$1");
@@ -12150,10 +12150,10 @@ var init_unescape = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/ast.js
+// ../../../node_modules/minimatch/dist/esm/ast.js
 var _a, types, isExtglobType, isExtglobAST, adoptionMap, adoptionWithSpaceMap, adoptionAnyMap, usurpMap, startNoTraversal, startNoDot, addPatternStart, justDots, reSpecials, regExpEscape, qmark, star, starNoEmpty, ID, AST;
 var init_ast = __esm({
-  "node_modules/minimatch/dist/esm/ast.js"() {
+  "../../../node_modules/minimatch/dist/esm/ast.js"() {
     init_brace_expressions();
     init_unescape();
     types = /* @__PURE__ */ new Set(["!", "?", "+", "*", "@"]);
@@ -12800,10 +12800,10 @@ var init_ast = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/escape.js
+// ../../../node_modules/minimatch/dist/esm/escape.js
 var escape;
 var init_escape = __esm({
-  "node_modules/minimatch/dist/esm/escape.js"() {
+  "../../../node_modules/minimatch/dist/esm/escape.js"() {
     escape = (s10, { windowsPathsNoEscape = false, magicalBraces = false } = {}) => {
       if (magicalBraces) {
         return windowsPathsNoEscape ? s10.replace(/[?*()[\]{}]/g, "[$&]") : s10.replace(/[?*()[\]\\{}]/g, "\\$&");
@@ -12813,10 +12813,10 @@ var init_escape = __esm({
   }
 });
 
-// node_modules/minimatch/dist/esm/index.js
+// ../../../node_modules/minimatch/dist/esm/index.js
 var minimatch, starDotExtRE, starDotExtTest, starDotExtTestDot, starDotExtTestNocase, starDotExtTestNocaseDot, starDotStarRE, starDotStarTest, starDotStarTestDot, dotStarRE, dotStarTest, starRE, starTest, starTestDot, qmarksRE, qmarksTestNocase, qmarksTestNocaseDot, qmarksTestDot, qmarksTest, qmarksTestNoExt, qmarksTestNoExtDot, defaultPlatform, path, sep, GLOBSTAR, qmark2, star2, twoStarDot, twoStarNoDot, filter, ext, defaults, braceExpand, makeRe, match, globMagic, regExpEscape2, Minimatch;
 var init_esm3 = __esm({
-  "node_modules/minimatch/dist/esm/index.js"() {
+  "../../../node_modules/minimatch/dist/esm/index.js"() {
     init_esm2();
     init_assert_valid_pattern();
     init_ast();
@@ -13635,7 +13635,7 @@ var init_esm3 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js
 function M3(n24) {
   if (n24 < 1024) return String(n24);
   if (n24 < 1024 * 1024) {
@@ -13832,7 +13832,7 @@ async function O3(n24, s10, c15, w20, S18, y21, P21, b26 = false, g17 = false, v
 }
 var k4, G3, Z4, q5;
 var init_chunk_V7TAPXDL = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     init_esm3();
@@ -13885,14 +13885,14 @@ var init_chunk_V7TAPXDL = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js
 var ls_KSXFZCWH_exports = {};
 __export(ls_KSXFZCWH_exports, {
   flagsForFuzzing: () => q5,
   lsCommand: () => Z4
 });
 var init_ls_KSXFZCWH = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js"() {
     init_chunk_V7TAPXDL();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -13900,10 +13900,10 @@ var init_ls_KSXFZCWH = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js
 var p5, b6, h5;
 var init_chunk_MDDMCKUK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -13932,14 +13932,14 @@ var init_chunk_MDDMCKUK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js
 var mkdir_TDEMSB6C_exports = {};
 __export(mkdir_TDEMSB6C_exports, {
   flagsForFuzzing: () => h5,
   mkdirCommand: () => b6
 });
 var init_mkdir_TDEMSB6C = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js"() {
     init_chunk_MDDMCKUK();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -13949,7 +13949,7 @@ var init_mkdir_TDEMSB6C = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js
 async function b7(t6, r10, e6, a15) {
   let o14 = "", s10 = "", n24 = t6.fs.resolvePath(t6.cwd, r10), i11 = await v7(t6, n24, r10, a15);
   if (o14 += i11.stdout, s10 += i11.stderr, i11.exitCode !== 0) return { stdout: o14, stderr: s10, exitCode: i11.exitCode };
@@ -13989,7 +13989,7 @@ function C3(t6) {
 }
 var x7, y5, D3, $4;
 var init_chunk_OCS6LSEM = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     x7 = `Usage: rmdir [-pv] DIRECTORY...
@@ -14018,14 +14018,14 @@ Options:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js
 var rmdir_XTQXT7RK_exports = {};
 __export(rmdir_XTQXT7RK_exports, {
   flagsForFuzzing: () => $4,
   rmdirCommand: () => D3
 });
 var init_rmdir_XTQXT7RK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js"() {
     init_chunk_OCS6LSEM();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14034,7 +14034,7 @@ var init_rmdir_XTQXT7RK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js
 function h6(s10) {
   let a15 = s10.replace(/\//g, "-"), r10 = new Date(a15);
   if (!Number.isNaN(r10.getTime())) return r10;
@@ -14052,7 +14052,7 @@ function h6(s10) {
 }
 var N3, b8;
 var init_chunk_OCLXQMOG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js"() {
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
     N3 = { name: "touch", async execute(s10, a15) {
@@ -14111,14 +14111,14 @@ var init_chunk_OCLXQMOG = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js
 var touch_DX2IJOQ4_exports = {};
 __export(touch_DX2IJOQ4_exports, {
   flagsForFuzzing: () => b8,
   touchCommand: () => N3
 });
 var init_touch_DX2IJOQ4 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js"() {
     init_chunk_OCLXQMOG();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14126,10 +14126,10 @@ var init_touch_DX2IJOQ4 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js
 var v8, E3, $5;
 var init_chunk_MIZPJHVH = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14165,14 +14165,14 @@ var init_chunk_MIZPJHVH = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js
 var rm_RTZG23RL_exports = {};
 __export(rm_RTZG23RL_exports, {
   flagsForFuzzing: () => $5,
   rmCommand: () => E3
 });
 var init_rm_RTZG23RL = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js"() {
     init_chunk_MIZPJHVH();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -14182,10 +14182,10 @@ var init_rm_RTZG23RL = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js
 var D4, E4, A, F4;
 var init_chunk_NUYSJFDK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14235,14 +14235,14 @@ var init_chunk_NUYSJFDK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js
 var cp_XOYR4ABJ_exports = {};
 __export(cp_XOYR4ABJ_exports, {
   cpCommand: () => A,
   flagsForFuzzing: () => F4
 });
 var init_cp_XOYR4ABJ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js"() {
     init_chunk_NUYSJFDK();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14251,10 +14251,10 @@ var init_cp_XOYR4ABJ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js
 var C4, P4, O4, x8;
 var init_chunk_A4JSPFCI = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14302,14 +14302,14 @@ var init_chunk_A4JSPFCI = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js
 var mv_Z6MORUFL_exports = {};
 __export(mv_Z6MORUFL_exports, {
   flagsForFuzzing: () => x8,
   mvCommand: () => O4
 });
 var init_mv_Z6MORUFL = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js"() {
     init_chunk_A4JSPFCI();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14318,10 +14318,10 @@ var init_mv_Z6MORUFL = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js
 var y6, v9, $6;
 var init_chunk_PBXLG62G = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js"() {
     init_chunk_3THT3N7L();
     init_chunk_74CEPOFO();
     y6 = { name: "ln", summary: "make links between files", usage: "ln [OPTIONS] TARGET LINK_NAME", options: ["-s      create a symbolic link instead of a hard link", "-f      remove existing destination files", "-n      treat LINK_NAME as a normal file if it is a symbolic link to a directory", "-v      print name of each linked file", "    --help display this help and exit"] };
@@ -14374,14 +14374,14 @@ var init_chunk_PBXLG62G = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js
 var ln_4TRFBYAT_exports = {};
 __export(ln_4TRFBYAT_exports, {
   flagsForFuzzing: () => $6,
   lnCommand: () => v9
 });
 var init_ln_4TRFBYAT = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js"() {
     init_chunk_PBXLG62G();
     init_chunk_3THT3N7L();
     init_chunk_74CEPOFO();
@@ -14389,7 +14389,7 @@ var init_ln_4TRFBYAT = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js
 async function y7(s10, a15, e6, c15, i11) {
   let n24 = "", l7 = await s10.fs.readdir(a15);
   for (let r10 of l7) {
@@ -14428,7 +14428,7 @@ function p6(s10, a15 = 420) {
 }
 var R3, C5, O5;
 var init_chunk_4GTNDTRF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js"() {
     init_chunk_74CEPOFO();
     R3 = { name: "chmod", summary: "change file mode bits", usage: "chmod [OPTIONS] MODE FILE...", options: ["-R      change files recursively", "-v      output a diagnostic for every file processed", "    --help display this help and exit"] };
     C5 = { name: "chmod", async execute(s10, a15) {
@@ -14488,24 +14488,24 @@ var init_chunk_4GTNDTRF = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js
 var chmod_SYMGL4JA_exports = {};
 __export(chmod_SYMGL4JA_exports, {
   chmodCommand: () => C5,
   flagsForFuzzing: () => O5
 });
 var init_chmod_SYMGL4JA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js"() {
     init_chunk_4GTNDTRF();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js
 var o5, f4;
 var init_chunk_A4HU7SVR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js"() {
     o5 = { name: "pwd", async execute(l7, a15) {
       let t6 = false;
       for (let e6 of l7) if (e6 === "-P") t6 = true;
@@ -14526,23 +14526,23 @@ var init_chunk_A4HU7SVR = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js
 var pwd_D4OZ7N27_exports = {};
 __export(pwd_D4OZ7N27_exports, {
   flagsForFuzzing: () => f4,
   pwdCommand: () => o5
 });
 var init_pwd_D4OZ7N27 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js"() {
     init_chunk_A4HU7SVR();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js
 var m6, y8, w5;
 var init_chunk_HJWBQKYG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js"() {
     init_chunk_74CEPOFO();
     m6 = { name: "readlink", summary: "print resolved symbolic links or canonical file names", usage: "readlink [OPTIONS] FILE...", options: ["-f      canonicalize by following every symlink in every component of the given name recursively", "    --help display this help and exit"] };
     y8 = { name: "readlink", async execute(a15, l7) {
@@ -14596,21 +14596,21 @@ var init_chunk_HJWBQKYG = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js
 var readlink_MI4GCHJF_exports = {};
 __export(readlink_MI4GCHJF_exports, {
   flagsForFuzzing: () => w5,
   readlinkCommand: () => y8
 });
 var init_readlink_MI4GCHJF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js"() {
     init_chunk_HJWBQKYG();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js
 function I3(t6, r10) {
   let i11 = 10, s10 = null, o14 = false, l7 = false, n24 = false, u12 = [];
   for (let f11 = 0; f11 < t6.length; f11++) {
@@ -14705,15 +14705,15 @@ function g4(t6, r10, i11, s10) {
 `;
 }
 var init_chunk_HDQ56CKY = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js"() {
     init_chunk_74CEPOFO();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js
 var f5, m7, g5;
 var init_chunk_64BAICW3 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js"() {
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
     f5 = { name: "head", summary: "output the first part of files", usage: "head [OPTION]... [FILE]...", options: ["-c, --bytes=NUM    print the first NUM bytes", "-n, --lines=NUM    print the first NUM lines (default 10)", "-q, --quiet        never print headers giving file names", "-v, --verbose      always print headers giving file names", "    --help         display this help and exit"] };
@@ -14728,14 +14728,14 @@ var init_chunk_64BAICW3 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js
 var head_HT2B6D2J_exports = {};
 __export(head_HT2B6D2J_exports, {
   flagsForFuzzing: () => g5,
   headCommand: () => m7
 });
 var init_head_HT2B6D2J = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js"() {
     init_chunk_64BAICW3();
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
@@ -14743,10 +14743,10 @@ var init_head_HT2B6D2J = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js
 var m8, d6, c6;
 var init_chunk_DCAAORBQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js"() {
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
     m8 = { name: "tail", summary: "output the last part of files", usage: "tail [OPTION]... [FILE]...", options: ["-c, --bytes=NUM    print the last NUM bytes", "-n, --lines=NUM    print the last NUM lines (default 10)", "-n +NUM            print starting from line NUM", "-q, --quiet        never print headers giving file names", "-v, --verbose      always print headers giving file names", "    --help         display this help and exit"] };
@@ -14761,14 +14761,14 @@ var init_chunk_DCAAORBQ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js
 var tail_S5ULNTJU_exports = {};
 __export(tail_S5ULNTJU_exports, {
   flagsForFuzzing: () => c6,
   tailCommand: () => d6
 });
 var init_tail_S5ULNTJU = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js"() {
     init_chunk_DCAAORBQ();
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
@@ -14776,7 +14776,7 @@ var init_tail_S5ULNTJU = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js
 function C6(a15) {
   let c15 = a15.length, n24 = 0, o14 = 0, e6 = false;
   for (let s10 = 0; s10 < c15; s10++) {
@@ -14794,7 +14794,7 @@ function w6(a15, c15, n24, o14, e6, s10) {
 }
 var $8, H3, E5, I4;
 var init_chunk_GXVXFKBA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -14829,14 +14829,14 @@ var init_chunk_GXVXFKBA = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js
 var wc_TQB3VNOX_exports = {};
 __export(wc_TQB3VNOX_exports, {
   flagsForFuzzing: () => I4,
   wcCommand: () => E5
 });
 var init_wc_TQB3VNOX = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js"() {
     init_chunk_GXVXFKBA();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -14845,20 +14845,20 @@ var init_wc_TQB3VNOX = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js
 function x9(r10, o14) {
   let t6 = o14 ? "d" : "-", n24 = [r10 & 256 ? "r" : "-", r10 & 128 ? "w" : "-", r10 & 64 ? "x" : "-", r10 & 32 ? "r" : "-", r10 & 16 ? "w" : "-", r10 & 8 ? "x" : "-", r10 & 4 ? "r" : "-", r10 & 2 ? "w" : "-", r10 & 1 ? "x" : "-"];
   return t6 + n24.join("");
 }
 var init_chunk_X2AJGDEF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js
 var S2, $9, A2, M4;
 var init_chunk_5QVNJEHU = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -14899,14 +14899,14 @@ var init_chunk_5QVNJEHU = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js
 var stat_BT5A227F_exports = {};
 __export(stat_BT5A227F_exports, {
   flagsForFuzzing: () => M4,
   statCommand: () => A2
 });
 var init_stat_BT5A227F = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js"() {
     init_chunk_5QVNJEHU();
     init_chunk_X2AJGDEF();
     init_chunk_HWKDQ44K();
@@ -14915,7 +14915,7 @@ var init_stat_BT5A227F = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js
 function u5(l7, c15, t6) {
   let s10 = typeof t6 == "boolean" ? { ignoreCase: t6 } : t6 ?? {}, e6 = c15;
   s10.stripQuotes && (e6.startsWith('"') && e6.endsWith('"') || e6.startsWith("'") && e6.endsWith("'")) && (e6 = e6.slice(1, -1));
@@ -14945,14 +14945,14 @@ function a7(l7, c15) {
 }
 var g6, o6;
 var init_chunk_J642UCRS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js"() {
     init_chunk_YNYSPYQ5();
     g6 = 2048;
     o6 = /* @__PURE__ */ new Map();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js
 function B3(n24, t6) {
   return n24.replace(/\$(&|\d+|<([^>]+)>)/g, (e6, i11, s10) => {
     if (i11 === "&") return t6[0];
@@ -15409,13 +15409,13 @@ function se2(n24) {
 }
 var q6;
 var init_chunk_VLGZJRPG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js"() {
     init_chunk_YNYSPYQ5();
     q6 = /* @__PURE__ */ new Map([["alpha", "a-zA-Z"], ["digit", "0-9"], ["alnum", "a-zA-Z0-9"], ["lower", "a-z"], ["upper", "A-Z"], ["xdigit", "0-9A-Fa-f"], ["space", " \\t\\n\\r\\f\\v"], ["blank", " \\t"], ["punct", "!-/:-@\\[-`{-~"], ["graph", "!-~"], ["print", " -~"], ["cntrl", "\\x00-\\x1F\\x7F"], ["ascii", "\\x00-\\x7F"], ["word", "a-zA-Z0-9_"]]);
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js
 async function K4(t6, s10, l7, f11, c15 = 0) {
   if (c15 >= J4) return;
   let p22 = l7.fs.resolvePath(l7.cwd, t6);
@@ -15503,7 +15503,7 @@ async function H5(t6, s10, l7 = [], f11 = [], c15 = [], p22, m26 = 0) {
 }
 var se3, j3, J4, ae3, fe2, ue2, ce2, pe2;
 var init_chunk_YS3AZT3J = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js"() {
     init_chunk_J642UCRS();
     init_chunk_VLGZJRPG();
     init_chunk_74CEPOFO();
@@ -15652,7 +15652,7 @@ var init_chunk_YS3AZT3J = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js
 var grep_3AIAIJVR_exports = {};
 __export(grep_3AIAIJVR_exports, {
   egrepCommand: () => fe2,
@@ -15663,7 +15663,7 @@ __export(grep_3AIAIJVR_exports, {
   grepCommand: () => j3
 });
 var init_grep_3AIAIJVR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js"() {
     init_chunk_YS3AZT3J();
     init_chunk_J642UCRS();
     init_chunk_VLGZJRPG();
@@ -15673,7 +15673,7 @@ var init_grep_3AIAIJVR = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js
 function a8(e6, n24) {
   if (Array.isArray(e6)) throw new TypeError(`${n24}: expected object, got array`);
   if (Object.getPrototypeOf(e6) !== null) throw new TypeError(`${n24}: expected null-prototype object, got prototypal object`);
@@ -15719,13 +15719,13 @@ function b9(...e6) {
 }
 var i7, p7;
 var init_chunk_7TSDKFEO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js"() {
     i7 = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
     p7 = /* @__PURE__ */ new Set([...i7, "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__", "hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString", "toString", "valueOf"]);
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js
 import { gunzipSync as ue3 } from "node:zlib";
 function H6() {
   let e6 = [];
@@ -16174,7 +16174,7 @@ async function be2(e6, t6, n24, s10, r10, l7, i11) {
 }
 var q7, M5, J5, ne5, re2, T5, k5, we2, Be, Ee2;
 var init_chunk_NYQYO467 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js"() {
     init_chunk_7TSDKFEO();
     init_chunk_VLGZJRPG();
     init_chunk_IPJHKYVM();
@@ -16513,14 +16513,14 @@ EXAMPLES:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js
 var rg_FOQSCCX3_exports = {};
 __export(rg_FOQSCCX3_exports, {
   flagsForFuzzing: () => Ee2,
   rgCommand: () => Be
 });
 var init_rg_FOQSCCX3 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js"() {
     init_chunk_NYQYO467();
     init_chunk_7TSDKFEO();
     init_chunk_VLGZJRPG();
@@ -16531,7 +16531,7 @@ var init_rg_FOQSCCX3 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js
 function H7(i11) {
   let e6 = "", t6 = 0, n24 = false;
   for (; t6 < i11.length; ) {
@@ -17177,7 +17177,7 @@ async function K6(i11, e6, t6, n24 = {}) {
 }
 var z4, de4, o7, _6, Z6, xe3, De2, qe2;
 var init_chunk_OL3S66CO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js"() {
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
     init_chunk_YNYSPYQ5();
@@ -17816,14 +17816,14 @@ Addresses:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js
 var sed_VFTTATXJ_exports = {};
 __export(sed_VFTTATXJ_exports, {
   flagsForFuzzing: () => qe2,
   sedCommand: () => De2
 });
 var init_sed_VFTTATXJ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js"() {
     init_chunk_OL3S66CO();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -17835,7 +17835,7 @@ var init_sed_VFTTATXJ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js
 function ie4(e6 = {}) {
   let { fieldSep: t6 = He2, maxIterations: n24 = Ue2, maxRecursionDepth: i11 = Be2, maxOutputSize: s10 = 0, fs: a15, cwd: o14, exec: l7, coverage: u12, requireDefenseContext: N16 } = e6;
   return { FS: " ", OFS: " ", ORS: `
@@ -18954,7 +18954,7 @@ function Ge2(e6) {
 }
 var Ue2, Be2, He2, U3, Re2, Ce3, q8, r8, _t2, ee4, p8, ne7, Wt2, Wn2, Vn2;
 var init_chunk_OARHFVLG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -19765,14 +19765,14 @@ var init_chunk_OARHFVLG = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js
 var awk2_POPGKRAI_exports = {};
 __export(awk2_POPGKRAI_exports, {
   awkCommand2: () => Wn2,
   flagsForFuzzing: () => Vn2
 });
 var init_awk2_POPGKRAI = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js"() {
     init_chunk_OARHFVLG();
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
@@ -19784,7 +19784,7 @@ var init_awk2_POPGKRAI = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js
 function O7(u12) {
   let r10 = u12.trim(), e6 = r10.match(/^([+-]?\d*\.?\d+)\s*([kmgtpeKMGTPE])?[iI]?[bB]?$/);
   if (!e6) {
@@ -19919,7 +19919,7 @@ function y11(u12) {
 }
 var A4, P6, q9, j6, U4;
 var init_chunk_KMEYNNUA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js"() {
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
     A4 = /* @__PURE__ */ new Map([["", 1], ["k", 1024], ["m", 1048576], ["g", 1073741824], ["t", 1099511627776], ["p", 1125899906842624], ["e", 1152921504606847e3]]);
@@ -20018,14 +20018,14 @@ Examples:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js
 var sort_DCNRDA7U_exports = {};
 __export(sort_DCNRDA7U_exports, {
   flagsForFuzzing: () => U4,
   sortCommand: () => j6
 });
 var init_sort_DCNRDA7U = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js"() {
     init_chunk_KMEYNNUA();
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
@@ -20033,10 +20033,10 @@ var init_sort_DCNRDA7U = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js
 var O8, w8, N5, P7;
 var init_chunk_WKFATFPP = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20066,14 +20066,14 @@ var init_chunk_WKFATFPP = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js
 var uniq_SUNANL47_exports = {};
 __export(uniq_SUNANL47_exports, {
   flagsForFuzzing: () => P7,
   uniqCommand: () => N5
 });
 var init_uniq_SUNANL47 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js"() {
     init_chunk_WKFATFPP();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -20082,10 +20082,10 @@ var init_uniq_SUNANL47 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js
 var x12, C7, I6;
 var init_chunk_Z7JVV2SM = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js"() {
     init_chunk_74CEPOFO();
     x12 = { name: "comm", summary: "compare two sorted files line by line", usage: "comm [OPTION]... FILE1 FILE2", options: ["-1             suppress column 1 (lines unique to FILE1)", "-2             suppress column 2 (lines unique to FILE2)", "-3             suppress column 3 (lines that appear in both files)", "    --help     display this help and exit"] };
     C7 = { name: "comm", async execute(p22, a15) {
@@ -20136,21 +20136,21 @@ Try 'comm --help' for more information.
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js
 var comm_5SLSESQG_exports = {};
 __export(comm_5SLSESQG_exports, {
   commCommand: () => C7,
   flagsForFuzzing: () => I6
 });
 var init_comm_5SLSESQG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js"() {
     init_chunk_Z7JVV2SM();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js
 function F5(t6) {
   let c15 = [], l7 = t6.split(",");
   for (let n24 of l7) if (n24.includes("-")) {
@@ -20172,7 +20172,7 @@ function L5(t6, c15) {
 }
 var w9, k7, C8;
 var init_chunk_SDNKECQQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js"() {
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
     w9 = { name: "cut", summary: "remove sections from each line of files", usage: "cut [OPTION]... [FILE]...", options: ["-c LIST              select only these characters", "-d DELIM             use DELIM instead of TAB for field delimiter", "-f LIST              select only these fields", "-s, --only-delimited  do not print lines without delimiters", "    --help           display this help and exit"] };
@@ -20229,14 +20229,14 @@ var init_chunk_SDNKECQQ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js
 var cut_OPC3VAGB_exports = {};
 __export(cut_OPC3VAGB_exports, {
   cutCommand: () => k7,
   flagsForFuzzing: () => C8
 });
 var init_cut_OPC3VAGB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js"() {
     init_chunk_SDNKECQQ();
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
@@ -20244,7 +20244,7 @@ var init_cut_OPC3VAGB = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js
 function y12(s10, i11) {
   if (s10.length === 0) return "";
   if (s10.length === 1) return s10[0];
@@ -20257,7 +20257,7 @@ function y12(s10, i11) {
 }
 var I7, F6, P8, T7;
 var init_chunk_JVPRLUMK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     I7 = { name: "paste", summary: "merge lines of files", usage: "paste [OPTION]... [FILE]...", description: ["Write lines consisting of the sequentially corresponding lines from", "each FILE, separated by TABs, to standard output.", "", "With no FILE, or when FILE is -, read standard input."], options: ["-d, --delimiters=LIST   reuse characters from LIST instead of TABs", "-s, --serial            paste one file at a time instead of in parallel", "    --help              display this help and exit"], examples: ["paste file1 file2       Merge file1 and file2 side by side", "paste -d, file1 file2   Use comma as delimiter", "paste -s file1          Paste all lines of file1 on one line", "paste - - < file        Paste pairs of lines from file"] };
@@ -20306,14 +20306,14 @@ var init_chunk_JVPRLUMK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js
 var paste_7N6AFSDS_exports = {};
 __export(paste_7N6AFSDS_exports, {
   flagsForFuzzing: () => T7,
   pasteCommand: () => P8
 });
 var init_paste_7N6AFSDS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js"() {
     init_chunk_JVPRLUMK();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20321,7 +20321,7 @@ var init_paste_7N6AFSDS = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js
 function S5(r10) {
   let o14 = "", e6 = 0;
   for (; e6 < r10.length; ) {
@@ -20352,7 +20352,7 @@ function S5(r10) {
 }
 var x13, b11, w10, q10, T8;
 var init_chunk_62RKD26F = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20422,14 +20422,14 @@ var init_chunk_62RKD26F = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js
 var tr_2HXZRDSW_exports = {};
 __export(tr_2HXZRDSW_exports, {
   flagsForFuzzing: () => T8,
   trCommand: () => q10
 });
 var init_tr_2HXZRDSW = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js"() {
     init_chunk_62RKD26F();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -20438,13 +20438,13 @@ var init_tr_2HXZRDSW = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js
 function d7(t6) {
   return Array.from(t6).reverse().join("");
 }
 var u7, v12, m10;
 var init_chunk_QCDB2VPH = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js"() {
     init_chunk_74CEPOFO();
     u7 = { name: "rev", summary: "reverse lines characterwise", usage: "rev [file ...]", description: "Copies the specified files to standard output, reversing the order of characters in every line. If no files are specified, standard input is read.", examples: ["echo 'hello' | rev     # Output: olleh", "rev file.txt           # Reverse each line in file"] };
     v12 = { name: "rev", execute: async (t6, s10) => {
@@ -20484,21 +20484,21 @@ var init_chunk_QCDB2VPH = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js
 var rev_XOSYPP45_exports = {};
 __export(rev_XOSYPP45_exports, {
   flagsForFuzzing: () => m10,
   rev: () => v12
 });
 var init_rev_XOSYPP45 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js"() {
     init_chunk_QCDB2VPH();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js
 function p9(r10, s10, i11) {
   let l7 = String(r10);
   switch (s10) {
@@ -20543,7 +20543,7 @@ function b12(r10, s10, i11) {
 }
 var h7, y13, x14;
 var init_chunk_F23WWYKW = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js"() {
     init_chunk_74CEPOFO();
     h7 = { name: "nl", summary: "number lines of files", usage: "nl [OPTION]... [FILE]...", description: "Write each FILE to standard output, with line numbers added. If no FILE is specified, standard input is read.", options: ["-b STYLE     Body numbering style: a (all), t (non-empty), n (none)", "-n FORMAT    Number format: ln (left), rn (right), rz (right zeros)", "-w WIDTH     Number width (default: 6)", "-s SEP       Separator after number (default: TAB)", "-v START     Starting line number (default: 1)", "-i INCR      Line number increment (default: 1)"], examples: ["nl file.txt              # Number non-empty lines", "nl -ba file.txt          # Number all lines", "nl -n rz -w 3 file.txt   # Right-justified with zeros", "nl -s ': ' file.txt      # Use ': ' as separator"] };
     y13 = { name: "nl", execute: async (r10, s10) => {
@@ -20628,21 +20628,21 @@ var init_chunk_F23WWYKW = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js
 var nl_U5YJDM32_exports = {};
 __export(nl_U5YJDM32_exports, {
   flagsForFuzzing: () => x14,
   nl: () => y13
 });
 var init_nl_U5YJDM32 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js"() {
     init_chunk_F23WWYKW();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js
 function g8(s10, r10, n24) {
   return n24 ? new TextEncoder().encode(s10).length : s10 === "	" ? 8 - r10 % 8 : s10 === "\b" ? -1 : 1;
 }
@@ -20667,7 +20667,7 @@ function b13(s10, r10) {
 }
 var m11, k8, x15;
 var init_chunk_D4J545R4 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js"() {
     init_chunk_74CEPOFO();
     m11 = { name: "fold", summary: "wrap each input line to fit in specified width", usage: "fold [OPTION]... [FILE]...", description: "Wrap input lines in each FILE, writing to standard output. If no FILE is specified, standard input is read.", options: ["-w WIDTH    Use WIDTH columns instead of 80", "-s          Break at spaces", "-b          Count bytes rather than columns"], examples: ["fold -w 40 file.txt           # Wrap at 40 columns", "fold -sw 40 file.txt          # Word wrap at 40 columns", "echo 'long line' | fold -w 5  # Force wrap at 5"] };
     k8 = { name: "fold", execute: async (s10, r10) => {
@@ -20731,21 +20731,21 @@ var init_chunk_D4J545R4 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js
 var fold_LDSORVYE_exports = {};
 __export(fold_LDSORVYE_exports, {
   flagsForFuzzing: () => x15,
   fold: () => k8
 });
 var init_fold_LDSORVYE = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js"() {
     init_chunk_D4J545R4();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js
 function p10(n24) {
   let i11 = n24.split(",").map((o14) => o14.trim()), t6 = [];
   for (let o14 of i11) {
@@ -20789,7 +20789,7 @@ function c7(n24, i11) {
 }
 var h8, m12, v13;
 var init_chunk_VJFXDYWH = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js"() {
     init_chunk_74CEPOFO();
     h8 = { name: "expand", summary: "convert tabs to spaces", usage: "expand [OPTION]... [FILE]...", description: "Convert TABs in each FILE to spaces, writing to standard output. If no FILE is specified, standard input is read.", options: ["-t N        Use N spaces per tab (default: 8)", "-t LIST     Use comma-separated list of tab stops", "-i          Only convert leading tabs on each line"], examples: ["expand file.txt             # Convert all tabs to 8 spaces", "expand -t 4 file.txt        # Use 4-space tabs", "expand -t 4,8,12 file.txt   # Custom tab stops"] };
     m12 = { name: "expand", execute: async (n24, i11) => {
@@ -20842,21 +20842,21 @@ var init_chunk_VJFXDYWH = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js
 var expand_DTNXU4LQ_exports = {};
 __export(expand_DTNXU4LQ_exports, {
   expand: () => m12,
   flagsForFuzzing: () => v13
 });
 var init_expand_DTNXU4LQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js"() {
     init_chunk_VJFXDYWH();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js
 function f7(s10) {
   let i11 = s10.split(",").map((l7) => l7.trim()), e6 = [];
   for (let l7 of i11) {
@@ -20910,7 +20910,7 @@ function C9(s10, i11) {
 }
 var k9, w11, F7;
 var init_chunk_PYSFUGCK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js"() {
     init_chunk_74CEPOFO();
     k9 = { name: "unexpand", summary: "convert spaces to tabs", usage: "unexpand [OPTION]... [FILE]...", description: "Convert blanks in each FILE to TABs, writing to standard output. If no FILE is specified, standard input is read.", options: ["-t N        Use N spaces per tab (default: 8)", "-t LIST     Use comma-separated list of tab stops", "-a          Convert all sequences of blanks (not just leading)"], examples: ["unexpand file.txt           # Convert leading spaces to tabs", "unexpand -a file.txt        # Convert all space sequences", "unexpand -t 4 file.txt      # Use 4-space tabs"] };
     w11 = { name: "unexpand", execute: async (s10, i11) => {
@@ -20963,21 +20963,21 @@ var init_chunk_PYSFUGCK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js
 var unexpand_RGTMIGZM_exports = {};
 __export(unexpand_RGTMIGZM_exports, {
   flagsForFuzzing: () => F7,
   unexpand: () => w11
 });
 var init_unexpand_RGTMIGZM = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js"() {
     init_chunk_PYSFUGCK();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js
 function p11(n24) {
   return n24 >= 32 && n24 <= 126 || n24 === 9;
 }
@@ -21015,7 +21015,7 @@ function g10(n24, s10) {
 }
 var m13, b14, N7;
 var init_chunk_VYOJP4TV = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js"() {
     init_chunk_74CEPOFO();
     m13 = { name: "strings", summary: "print the sequences of printable characters in files", usage: "strings [OPTION]... [FILE]...", description: "For each FILE, print the printable character sequences that are at least MIN characters long. If no FILE is specified, standard input is read.", options: ["-n MIN       Print sequences of at least MIN characters (default: 4)", "-t FORMAT    Print offset before each string (o=octal, x=hex, d=decimal)", "-a           Scan the entire file (default behavior)", "-e ENCODING  Select character encoding (s=7-bit, S=8-bit)"], examples: ["strings file.bin          # Extract strings (min 4 chars)", "strings -n 8 file.bin     # Extract strings (min 8 chars)", "strings -t x file.bin     # Show hex offset", "echo 'hello' | strings    # Read from stdin"] };
     b14 = { name: "strings", execute: async (n24, s10) => {
@@ -21092,21 +21092,21 @@ var init_chunk_VYOJP4TV = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js
 var strings_7PLOGTPD_exports = {};
 __export(strings_7PLOGTPD_exports, {
   flagsForFuzzing: () => N7,
   strings: () => b14
 });
 var init_strings_7PLOGTPD = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js"() {
     init_chunk_VYOJP4TV();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js
 function m14(s10) {
   let l7 = s10.match(/^(\d+)([KMGTPEZY]?)([B]?)$/i);
   if (!l7) return null;
@@ -21154,7 +21154,7 @@ function S6(s10, l7) {
 }
 var k10, p12, I8, $11;
 var init_chunk_MYE6AGBJ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js"() {
     init_chunk_74CEPOFO();
     k10 = { name: "split", summary: "split a file into pieces", usage: "split [OPTION]... [FILE [PREFIX]]", description: "Output pieces of FILE to PREFIXaa, PREFIXab, ...; default size is 1000 lines, and default PREFIX is 'x'.", options: ["-l N         Put N lines per output file", "-b SIZE      Put SIZE bytes per output file (K, M, G suffixes)", "-n CHUNKS    Split into CHUNKS equal-sized files", "-d           Use numeric suffixes (00, 01, ...) instead of alphabetic", "-a LENGTH    Use suffixes of length LENGTH (default: 2)", "--additional-suffix=SUFFIX  Append SUFFIX to file names"], examples: ["split -l 100 file.txt        # Split into 100-line chunks", "split -b 1M file.bin         # Split into 1MB chunks", "split -n 5 file.txt          # Split into 5 equal parts", "split -d file.txt part_      # part_00, part_01, ...", "split -a 3 -d file.txt x     # x000, x001, ..."] };
     p12 = 1e5;
@@ -21253,21 +21253,21 @@ var init_chunk_MYE6AGBJ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js
 var split_SITCSYCZ_exports = {};
 __export(split_SITCSYCZ_exports, {
   flagsForFuzzing: () => $11,
   split: () => I8
 });
 var init_split_SITCSYCZ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js"() {
     init_chunk_MYE6AGBJ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js
 function C11(t6, e6, l7) {
   return e6 ? l7 ? t6.split(e6) : t6.split(e6).filter((n24) => n24.length > 0) : l7 ? t6.split(/[ \t]/) : t6.split(/[ \t]+/).filter((n24) => n24.length > 0);
 }
@@ -21306,7 +21306,7 @@ function j7(t6, e6, l7) {
 }
 var v15, H8, M8, P9;
 var init_chunk_LWEGUNWT = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     v15 = { name: "column", summary: "columnate lists", usage: "column [OPTION]... [FILE]...", description: "Format input into multiple columns. By default, fills rows first. Use -t to create a table based on whitespace-delimited input.", options: ["-t           Create a table (determine columns from input)", "-s SEP       Input field delimiter (default: whitespace)", "-o SEP       Output field delimiter (default: two spaces)", "-c WIDTH     Output width for fill mode (default: 80)", "-n           Don't merge multiple adjacent delimiters"], examples: ["ls | column              # Fill columns with ls output", "cat data | column -t     # Format as table", "column -t -s ',' file    # Format CSV as table", "column -c 40 file        # Fill 40-char wide columns"] };
@@ -21352,14 +21352,14 @@ var init_chunk_LWEGUNWT = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js
 var column_WLPMMSTS_exports = {};
 __export(column_WLPMMSTS_exports, {
   column: () => M8,
   flagsForFuzzing: () => P9
 });
 var init_column_WLPMMSTS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js"() {
     init_chunk_LWEGUNWT();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -21367,7 +21367,7 @@ var init_column_WLPMMSTS = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js
 function N8(i11, s10) {
   return s10 ? i11.split(s10) : i11.split(/[ \t]+/).filter((n24) => n24.length > 0);
 }
@@ -21403,7 +21403,7 @@ function I10(i11) {
 }
 var v16, w12, U5;
 var init_chunk_A7ICOL4V = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js"() {
     init_chunk_74CEPOFO();
     v16 = { name: "join", summary: "join lines of two files on a common field", usage: "join [OPTION]... FILE1 FILE2", description: "For each pair of input lines with identical join fields, write a line to standard output. The default join field is the first, delimited by blanks.", options: ["-1 FIELD     Join on this FIELD of file 1 (default: 1)", "-2 FIELD     Join on this FIELD of file 2 (default: 1)", "-t CHAR      Use CHAR as input and output field separator", "-a FILENUM   Also print unpairable lines from file FILENUM (1 or 2)", "-v FILENUM   Like -a but only output unpairable lines", "-e STRING    Replace missing fields with STRING", "-o FORMAT    Output format (comma-separated list of FILENUM.FIELD)", "-i           Ignore case when comparing fields"], examples: ["join file1 file2               # Join on first field", "join -1 2 -2 1 file1 file2     # Join file1 col 2 with file2 col 1", "join -t ',' file1.csv file2.csv  # Join CSV files", "join -a 1 file1 file2          # Left outer join"] };
     w12 = { name: "join", execute: async (i11, s10) => {
@@ -21487,24 +21487,24 @@ var init_chunk_A7ICOL4V = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js
 var join_GG2LDHE5_exports = {};
 __export(join_GG2LDHE5_exports, {
   flagsForFuzzing: () => U5,
   join: () => w12
 });
 var init_join_GG2LDHE5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js"() {
     init_chunk_A7ICOL4V();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js
 var u8, m16, y16, w13;
 var init_chunk_55VFSPNA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     u8 = { name: "tee", summary: "read from stdin and write to stdout and files", usage: "tee [OPTION]... [FILE]...", options: ["-a, --append     append to the given FILEs, do not overwrite", "    --help       display this help and exit"] };
@@ -21527,14 +21527,14 @@ var init_chunk_55VFSPNA = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js
 var tee_O7VXZDCO_exports = {};
 __export(tee_O7VXZDCO_exports, {
   flagsForFuzzing: () => w13,
   teeCommand: () => y16
 });
 var init_tee_O7VXZDCO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js"() {
     init_chunk_55VFSPNA();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -21542,7 +21542,7 @@ var init_tee_O7VXZDCO = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js
 function k11(e6, t6) {
   switch (e6.type) {
     case "name": {
@@ -22103,7 +22103,7 @@ function ze3(e6, t6) {
 }
 var ye4, $e3, Re3, je3, Je3;
 var init_chunk_LPQPILI2 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_J642UCRS();
     init_chunk_IPJHKYVM();
@@ -22326,14 +22326,14 @@ var init_chunk_LPQPILI2 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js
 var find_TPUOAIUQ_exports = {};
 __export(find_TPUOAIUQ_exports, {
   findCommand: () => je3,
   flagsForFuzzing: () => Je3
 });
 var init_find_TPUOAIUQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js"() {
     init_chunk_LPQPILI2();
     init_chunk_X2AJGDEF();
     init_chunk_J642UCRS();
@@ -22345,10 +22345,10 @@ var init_find_TPUOAIUQ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js
 var p13, c8, h9;
 var init_chunk_ALLTKNUZ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js"() {
     init_chunk_74CEPOFO();
     p13 = { name: "basename", summary: "strip directory and suffix from filenames", usage: `basename NAME [SUFFIX]
 basename OPTION... NAME...`, options: ["-a, --multiple   support multiple arguments", "-s, --suffix=SUFFIX  remove a trailing SUFFIX", "    --help       display this help and exit"] };
@@ -22375,24 +22375,24 @@ basename OPTION... NAME...`, options: ["-a, --multiple   support multiple argume
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js
 var basename_AA2KJYZQ_exports = {};
 __export(basename_AA2KJYZQ_exports, {
   basenameCommand: () => c8,
   flagsForFuzzing: () => h9
 });
 var init_basename_AA2KJYZQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js"() {
     init_chunk_ALLTKNUZ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js
 var m17, p14, c9;
 var init_chunk_4Q4SM6WR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js"() {
     init_chunk_74CEPOFO();
     m17 = { name: "dirname", summary: "strip last component from file name", usage: "dirname [OPTION] NAME...", options: ["    --help       display this help and exit"] };
     p14 = { name: "dirname", async execute(t6, l7) {
@@ -22413,21 +22413,21 @@ var init_chunk_4Q4SM6WR = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js
 var dirname_LEMTZZFS_exports = {};
 __export(dirname_LEMTZZFS_exports, {
   dirnameCommand: () => p14,
   flagsForFuzzing: () => c9
 });
 var init_dirname_LEMTZZFS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js"() {
     init_chunk_4Q4SM6WR();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js
 async function T9(i11, o14, s10, f11, d15) {
   let e6 = { output: "", stderr: "", dirCount: 0, fileCount: 0 }, l7 = i11.fs.resolvePath(i11.cwd, o14);
   try {
@@ -22527,7 +22527,7 @@ async function w14(i11, o14, s10, f11, d15) {
 }
 var P10, b15, O9, L8;
 var init_chunk_XVDPCNWR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     P10 = { name: "tree", summary: "list contents of directories in a tree-like format", usage: "tree [OPTION]... [DIRECTORY]...", options: ["-a          include hidden files", "-d          list directories only", "-L LEVEL    limit depth of directory tree", "-f          print full path prefix for each file", "    --help  display this help and exit"] };
@@ -22551,14 +22551,14 @@ ${a15} director${a15 === 1 ? "y" : "ies"}`, f11.directoriesOnly || (e6 += `, ${n
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js
 var tree_LYXBS7DC_exports = {};
 __export(tree_LYXBS7DC_exports, {
   flagsForFuzzing: () => L8,
   treeCommand: () => O9
 });
 var init_tree_LYXBS7DC = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js"() {
     init_chunk_XVDPCNWR();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -22566,7 +22566,7 @@ var init_tree_LYXBS7DC = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js
 async function w15(a15, s10, n24, r10, l7) {
   let o14 = { output: "", totalSize: 0, stderr: "" };
   if (l7 > E7) return o14;
@@ -22637,7 +22637,7 @@ function D7(a15, s10) {
 }
 var x17, R4, _8, E7, v17;
 var init_chunk_RPNGRAAP = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     x17 = { name: "du", summary: "estimate file space usage", usage: "du [OPTION]... [FILE]...", options: ["-a          write counts for all files, not just directories", "-h          print sizes in human readable format", "-s          display only a total for each argument", "-c          produce a grand total", "--max-depth=N  print total for directory only if N or fewer levels deep", "    --help  display this help and exit"] };
@@ -22668,14 +22668,14 @@ var init_chunk_RPNGRAAP = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js
 var du_WO2ENHXQ_exports = {};
 __export(du_WO2ENHXQ_exports, {
   duCommand: () => _8,
   flagsForFuzzing: () => v17
 });
 var init_du_WO2ENHXQ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js"() {
     init_chunk_RPNGRAAP();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -22683,10 +22683,10 @@ var init_du_WO2ENHXQ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js
 var g12, w16, x18, E8, M9, N9;
 var init_chunk_NAERJDUW = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
     g12 = { name: "env", summary: "run a program in a modified environment", usage: "env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]", options: ["-i, --ignore-environment  start with an empty environment", "-u NAME, --unset=NAME     remove NAME from the environment", "    --help                display this help and exit"] };
@@ -22757,7 +22757,7 @@ var init_chunk_NAERJDUW = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js
 var env_5EPCWSXR_exports = {};
 __export(env_5EPCWSXR_exports, {
   envCommand: () => w16,
@@ -22766,7 +22766,7 @@ __export(env_5EPCWSXR_exports, {
   printenvFlagsForFuzzing: () => N9
 });
 var init_env_5EPCWSXR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js"() {
     init_chunk_NAERJDUW();
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
@@ -22774,10 +22774,10 @@ var init_env_5EPCWSXR = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js
 var d9, o8, m18, c10, p15, h10;
 var init_chunk_VOBGTVA6 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js"() {
     init_chunk_74CEPOFO();
     d9 = { name: "alias", summary: "define or display aliases", usage: "alias [name[=value] ...]", options: ["    --help display this help and exit"] };
     o8 = "BASH_ALIAS_";
@@ -22828,7 +22828,7 @@ var init_chunk_VOBGTVA6 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js
 var alias_JE7RI5QX_exports = {};
 __export(alias_JE7RI5QX_exports, {
   aliasCommand: () => m18,
@@ -22837,17 +22837,17 @@ __export(alias_JE7RI5QX_exports, {
   unaliasFlagsForFuzzing: () => h10
 });
 var init_alias_JE7RI5QX = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js"() {
     init_chunk_VOBGTVA6();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js
 var p16, h11, m19, u9;
 var init_chunk_NCNPKYJZ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js"() {
     init_chunk_74CEPOFO();
     p16 = { name: "history", summary: "display command history", usage: "history [n]", options: ["-c      clear the history list", "    --help display this help and exit"] };
     h11 = "BASH_HISTORY";
@@ -22874,24 +22874,24 @@ var init_chunk_NCNPKYJZ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js
 var history_J4QRNGRO_exports = {};
 __export(history_J4QRNGRO_exports, {
   flagsForFuzzing: () => u9,
   historyCommand: () => m19
 });
 var init_history_J4QRNGRO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js"() {
     init_chunk_NCNPKYJZ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js
 var $12, P11, H9;
 var init_chunk_TOMNU26N = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js"() {
     init_chunk_IPJHKYVM();
     init_chunk_74CEPOFO();
     $12 = { name: "xargs", summary: "build and execute command lines from standard input", usage: "xargs [OPTION]... [COMMAND [INITIAL-ARGS]]", options: ["-I REPLACE   replace occurrences of REPLACE with input", "-d DELIM     use DELIM as input delimiter (e.g., -d '\\n' for newline)", "-n NUM       use at most NUM arguments per command line", "-P NUM       run at most NUM processes at a time", "-0, --null   items are separated by null, not whitespace", "-t, --verbose  print commands before executing", "-r, --no-run-if-empty  do not run command if input is empty", "    --help   display this help and exit"] };
@@ -22961,14 +22961,14 @@ var init_chunk_TOMNU26N = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js
 var xargs_I6EZUCYF_exports = {};
 __export(xargs_I6EZUCYF_exports, {
   flagsForFuzzing: () => H9,
   xargsCommand: () => P11
 });
 var init_xargs_I6EZUCYF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js"() {
     init_chunk_TOMNU26N();
     init_chunk_IPJHKYVM();
     init_chunk_74CEPOFO();
@@ -22976,10 +22976,10 @@ var init_xargs_I6EZUCYF = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js
 var e4, t, s3, r9;
 var init_chunk_R6QSAL5T = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js"() {
     e4 = { name: "true", async execute() {
       return { stdout: "", stderr: "", exitCode: 0 };
     } };
@@ -22991,7 +22991,7 @@ var init_chunk_R6QSAL5T = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js
 var true_WHJNXCHG_exports = {};
 __export(true_WHJNXCHG_exports, {
   falseCommand: () => t,
@@ -23000,16 +23000,16 @@ __export(true_WHJNXCHG_exports, {
   trueCommand: () => e4
 });
 var init_true_WHJNXCHG = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js"() {
     init_chunk_R6QSAL5T();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js
 var t2, s4, o9;
 var init_chunk_LL3S3NLB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js"() {
     init_chunk_74CEPOFO();
     t2 = { name: "clear", summary: "clear the terminal screen", usage: "clear [OPTIONS]", options: ["    --help display this help and exit"] };
     s4 = { name: "clear", async execute(r10, c15) {
@@ -23019,21 +23019,21 @@ var init_chunk_LL3S3NLB = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js
 var clear_5CZ5X4YR_exports = {};
 __export(clear_5CZ5X4YR_exports, {
   clearCommand: () => s4,
   flagsForFuzzing: () => o9
 });
 var init_clear_5CZ5X4YR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js"() {
     init_chunk_LL3S3NLB();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js
 async function o10(t6, e6, n24, r10) {
   if (!r10.exec) return { stdout: "", stderr: `bash: internal error: exec function not available
 `, exitCode: 1 };
@@ -23051,7 +23051,7 @@ async function o10(t6, e6, n24, r10) {
 }
 var d10, y17, C12, b16, P12;
 var init_chunk_D6CWQ5DW = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
     d10 = { name: "bash", summary: "execute shell commands or scripts", usage: "bash [OPTIONS] [SCRIPT_FILE] [ARGUMENTS...]", options: ["-c COMMAND  execute COMMAND string", "    --help  display this help and exit"], notes: ["Without -c, reads and executes commands from SCRIPT_FILE.", "Arguments are passed as $1, $2, etc. to the script.", '$0 is set to the script name (or "bash" with -c).'] };
@@ -23092,7 +23092,7 @@ var init_chunk_D6CWQ5DW = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js
 var bash_IJWYRKFO_exports = {};
 __export(bash_IJWYRKFO_exports, {
   bashCommand: () => y17,
@@ -23101,7 +23101,7 @@ __export(bash_IJWYRKFO_exports, {
   shFlagsForFuzzing: () => P12
 });
 var init_bash_IJWYRKFO = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js"() {
     init_chunk_D6CWQ5DW();
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
@@ -23109,7 +23109,7 @@ var init_bash_IJWYRKFO = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js
 function W8(t6, r10, e6, n24, p22, o14, u12, c15, s10, f11) {
   switch (r10) {
     case "sort":
@@ -25316,7 +25316,7 @@ function Ne3(t6) {
 }
 var Ot3, Nt3, P13, H10, St3, bt3, Ct3, At3, Y5, ut3;
 var init_chunk_BBXLRYSX = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js"() {
     init_chunk_7TSDKFEO();
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
@@ -25713,7 +25713,7 @@ var init_chunk_BBXLRYSX = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js
 function A5(s10) {
   let r10 = [], t6 = 0, l7 = s10.length;
   for (; t6 < l7; ) {
@@ -25778,7 +25778,7 @@ ${i11.repeat(n24)}}`;
 }
 var W9, Y6, Z9;
 var init_chunk_YCFVLTST = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js"() {
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
     init_chunk_24IMIIXA();
@@ -25869,14 +25869,14 @@ var init_chunk_YCFVLTST = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js
 var jq_ODXZBPLY_exports = {};
 __export(jq_ODXZBPLY_exports, {
   flagsForFuzzing: () => Z9,
   jqCommand: () => Y6
 });
 var init_jq_ODXZBPLY = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js"() {
     init_chunk_YCFVLTST();
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
@@ -25892,7 +25892,7 @@ var init_jq_ODXZBPLY = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js
 async function p17(r10, o14, n24) {
   if (o14.length === 0 || o14.length === 1 && o14[0] === "-") return { ok: true, data: Uint8Array.from(r10.stdin, (e6) => e6.charCodeAt(0)) };
   let d15 = [];
@@ -25915,7 +25915,7 @@ async function p17(r10, o14, n24) {
 }
 var b17, m20, A6, F10;
 var init_chunk_QJ7O6ZN3 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     b17 = { name: "base64", summary: "base64 encode/decode data and print to standard output", usage: "base64 [OPTION]... [FILE]", options: ["-d, --decode    decode data", "-w, --wrap=COLS wrap encoded lines after COLS character (default 76, 0 to disable)", "    --help      display this help and exit"] };
@@ -25956,14 +25956,14 @@ var init_chunk_QJ7O6ZN3 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js
 var base64_4YMZCVJ5_exports = {};
 __export(base64_4YMZCVJ5_exports, {
   base64Command: () => A6,
   flagsForFuzzing: () => F10
 });
 var init_base64_4YMZCVJ5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js"() {
     init_chunk_QJ7O6ZN3();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -25971,10 +25971,10 @@ var init_base64_4YMZCVJ5 = __esm({
   }
 });
 
-// node_modules/diff/libesm/diff/base.js
+// ../../../node_modules/diff/libesm/diff/base.js
 var Diff;
 var init_base = __esm({
-  "node_modules/diff/libesm/diff/base.js"() {
+  "../../../node_modules/diff/libesm/diff/base.js"() {
     Diff = class {
       diff(oldStr, newStr, options = {}) {
         let callback;
@@ -26178,7 +26178,7 @@ var init_base = __esm({
   }
 });
 
-// node_modules/diff/libesm/diff/line.js
+// ../../../node_modules/diff/libesm/diff/line.js
 function diffLines(oldStr, newStr, options) {
   return lineDiff.diff(oldStr, newStr, options);
 }
@@ -26202,7 +26202,7 @@ function tokenize(value, options) {
 }
 var LineDiff, lineDiff;
 var init_line = __esm({
-  "node_modules/diff/libesm/diff/line.js"() {
+  "../../../node_modules/diff/libesm/diff/line.js"() {
     init_base();
     LineDiff = class extends Diff {
       constructor() {
@@ -26232,7 +26232,7 @@ var init_line = __esm({
   }
 });
 
-// node_modules/diff/libesm/patch/create.js
+// ../../../node_modules/diff/libesm/patch/create.js
 function structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options) {
   let optionsObj;
   if (!options) {
@@ -26408,7 +26408,7 @@ function splitLines(text) {
 }
 var INCLUDE_HEADERS;
 var init_create = __esm({
-  "node_modules/diff/libesm/patch/create.js"() {
+  "../../../node_modules/diff/libesm/patch/create.js"() {
     init_line();
     INCLUDE_HEADERS = {
       includeIndex: true,
@@ -26418,17 +26418,17 @@ var init_create = __esm({
   }
 });
 
-// node_modules/diff/libesm/index.js
+// ../../../node_modules/diff/libesm/index.js
 var init_libesm = __esm({
-  "node_modules/diff/libesm/index.js"() {
+  "../../../node_modules/diff/libesm/index.js"() {
     init_create();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js
 var y18, b18, $14, x19;
 var init_chunk_TLSUDHID = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     init_libesm();
@@ -26463,14 +26463,14 @@ var init_chunk_TLSUDHID = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js
 var diff_HJF2MPDN_exports = {};
 __export(diff_HJF2MPDN_exports, {
   diffCommand: () => $14,
   flagsForFuzzing: () => x19
 });
 var init_diff_HJF2MPDN = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js"() {
     init_chunk_TLSUDHID();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -26478,7 +26478,7 @@ var init_diff_HJF2MPDN = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js
 function s5(a15, i11 = 2) {
   return String(a15).padStart(i11, "0");
 }
@@ -26579,7 +26579,7 @@ function h12(a15) {
 }
 var g13, T10, S8, M11, D9;
 var init_chunk_D7MEQ3VN = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js"() {
     init_chunk_74CEPOFO();
     g13 = { name: "date", summary: "display the current time in the given FORMAT", usage: "date [OPTION]... [+FORMAT]", options: ["-d, --date=STRING   display time described by STRING", "-u, --utc           print Coordinated Universal Time (UTC)", "-I, --iso-8601      output date/time in ISO 8601 format", "-R, --rfc-email     output RFC 5322 date format", "    --help          display this help and exit"] };
     T10 = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -26614,21 +26614,21 @@ var init_chunk_D7MEQ3VN = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js
 var date_DD7FVA2V_exports = {};
 __export(date_DD7FVA2V_exports, {
   dateCommand: () => M11,
   flagsForFuzzing: () => D9
 });
 var init_date_DD7FVA2V = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js"() {
     init_chunk_D7MEQ3VN();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js
 function n22(e6) {
   let r10 = e6.match(/^(\d+\.?\d*)(s|m|h|d)?$/);
   if (!r10) return null;
@@ -26647,14 +26647,14 @@ function n22(e6) {
   }
 }
 var init_chunk_3ZUFRYJ4 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js"() {
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js
 var u10, m21, h13, b20;
 var init_chunk_GOV5EKKI = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js"() {
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
     init_chunk_74CEPOFO();
@@ -26690,14 +26690,14 @@ NUMBER may be a decimal number.`, options: ["    --help display this help and ex
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js
 var sleep_VZFPZFWA_exports = {};
 __export(sleep_VZFPZFWA_exports, {
   flagsForFuzzing: () => b20,
   sleepCommand: () => h13
 });
 var init_sleep_VZFPZFWA = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js"() {
     init_chunk_GOV5EKKI();
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
@@ -26707,10 +26707,10 @@ var init_sleep_VZFPZFWA = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js
 var v19, N10, D10;
 var init_chunk_YTNYSM6T = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js"() {
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
     init_chunk_IPJHKYVM();
@@ -26771,14 +26771,14 @@ DURATION is a number with optional suffix:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js
 var timeout_VRKMCG72_exports = {};
 __export(timeout_VRKMCG72_exports, {
   flagsForFuzzing: () => D10,
   timeoutCommand: () => N10
 });
 var init_timeout_VRKMCG72 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js"() {
     init_chunk_YTNYSM6T();
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
@@ -26789,14 +26789,14 @@ var init_timeout_VRKMCG72 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js
 function F11(r10) {
   let s10 = Math.floor(r10 / 3600), a15 = Math.floor(r10 % 3600 / 60), o14 = r10 % 60;
   return s10 > 0 ? `${s10}:${a15.toString().padStart(2, "0")}:${o14.toFixed(2).padStart(5, "0")}` : `${a15}:${o14.toFixed(2).padStart(5, "0")}`;
 }
 var v20, S9;
 var init_chunk_Z6LRHWXI = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_IPJHKYVM();
     init_chunk_OJDRYQWQ();
@@ -26859,14 +26859,14 @@ sys 0.00
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js
 var time_DEUO3QV2_exports = {};
 __export(time_DEUO3QV2_exports, {
   flagsForFuzzing: () => S9,
   timeCommand: () => v20
 });
 var init_time_DEUO3QV2 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js"() {
     init_chunk_Z6LRHWXI();
     init_chunk_CWQS3NFK();
     init_chunk_IPJHKYVM();
@@ -26876,10 +26876,10 @@ var init_time_DEUO3QV2 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js
 var F12, b21;
 var init_chunk_A7A2DBEE = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js"() {
     F12 = { name: "seq", async execute(r10) {
       let d15 = `
 `, f11 = false, s10 = [], t6 = 0;
@@ -26938,20 +26938,20 @@ var init_chunk_A7A2DBEE = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js
 var seq_RN5ZUASB_exports = {};
 __export(seq_RN5ZUASB_exports, {
   flagsForFuzzing: () => b21,
   seqCommand: () => F12
 });
 var init_seq_RN5ZUASB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js"() {
     init_chunk_A7A2DBEE();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js
 function x20(s10) {
   if (s10.length === 1) return s10[0];
   let r10 = 0;
@@ -27059,7 +27059,7 @@ function x20(s10) {
 }
 var S10, E9;
 var init_chunk_YFG2CMIF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js"() {
     init_chunk_YNYSPYQ5();
     init_chunk_3THT3N7L();
     S10 = { name: "expr", async execute(s10, r10) {
@@ -27078,14 +27078,14 @@ var init_chunk_YFG2CMIF = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js
 var expr_5T3UU5KE_exports = {};
 __export(expr_5T3UU5KE_exports, {
   exprCommand: () => S10,
   flagsForFuzzing: () => E9
 });
 var init_expr_5T3UU5KE = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js"() {
     init_chunk_YFG2CMIF();
     init_chunk_YNYSPYQ5();
     init_chunk_3THT3N7L();
@@ -27093,7 +27093,7 @@ var init_expr_5T3UU5KE = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js
 function L10(n24) {
   function h18(r10, u12) {
     return r10 << u12 | r10 >>> 32 - u12;
@@ -27182,30 +27182,30 @@ function S11(n24, h18, g17) {
 }
 var F13;
 var init_chunk_EIZGF4BS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js"() {
     init_chunk_74CEPOFO();
     F13 = /* @__PURE__ */ new Map([["sha1", "SHA-1"], ["sha256", "SHA-256"]]);
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js
 var s6, o11;
 var init_chunk_APT7OOP2 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js"() {
     init_chunk_EIZGF4BS();
     s6 = S11("md5sum", "md5", "compute MD5 message digest");
     o11 = { name: "md5sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js
 var md5sum_INMIK4DX_exports = {};
 __export(md5sum_INMIK4DX_exports, {
   flagsForFuzzing: () => o11,
   md5sumCommand: () => s6
 });
 var init_md5sum_INMIK4DX = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js"() {
     init_chunk_APT7OOP2();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27213,24 +27213,24 @@ var init_md5sum_INMIK4DX = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js
 var a9, m22;
 var init_chunk_XKQRETAK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js"() {
     init_chunk_EIZGF4BS();
     a9 = S11("sha1sum", "sha1", "compute SHA1 message digest");
     m22 = { name: "sha1sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js
 var sha1sum_VJPNLNU6_exports = {};
 __export(sha1sum_VJPNLNU6_exports, {
   flagsForFuzzing: () => m22,
   sha1sumCommand: () => a9
 });
 var init_sha1sum_VJPNLNU6 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js"() {
     init_chunk_XKQRETAK();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27238,24 +27238,24 @@ var init_sha1sum_VJPNLNU6 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js
 var a10, m23;
 var init_chunk_5V6VZH6T = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js"() {
     init_chunk_EIZGF4BS();
     a10 = S11("sha256sum", "sha256", "compute SHA256 message digest");
     m23 = { name: "sha256sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js
 var sha256sum_PI32XWXY_exports = {};
 __export(sha256sum_PI32XWXY_exports, {
   flagsForFuzzing: () => m23,
   sha256sumCommand: () => a10
 });
 var init_sha256sum_PI32XWXY = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js"() {
     init_chunk_5V6VZH6T();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27263,7 +27263,7 @@ var init_sha256sum_PI32XWXY = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js
 import { open as ct4 } from "node:fs/promises";
 function oe4(i11) {
   try {
@@ -27521,7 +27521,7 @@ async function Qt2(i11, e6) {
 }
 var Te3, ze4, fe4, Le3, je4, _e3, He3, We3, nt4, x21, D11, M12, J9, _9, L11, S12, st4, X8, Z10, Q6, $15, ft4, Ae3, ce6, mt4, Be3, d12, R5, h14, Ie4, Oe3, De4, b22, Je4, U7, ue6, Ve3, qe4, Ge3, E10, xe5, Nt4, ie5, H11, W10, ur2, xr2, dr2, Ye3, Ke3, et4, he6, we4, Ht3, Wt3, Vt2, qt, Gt3, Dr2, Mr;
 var init_chunk_CR5AFCPT = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js"() {
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
     Te3 = o3((ae9) => {
@@ -28796,23 +28796,23 @@ var init_chunk_CR5AFCPT = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js
 var file_ZIGAJ4YS_exports = {};
 __export(file_ZIGAJ4YS_exports, {
   fileCommand: () => Dr2,
   flagsForFuzzing: () => Mr
 });
 var init_file_ZIGAJ4YS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js"() {
     init_chunk_CR5AFCPT();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Event.js
+// ../../../node_modules/@mixmark-io/domino/lib/Event.js
 var require_Event = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Event.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Event.js"(exports, module) {
     "use strict";
     module.exports = Event;
     Event.CAPTURING_PHASE = 1;
@@ -28867,9 +28867,9 @@ var require_Event = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/UIEvent.js
+// ../../../node_modules/@mixmark-io/domino/lib/UIEvent.js
 var require_UIEvent = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/UIEvent.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/UIEvent.js"(exports, module) {
     "use strict";
     var Event = require_Event();
     module.exports = UIEvent;
@@ -28889,9 +28889,9 @@ var require_UIEvent = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/MouseEvent.js
+// ../../../node_modules/@mixmark-io/domino/lib/MouseEvent.js
 var require_MouseEvent = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/MouseEvent.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/MouseEvent.js"(exports, module) {
     "use strict";
     var UIEvent = require_UIEvent();
     module.exports = MouseEvent;
@@ -28950,9 +28950,9 @@ var require_MouseEvent = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/DOMException.js
+// ../../../node_modules/@mixmark-io/domino/lib/DOMException.js
 var require_DOMException = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/DOMException.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/DOMException.js"(exports, module) {
     "use strict";
     module.exports = DOMException;
     var INDEX_SIZE_ERR = 1;
@@ -29087,16 +29087,16 @@ var require_DOMException = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/config.js
+// ../../../node_modules/@mixmark-io/domino/lib/config.js
 var require_config = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/config.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/config.js"(exports) {
     exports.isApiWritable = !globalThis.__domino_frozen__;
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/utils.js
+// ../../../node_modules/@mixmark-io/domino/lib/utils.js
 var require_utils = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/utils.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/utils.js"(exports) {
     "use strict";
     var DOMException = require_DOMException();
     var ERR = DOMException;
@@ -29209,9 +29209,9 @@ var require_utils = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/EventTarget.js
+// ../../../node_modules/@mixmark-io/domino/lib/EventTarget.js
 var require_EventTarget = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/EventTarget.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/EventTarget.js"(exports, module) {
     "use strict";
     var Event = require_Event();
     var MouseEvent = require_MouseEvent();
@@ -29455,9 +29455,9 @@ var require_EventTarget = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/LinkedList.js
+// ../../../node_modules/@mixmark-io/domino/lib/LinkedList.js
 var require_LinkedList = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/LinkedList.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/LinkedList.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     var LinkedList = module.exports = {
@@ -29505,9 +29505,9 @@ var require_LinkedList = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeUtils.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeUtils.js
 var require_NodeUtils = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeUtils.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeUtils.js"(exports, module) {
     "use strict";
     module.exports = {
       // NOTE: The `serializeOne()` function used to live on the `Node.prototype`
@@ -29705,9 +29705,9 @@ var require_NodeUtils = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Node.js
+// ../../../node_modules/@mixmark-io/domino/lib/Node.js
 var require_Node = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Node.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Node.js"(exports, module) {
     "use strict";
     module.exports = Node;
     var EventTarget = require_EventTarget();
@@ -30305,9 +30305,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeList.es6.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeList.es6.js
 var require_NodeList_es6 = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeList.es6.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeList.es6.js"(exports, module) {
     "use strict";
     module.exports = class NodeList extends Array {
       constructor(a15) {
@@ -30325,9 +30325,9 @@ var require_NodeList_es6 = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeList.es5.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeList.es5.js
 var require_NodeList_es5 = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeList.es5.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeList.es5.js"(exports, module) {
     "use strict";
     function item(i11) {
       return this[i11] || null;
@@ -30341,9 +30341,9 @@ var require_NodeList_es5 = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeList.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeList.js
 var require_NodeList = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeList.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeList.js"(exports, module) {
     "use strict";
     var NodeList;
     try {
@@ -30355,9 +30355,9 @@ var require_NodeList = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/ContainerNode.js
+// ../../../node_modules/@mixmark-io/domino/lib/ContainerNode.js
 var require_ContainerNode = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/ContainerNode.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/ContainerNode.js"(exports, module) {
     "use strict";
     module.exports = ContainerNode;
     var Node = require_Node();
@@ -30426,9 +30426,9 @@ var require_ContainerNode = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/xmlnames.js
+// ../../../node_modules/@mixmark-io/domino/lib/xmlnames.js
 var require_xmlnames = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/xmlnames.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/xmlnames.js"(exports) {
     "use strict";
     exports.isValidName = isValidName;
     exports.isValidQName = isValidQName;
@@ -30470,9 +30470,9 @@ var require_xmlnames = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/attributes.js
+// ../../../node_modules/@mixmark-io/domino/lib/attributes.js
 var require_attributes = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/attributes.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/attributes.js"(exports) {
     "use strict";
     var utils = require_utils();
     exports.property = function(attr) {
@@ -30602,9 +30602,9 @@ var require_attributes = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/FilteredElementList.js
+// ../../../node_modules/@mixmark-io/domino/lib/FilteredElementList.js
 var require_FilteredElementList = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/FilteredElementList.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/FilteredElementList.js"(exports, module) {
     "use strict";
     module.exports = FilteredElementList;
     var Node = require_Node();
@@ -30674,9 +30674,9 @@ var require_FilteredElementList = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/DOMTokenList.js
+// ../../../node_modules/@mixmark-io/domino/lib/DOMTokenList.js
 var require_DOMTokenList = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/DOMTokenList.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/DOMTokenList.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     module.exports = DOMTokenList;
@@ -30840,9 +30840,9 @@ var require_DOMTokenList = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/select.js
+// ../../../node_modules/@mixmark-io/domino/lib/select.js
 var require_select = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/select.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/select.js"(exports, module) {
     "use strict";
     var window2 = Object.create(null, {
       location: { get: function() {
@@ -31574,9 +31574,9 @@ var require_select = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/ChildNode.js
+// ../../../node_modules/@mixmark-io/domino/lib/ChildNode.js
 var require_ChildNode = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/ChildNode.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/ChildNode.js"(exports, module) {
     "use strict";
     var Node = require_Node();
     var LinkedList = require_LinkedList();
@@ -31675,9 +31675,9 @@ var require_ChildNode = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js
+// ../../../node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js
 var require_NonDocumentTypeChildNode = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js"(exports, module) {
     "use strict";
     var Node = require_Node();
     var NonDocumentTypeChildNode = {
@@ -31702,9 +31702,9 @@ var require_NonDocumentTypeChildNode = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NamedNodeMap.js
+// ../../../node_modules/@mixmark-io/domino/lib/NamedNodeMap.js
 var require_NamedNodeMap = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NamedNodeMap.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NamedNodeMap.js"(exports, module) {
     "use strict";
     module.exports = NamedNodeMap;
     var utils = require_utils();
@@ -31742,9 +31742,9 @@ var require_NamedNodeMap = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Element.js
+// ../../../node_modules/@mixmark-io/domino/lib/Element.js
 var require_Element = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Element.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Element.js"(exports, module) {
     "use strict";
     module.exports = Element;
     var xml = require_xmlnames();
@@ -32778,9 +32778,9 @@ var require_Element = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Leaf.js
+// ../../../node_modules/@mixmark-io/domino/lib/Leaf.js
 var require_Leaf = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Leaf.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Leaf.js"(exports, module) {
     "use strict";
     module.exports = Leaf;
     var Node = require_Node();
@@ -32819,9 +32819,9 @@ var require_Leaf = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/CharacterData.js
+// ../../../node_modules/@mixmark-io/domino/lib/CharacterData.js
 var require_CharacterData = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/CharacterData.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/CharacterData.js"(exports, module) {
     "use strict";
     module.exports = CharacterData;
     var Leaf = require_Leaf();
@@ -32930,9 +32930,9 @@ var require_CharacterData = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Text.js
+// ../../../node_modules/@mixmark-io/domino/lib/Text.js
 var require_Text = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Text.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Text.js"(exports, module) {
     "use strict";
     module.exports = Text;
     var utils = require_utils();
@@ -33006,9 +33006,9 @@ var require_Text = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Comment.js
+// ../../../node_modules/@mixmark-io/domino/lib/Comment.js
 var require_Comment = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Comment.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Comment.js"(exports, module) {
     "use strict";
     module.exports = Comment;
     var Node = require_Node();
@@ -33053,9 +33053,9 @@ var require_Comment = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/DocumentFragment.js
+// ../../../node_modules/@mixmark-io/domino/lib/DocumentFragment.js
 var require_DocumentFragment = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/DocumentFragment.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/DocumentFragment.js"(exports, module) {
     "use strict";
     module.exports = DocumentFragment;
     var Node = require_Node();
@@ -33118,9 +33118,9 @@ var require_DocumentFragment = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js
+// ../../../node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js
 var require_ProcessingInstruction = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js"(exports, module) {
     "use strict";
     module.exports = ProcessingInstruction;
     var Node = require_Node();
@@ -33170,9 +33170,9 @@ var require_ProcessingInstruction = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeFilter.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeFilter.js
 var require_NodeFilter = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeFilter.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeFilter.js"(exports, module) {
     "use strict";
     var NodeFilter = {
       // Constants for acceptNode()
@@ -33203,9 +33203,9 @@ var require_NodeFilter = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeTraversal.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeTraversal.js
 var require_NodeTraversal = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeTraversal.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeTraversal.js"(exports, module) {
     "use strict";
     var NodeTraversal = module.exports = {
       nextSkippingChildren,
@@ -33270,9 +33270,9 @@ var require_NodeTraversal = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/TreeWalker.js
+// ../../../node_modules/@mixmark-io/domino/lib/TreeWalker.js
 var require_TreeWalker = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/TreeWalker.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/TreeWalker.js"(exports, module) {
     "use strict";
     module.exports = TreeWalker;
     var Node = require_Node();
@@ -33551,9 +33551,9 @@ var require_TreeWalker = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NodeIterator.js
+// ../../../node_modules/@mixmark-io/domino/lib/NodeIterator.js
 var require_NodeIterator = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NodeIterator.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NodeIterator.js"(exports, module) {
     "use strict";
     module.exports = NodeIterator;
     var NodeFilter = require_NodeFilter();
@@ -33723,9 +33723,9 @@ var require_NodeIterator = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/URL.js
+// ../../../node_modules/@mixmark-io/domino/lib/URL.js
 var require_URL = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/URL.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/URL.js"(exports, module) {
     "use strict";
     module.exports = URL2;
     function URL2(url) {
@@ -33889,9 +33889,9 @@ var require_URL = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/CustomEvent.js
+// ../../../node_modules/@mixmark-io/domino/lib/CustomEvent.js
 var require_CustomEvent = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/CustomEvent.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/CustomEvent.js"(exports, module) {
     "use strict";
     module.exports = CustomEvent;
     var Event = require_Event();
@@ -33904,9 +33904,9 @@ var require_CustomEvent = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/events.js
+// ../../../node_modules/@mixmark-io/domino/lib/events.js
 var require_events = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/events.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/events.js"(exports, module) {
     "use strict";
     module.exports = {
       Event: require_Event(),
@@ -33917,9 +33917,9 @@ var require_events = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/style_parser.js
+// ../../../node_modules/@mixmark-io/domino/lib/style_parser.js
 var require_style_parser = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/style_parser.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/style_parser.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.hyphenate = exports.parse = void 0;
@@ -33987,9 +33987,9 @@ var require_style_parser = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js
+// ../../../node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js
 var require_CSSStyleDeclaration = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js"(exports, module) {
     "use strict";
     var { parse } = require_style_parser();
     module.exports = function(elt) {
@@ -34171,9 +34171,9 @@ var require_CSSStyleDeclaration = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/URLUtils.js
+// ../../../node_modules/@mixmark-io/domino/lib/URLUtils.js
 var require_URLUtils = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/URLUtils.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/URLUtils.js"(exports, module) {
     "use strict";
     var URL2 = require_URL();
     module.exports = URLUtils;
@@ -34418,9 +34418,9 @@ var require_URLUtils = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/defineElement.js
+// ../../../node_modules/@mixmark-io/domino/lib/defineElement.js
 var require_defineElement = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/defineElement.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/defineElement.js"(exports, module) {
     "use strict";
     var attributes = require_attributes();
     var isApiWritable = require_config().isApiWritable;
@@ -34482,9 +34482,9 @@ var require_defineElement = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/htmlelts.js
+// ../../../node_modules/@mixmark-io/domino/lib/htmlelts.js
 var require_htmlelts = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/htmlelts.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/htmlelts.js"(exports) {
     "use strict";
     var Node = require_Node();
     var Element = require_Element();
@@ -36037,9 +36037,9 @@ var require_htmlelts = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/svg.js
+// ../../../node_modules/@mixmark-io/domino/lib/svg.js
 var require_svg = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/svg.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/svg.js"(exports) {
     "use strict";
     var Element = require_Element();
     var defineElement = require_defineElement();
@@ -36166,9 +36166,9 @@ var require_svg = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/MutationConstants.js
+// ../../../node_modules/@mixmark-io/domino/lib/MutationConstants.js
 var require_MutationConstants = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/MutationConstants.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/MutationConstants.js"(exports, module) {
     "use strict";
     module.exports = {
       VALUE: 1,
@@ -36187,9 +36187,9 @@ var require_MutationConstants = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Document.js
+// ../../../node_modules/@mixmark-io/domino/lib/Document.js
 var require_Document = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Document.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Document.js"(exports, module) {
     "use strict";
     module.exports = Document;
     var Node = require_Node();
@@ -36931,9 +36931,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/DocumentType.js
+// ../../../node_modules/@mixmark-io/domino/lib/DocumentType.js
 var require_DocumentType = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/DocumentType.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/DocumentType.js"(exports, module) {
     "use strict";
     module.exports = DocumentType;
     var Node = require_Node();
@@ -36970,9 +36970,9 @@ var require_DocumentType = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/HTMLParser.js
+// ../../../node_modules/@mixmark-io/domino/lib/HTMLParser.js
 var require_HTMLParser = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/HTMLParser.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/HTMLParser.js"(exports, module) {
     "use strict";
     module.exports = HTMLParser;
     var Document = require_Document();
@@ -45132,9 +45132,9 @@ var require_HTMLParser = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/DOMImplementation.js
+// ../../../node_modules/@mixmark-io/domino/lib/DOMImplementation.js
 var require_DOMImplementation = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/DOMImplementation.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/DOMImplementation.js"(exports, module) {
     "use strict";
     module.exports = DOMImplementation;
     var Document = require_Document();
@@ -45211,9 +45211,9 @@ var require_DOMImplementation = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Location.js
+// ../../../node_modules/@mixmark-io/domino/lib/Location.js
 var require_Location = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Location.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Location.js"(exports, module) {
     "use strict";
     var URL2 = require_URL();
     var URLUtils = require_URLUtils();
@@ -45251,9 +45251,9 @@ var require_Location = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/NavigatorID.js
+// ../../../node_modules/@mixmark-io/domino/lib/NavigatorID.js
 var require_NavigatorID = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/NavigatorID.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/NavigatorID.js"(exports, module) {
     "use strict";
     var NavigatorID = Object.create(null, {
       appCodeName: { value: "Mozilla" },
@@ -45273,9 +45273,9 @@ var require_NavigatorID = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/WindowTimers.js
+// ../../../node_modules/@mixmark-io/domino/lib/WindowTimers.js
 var require_WindowTimers = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/WindowTimers.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/WindowTimers.js"(exports, module) {
     "use strict";
     var WindowTimers = {
       setTimeout,
@@ -45287,9 +45287,9 @@ var require_WindowTimers = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/impl.js
+// ../../../node_modules/@mixmark-io/domino/lib/impl.js
 var require_impl = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/impl.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/impl.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     exports = module.exports = {
@@ -45318,9 +45318,9 @@ var require_impl = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/Window.js
+// ../../../node_modules/@mixmark-io/domino/lib/Window.js
 var require_Window = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/Window.js"(exports, module) {
+  "../../../node_modules/@mixmark-io/domino/lib/Window.js"(exports, module) {
     "use strict";
     var DOMImplementation = require_DOMImplementation();
     var EventTarget = require_EventTarget();
@@ -45386,9 +45386,9 @@ var require_Window = __commonJS({
   }
 });
 
-// node_modules/@mixmark-io/domino/lib/index.js
+// ../../../node_modules/@mixmark-io/domino/lib/index.js
 var require_lib = __commonJS({
-  "node_modules/@mixmark-io/domino/lib/index.js"(exports) {
+  "../../../node_modules/@mixmark-io/domino/lib/index.js"(exports) {
     "use strict";
     var DOMImplementation = require_DOMImplementation();
     var HTMLParser = require_HTMLParser();
@@ -45469,9 +45469,9 @@ var require_lib = __commonJS({
   }
 });
 
-// node_modules/turndown/lib/turndown.cjs.js
+// ../../../node_modules/turndown/lib/turndown.cjs.js
 var require_turndown_cjs = __commonJS({
-  "node_modules/turndown/lib/turndown.cjs.js"(exports, module) {
+  "../../../node_modules/turndown/lib/turndown.cjs.js"(exports, module) {
     "use strict";
     function extend(destination) {
       for (var i11 = 1; i11 < arguments.length; i11++) {
@@ -46114,10 +46114,10 @@ var require_turndown_cjs = __commonJS({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js
 var import_turndown, p18, g14, x22;
 var init_chunk_MDLLFABN = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js"() {
     init_chunk_74CEPOFO();
     import_turndown = __toESM(require_turndown_cjs(), 1);
     p18 = { name: "html-to-markdown", summary: "convert HTML to Markdown (BashEnv extension)", usage: "html-to-markdown [OPTION]... [FILE]", description: ["Convert HTML content to Markdown format using the turndown library.", "This is a non-standard BashEnv extension command, not available in regular bash.", "", "Read HTML from FILE or standard input and output Markdown to standard output.", "Commonly used with curl to convert web pages:", "  curl -s https://example.com | html-to-markdown", "", "Supported HTML elements:", "  - Headings (h1-h6) \u2192 # Markdown headings", "  - Paragraphs (p) \u2192 Plain text with blank lines", "  - Links (a) \u2192 [text](url)", "  - Images (img) \u2192 ![alt](src)", "  - Bold/Strong \u2192 **text**", "  - Italic/Em \u2192 _text_", "  - Code (code, pre) \u2192 `inline` or fenced blocks", "  - Lists (ul, ol, li) \u2192 - or 1. items", "  - Blockquotes \u2192 > quoted text", "  - Horizontal rules (hr) \u2192 ---"], options: ["-b, --bullet=CHAR     bullet character for unordered lists (-, +, or *)", "-c, --code=FENCE      fence style for code blocks (``` or ~~~)", "-r, --hr=STRING       string for horizontal rules (default: ---)", "    --heading-style=STYLE", "                      heading style: 'atx' for # headings (default),", "                      'setext' for underlined headings (h1/h2 only)", "    --help            display this help and exit"], examples: ["echo '<h1>Hello</h1><p>World</p>' | html-to-markdown", "html-to-markdown page.html", "curl -s https://example.com | html-to-markdown > page.md"] };
@@ -46165,21 +46165,21 @@ var init_chunk_MDLLFABN = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js
 var html_to_markdown_TFCECAGV_exports = {};
 __export(html_to_markdown_TFCECAGV_exports, {
   flagsForFuzzing: () => x22,
   htmlToMarkdownCommand: () => g14
 });
 var init_html_to_markdown_TFCECAGV = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js"() {
     init_chunk_MDLLFABN();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js
 function d13(n24) {
   let e6 = [], s10 = new Set(n24);
   e6.push(`Available commands:
@@ -46201,7 +46201,7 @@ function d13(n24) {
 }
 var c11, h15, p19;
 var init_chunk_MLXIYONF = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js"() {
     init_chunk_IPJHKYVM();
     c11 = /* @__PURE__ */ new Map([["File operations", ["ls", "cat", "head", "tail", "wc", "touch", "mkdir", "rm", "cp", "mv", "ln", "chmod", "stat", "readlink"]], ["Text processing", ["grep", "sed", "awk", "sort", "uniq", "cut", "tr", "tee", "diff"]], ["Search", ["find"]], ["Navigation & paths", ["pwd", "basename", "dirname", "tree", "du"]], ["Environment & shell", ["echo", "printf", "env", "printenv", "export", "alias", "unalias", "history", "clear", "true", "false", "bash", "sh"]], ["Data processing", ["xargs", "jq", "base64", "date"]], ["Network", ["curl", "html-to-markdown"]]]);
     h15 = { name: "help", async execute(n24, e6) {
@@ -46226,24 +46226,24 @@ Otherwise, lists all available commands.
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js
 var help_VVWX7SA5_exports = {};
 __export(help_VVWX7SA5_exports, {
   flagsForFuzzing: () => p19,
   helpCommand: () => h15
 });
 var init_help_VVWX7SA5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js"() {
     init_chunk_MLXIYONF();
     init_chunk_IPJHKYVM();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js
 var g15, w17, A8, v21;
 var init_chunk_A65PWWJC = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     g15 = { name: "which", summary: "locate a command", usage: "which [-as] program ...", options: ["-a         List all instances of executables found", "-s         No output, just return 0 if found, 1 if not", "--help     display this help and exit"] };
@@ -46271,14 +46271,14 @@ var init_chunk_A65PWWJC = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js
 var which_XZHEH76L_exports = {};
 __export(which_XZHEH76L_exports, {
   flagsForFuzzing: () => v21,
   whichCommand: () => A8
 });
 var init_which_XZHEH76L = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js"() {
     init_chunk_A65PWWJC();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -46286,7 +46286,7 @@ var init_which_XZHEH76L = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js
 async function c12(e6, t6) {
   if (e6.length > 0 && e6[0] !== "-") {
     let i11 = t6.fs.resolvePath(t6.cwd, e6[0]);
@@ -46313,78 +46313,78 @@ async function c12(e6, t6) {
 }
 var l5, a11;
 var init_chunk_MHTUABJP = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js"() {
     l5 = { name: "tac", execute: c12 };
     a11 = { name: "tac", flags: [], stdinType: "text", needsFiles: true };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js
 var tac_SJGXQ4T2_exports = {};
 __export(tac_SJGXQ4T2_exports, {
   flagsForFuzzing: () => a11,
   tac: () => l5
 });
 var init_tac_SJGXQ4T2 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js"() {
     init_chunk_MHTUABJP();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js
 async function t5(e6, n24) {
   return { stdout: `localhost
 `, stderr: "", exitCode: 0 };
 }
 var o12, s7;
 var init_chunk_4HHKTUW3 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js"() {
     o12 = { name: "hostname", execute: t5 };
     s7 = { name: "hostname", flags: [] };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js
 var hostname_BK6HG2DE_exports = {};
 __export(hostname_BK6HG2DE_exports, {
   flagsForFuzzing: () => s7,
   hostname: () => o12
 });
 var init_hostname_BK6HG2DE = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js"() {
     init_chunk_4HHKTUW3();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js
 async function e5(t6, o14) {
   return { stdout: `user
 `, stderr: "", exitCode: 0 };
 }
 var a12, n23;
 var init_chunk_HJQJAYMS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js"() {
     a12 = { name: "whoami", execute: e5 };
     n23 = { name: "whoami", flags: [] };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js
 var whoami_DGKU3D2X_exports = {};
 __export(whoami_DGKU3D2X_exports, {
   flagsForFuzzing: () => n23,
   whoami: () => a12
 });
 var init_whoami_DGKU3D2X = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js"() {
     init_chunk_HJQJAYMS();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js
 async function x23(a15, u12) {
   let o14 = "octal", n24 = [], i11 = [];
   for (let t6 = 0; t6 < a15.length; t6++) {
@@ -46435,26 +46435,26 @@ async function x23(a15, u12) {
 }
 var $16, v22;
 var init_chunk_PP6PSHAB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js"() {
     $16 = { name: "od", execute: x23 };
     v22 = { name: "od", flags: [{ flag: "-c", type: "boolean" }, { flag: "-A", type: "value", valueHint: "string" }, { flag: "-t", type: "value", valueHint: "string" }, { flag: "-N", type: "value", valueHint: "number" }], stdinType: "text", needsFiles: true };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js
 var od_VJEF2UR5_exports = {};
 __export(od_VJEF2UR5_exports, {
   flagsForFuzzing: () => v22,
   od: () => $16
 });
 var init_od_VJEF2UR5 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js"() {
     init_chunk_PP6PSHAB();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js
 import { constants as x24, gunzipSync as F14, gzipSync as S13 } from "node:zlib";
 function E11(e6) {
   return e6.best ? x24.Z_BEST_COMPRESSION : e6.level8 ? 8 : e6.level7 ? 7 : e6.level6 ? 6 : e6.level5 ? 5 : e6.level4 ? 4 : e6.level3 ? 3 : e6.level2 ? 2 : e6.fast ? x24.Z_BEST_SPEED : x24.Z_DEFAULT_COMPRESSION;
@@ -46678,7 +46678,7 @@ async function C14(e6, t6, r10) {
 }
 var O10, U8, D12, T11, G5, M13, Z11, R6, K9, j10;
 var init_chunk_LTZRCH7N = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     O10 = { name: "gzip", summary: "compress or expand files", usage: "gzip [OPTION]... [FILE]...", description: `Compress FILEs (by default, in-place).
@@ -46708,7 +46708,7 @@ When no FILE is given, or when FILE is -, read from standard input.`, options: [
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js
 var gzip_AQXSGOVS_exports = {};
 __export(gzip_AQXSGOVS_exports, {
   flagsForFuzzing: () => R6,
@@ -46719,7 +46719,7 @@ __export(gzip_AQXSGOVS_exports, {
   zcatFlagsForFuzzing: () => j10
 });
 var init_gzip_AQXSGOVS = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js"() {
     init_chunk_LTZRCH7N();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -46727,9 +46727,9 @@ var init_gzip_AQXSGOVS = __esm({
   }
 });
 
-// node_modules/amdefine/amdefine.js
+// ../../../node_modules/amdefine/amdefine.js
 var require_amdefine = __commonJS({
-  "node_modules/amdefine/amdefine.js"(exports, module) {
+  "../../../node_modules/amdefine/amdefine.js"(exports, module) {
     "use strict";
     function amdefine(module2, requireFn) {
       "use strict";
@@ -46918,9 +46918,9 @@ var require_amdefine = __commonJS({
   }
 });
 
-// node_modules/compressjs/main.js
+// ../../../node_modules/compressjs/main.js
 var require_main = __commonJS({
-  "node_modules/compressjs/main.js"(exports, module) {
+  "../../../node_modules/compressjs/main.js"(exports, module) {
     if (typeof define2 !== "function") {
       define2 = require_amdefine()(module);
     }
@@ -46956,7 +46956,7 @@ var require_main = __commonJS({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js
 function v24(e6, t6, n24, r10) {
   r10 && F15.encodeInto(r10, e6.subarray(t6, t6 + n24));
 }
@@ -48111,7 +48111,7 @@ async function pt4(e6, t6, n24) {
 }
 var import_compressjs, j11, ue7, fe5, Z12, Be4, Ne4, De5, $17, F15, de7, b24, X9, Le4, We4, Ye4, O11, W12, k13, M14, ye5, B5, N11, D13, L13, y20, xe6, ve5, Me4, ot4, Ft3, zt2;
 var init_chunk_ZXL7TQLN = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_5QMZ5MUS();
     init_chunk_YNYSPYQ5();
@@ -48193,14 +48193,14 @@ var init_chunk_ZXL7TQLN = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js
 var tar_232RCEFK_exports = {};
 __export(tar_232RCEFK_exports, {
   flagsForFuzzing: () => zt2,
   tarCommand: () => Ft3
 });
 var init_tar_232RCEFK = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js"() {
     init_chunk_ZXL7TQLN();
     init_chunk_X2AJGDEF();
     init_chunk_5QMZ5MUS();
@@ -48210,10 +48210,10 @@ var init_tar_232RCEFK = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js
 var xe7;
 var init_chunk_SYMJJMQ4 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js"() {
     init_chunk_DXB73IDG();
     xe7 = o3((de10, pe7) => {
       (function(oe7, R13) {
@@ -48821,7 +48821,7 @@ var init_chunk_SYMJJMQ4 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js
 function St4(s10, e6) {
   let t6 = [], n24 = e6.exec(s10);
   for (; n24; ) {
@@ -49774,7 +49774,7 @@ function Mh(s10) {
 }
 var Xi, O12, Ke5, Us, Pt3, Js, z9, Mt4, Je6, C16, We5, xt5, Ge5, Tr2, Qe5, He5, Cr2, nn, Jt3, an2, se9, cn2, ie7, Te5, re5, Oe5, tt5, Zt3, hn2, ke5, mn2, yn2, to, io, Nn2, os2, Tn2, mo, go, bo, Cn2, Pn2, vo, Mo, Vn3, xo, lt5, ut6, dt6, gs2, Xn2, Dn2, Xo, Qo, Ce5, ta, na, ei, si, ca, ua, pa2, ya, oi, va, Ta, Ia, Ss2, gi, bi, Si, Ra, Ua, Pi, Ha, za, Za, be6, el, tl, sl, il, cl, ji, Nt5, V11, _e5, x26, fl, ul, dl, hl, Be5, Sl2, El, Al2, Ps2, we6, $l, As2, Ei, T12, Kl, Fe4, Rl, Yl, Ul, Jl, Qi, Gl, tr2, bt4, kh, qh, Ja, Ph, hg, pg;
 var init_chunk_XORM457F = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js"() {
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
@@ -54259,14 +54259,14 @@ EXAMPLES:
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js
 var yq_MJMAR36V_exports = {};
 __export(yq_MJMAR36V_exports, {
   flagsForFuzzing: () => pg,
   yqCommand: () => hg
 });
 var init_yq_MJMAR36V = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js"() {
     init_chunk_XORM457F();
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
@@ -54282,7 +54282,7 @@ var init_yq_MJMAR36V = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js
 function j12() {
   return /* @__PURE__ */ Object.create(null);
 }
@@ -54369,28 +54369,28 @@ async function k14(e6, o14) {
 }
 var w18;
 var init_chunk_F55TLFGB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js"() {
     init_chunk_SYMJJMQ4();
     init_chunk_DXB73IDG();
     w18 = q3(xe7(), 1);
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js
 var xan_view_ECQUO7AJ_exports = {};
 __export(xan_view_ECQUO7AJ_exports, {
   cmdFlatten: () => W13,
   cmdView: () => k14
 });
 var init_xan_view_ECQUO7AJ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js"() {
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
     init_chunk_DXB73IDG();
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js
 function V12(e6) {
   let n24 = [], s10 = new q14(e6).tokenize(), r10 = 0, o14 = () => s10[r10] || { type: "eof", value: "", pos: 0 }, i11 = () => s10[r10++];
   for (; o14().type !== "eof"; ) {
@@ -55454,7 +55454,7 @@ async function Ve6(e6, n24) {
 }
 var q14, He6, Je7, R9, J11, U10, z10, nt6, me7, Be6, lt6, Ye5, ut7, fn2, dn2;
 var init_chunk_UNYNJIFU = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js"() {
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
@@ -56080,14 +56080,14 @@ Run 'xan --help' for usage.
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js
 var xan_BXDXYEIB_exports = {};
 __export(xan_BXDXYEIB_exports, {
   flagsForFuzzing: () => dn2,
   xanCommand: () => fn2
 });
 var init_xan_BXDXYEIB = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js"() {
     init_chunk_UNYNJIFU();
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
@@ -56104,9 +56104,9 @@ var init_xan_BXDXYEIB = __esm({
   }
 });
 
-// node_modules/sql.js/dist/sql-wasm.js
+// ../../../node_modules/sql.js/dist/sql-wasm.js
 var require_sql_wasm = __commonJS({
-  "node_modules/sql.js/dist/sql-wasm.js"(exports, module) {
+  "../../../node_modules/sql.js/dist/sql-wasm.js"(exports, module) {
     var initSqlJsPromise = void 0;
     var initSqlJs = function(moduleConfig) {
       if (initSqlJsPromise) {
@@ -58247,7 +58247,7 @@ var require_sql_wasm = __commonJS({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js
 import { randomBytes as z11 } from "node:crypto";
 import { existsSync as T13 } from "node:fs";
 import { dirname as X10, join as x27 } from "node:path";
@@ -58536,7 +58536,7 @@ async function ie9(e6, t6, r10) {
 }
 var import_sql, Z14, v25, ne10, $e7, ye7;
 var init_chunk_HWBSOZZR = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js"() {
     init_chunk_A5O5YHGN();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -58600,7 +58600,7 @@ var init_chunk_HWBSOZZR = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js
 var sqlite3_56UMWEY3_exports = {};
 __export(sqlite3_56UMWEY3_exports, {
   _internals: () => ne10,
@@ -58608,7 +58608,7 @@ __export(sqlite3_56UMWEY3_exports, {
   sqlite3Command: () => $e7
 });
 var init_sqlite3_56UMWEY3 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js"() {
     init_chunk_HWBSOZZR();
     init_chunk_A5O5YHGN();
     init_chunk_24IMIIXA();
@@ -58619,13 +58619,13 @@ var init_sqlite3_56UMWEY3 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js
 function _13() {
   return new r(E13.TOTAL);
 }
 var h16, a13, u11, s9, E13, S16, l6, R11, A11;
 var init_chunk_S4EYC6T6 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_A5O5YHGN();
     init_chunk_IPJHKYVM();
@@ -59109,7 +59109,7 @@ ${this.commandName}: execution timeout exceeded
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js
 var python3_SG3DOKBZ_exports = {};
 __export(python3_SG3DOKBZ_exports, {
   _resetExecutionQueue: () => ie10,
@@ -59228,7 +59228,7 @@ async function j13(r10, e6, t6, o14 = []) {
 }
 var U12, H13, I15, k16, N13, Y10, ce10;
 var init_python3_SG3DOKBZ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js"() {
     init_chunk_S4EYC6T6();
     init_chunk_XHM67O4N();
     init_chunk_CWQS3NFK();
@@ -59280,7 +59280,7 @@ var init_python3_SG3DOKBZ = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js
 var js_exec_4CW5N6RM_exports = {};
 __export(js_exec_4CW5N6RM_exports, {
   jsExecCommand: () => de9,
@@ -59378,7 +59378,7 @@ async function X11(t6, e6, r10, s10 = [], n24, u12, a15) {
 }
 var N14, H14, B9, _14, i10, w19, c13, o13, $19, de9, fe8;
 var init_js_exec_4CW5N6RM = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js"() {
     init_chunk_S4EYC6T6();
     init_chunk_XHM67O4N();
     init_chunk_CWQS3NFK();
@@ -59518,7 +59518,7 @@ ${_14}`, exitCode: 1 };
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js
 var curl_COE4TZE6_exports = {};
 __export(curl_COE4TZE6_exports, {
   curlCommand: () => q15
@@ -59751,7 +59751,7 @@ function H15(s10, t6, a15) {
 }
 var F18, q15;
 var init_curl_COE4TZE6 = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -59787,7 +59787,7 @@ var init_curl_COE4TZE6 = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js
 var flag_coverage_LMTH7T5F_exports = {};
 __export(flag_coverage_LMTH7T5F_exports, {
   emitFlagCoverage: () => Fa
@@ -59801,7 +59801,7 @@ function Fa(r10, o14, Dr4) {
 }
 var Er2, Br;
 var init_flag_coverage_LMTH7T5F = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js"() {
     init_chunk_ZXL7TQLN();
     init_chunk_XORM457F();
     init_chunk_UNYNJIFU();
@@ -59908,7 +59908,7 @@ var init_flag_coverage_LMTH7T5F = __esm({
   }
 });
 
-// node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js
+// ../../../node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js
 var expansion_ENLSRCXJ_exports = {};
 __export(expansion_ENLSRCXJ_exports, {
   escapeGlobChars: () => X2,
@@ -59925,7 +59925,7 @@ __export(expansion_ENLSRCXJ_exports, {
   isWordFullyQuoted: () => Al
 });
 var init_expansion_ENLSRCXJ = __esm({
-  "node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js"() {
+  "../../../node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js"() {
     init_chunk_FEIOJCZD();
     init_chunk_YNYSPYQ5();
     init_chunk_GFQRA5P5();
@@ -59936,7 +59936,7 @@ var init_expansion_ENLSRCXJ = __esm({
 // dist/src/shell/deeplake-shell.js
 import { createInterface } from "node:readline";
 
-// node_modules/just-bash/dist/bundle/index.js
+// ../../../node_modules/just-bash/dist/bundle/index.js
 init_chunk_FEIOJCZD();
 init_chunk_XHM67O4N();
 init_chunk_CWQS3NFK();
@@ -67556,11 +67556,11 @@ var DeeplakeFs = class _DeeplakeFs {
   }
 };
 
-// node_modules/yargs-parser/build/lib/index.js
+// ../../../node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
 import { normalize, resolve as resolve4 } from "path";
 
-// node_modules/yargs-parser/build/lib/string-utils.js
+// ../../../node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase(str) {
   const isCamelCase = str !== str.toLowerCase() && str !== str.toUpperCase();
   if (!isCamelCase) {
@@ -67614,7 +67614,7 @@ function looksLikeNumber(x28) {
   return /^[-]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x28);
 }
 
-// node_modules/yargs-parser/build/lib/tokenize-arg-string.js
+// ../../../node_modules/yargs-parser/build/lib/tokenize-arg-string.js
 function tokenizeArgString(argString) {
   if (Array.isArray(argString)) {
     return argString.map((e6) => typeof e6 !== "string" ? e6 + "" : e6);
@@ -67646,7 +67646,7 @@ function tokenizeArgString(argString) {
   return args;
 }
 
-// node_modules/yargs-parser/build/lib/yargs-parser-types.js
+// ../../../node_modules/yargs-parser/build/lib/yargs-parser-types.js
 var DefaultValuesForTypeKey;
 (function(DefaultValuesForTypeKey2) {
   DefaultValuesForTypeKey2["BOOLEAN"] = "boolean";
@@ -67655,7 +67655,7 @@ var DefaultValuesForTypeKey;
   DefaultValuesForTypeKey2["ARRAY"] = "array";
 })(DefaultValuesForTypeKey || (DefaultValuesForTypeKey = {}));
 
-// node_modules/yargs-parser/build/lib/yargs-parser.js
+// ../../../node_modules/yargs-parser/build/lib/yargs-parser.js
 var mixin;
 var YargsParser = class {
   constructor(_mixin) {
@@ -68495,7 +68495,7 @@ function stripQuotes(val) {
   return typeof val === "string" && (val[0] === "'" || val[0] === '"') && val[val.length - 1] === val[0] ? val.substring(1, val.length - 1) : val;
 }
 
-// node_modules/yargs-parser/build/lib/index.js
+// ../../../node_modules/yargs-parser/build/lib/index.js
 import { readFileSync as readFileSync2 } from "fs";
 import { createRequire } from "node:module";
 var _a3;

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -38,7 +38,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js
 function T1(n24) {
   let t6 = 0;
   return n24.includes("i") && (t6 |= y.CASE_INSENSITIVE), n24.includes("m") && (t6 |= y.MULTILINE), n24.includes("s") && (t6 |= y.DOTALL), t6;
@@ -51,7 +51,7 @@ function b1(n24, t6 = "") {
 }
 var g, u, a, b, w, O, R1, I, F, X, P, _, m, v, U, z, V, L, $, j, N, E, W, Y, M, c, q, D, K, Z, d, n1, r1, a1, o1, l1, h1, u1, c1, p1, f1, g1, A1, w1, E1, d1, O1, C1, m1, S1, x, H, Q, J, t1, e1, s1, y, B, i1;
 var init_chunk_YNYSPYQ5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-YNYSPYQ5.js"() {
     g = class n {
       static FOLD_CASE = 1;
       static LITERAL = 2;
@@ -2970,13 +2970,13 @@ var init_chunk_YNYSPYQ5 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js
 function v2(r10) {
   return r10 instanceof c2 || r10 instanceof a2 || r10 instanceof i;
 }
 var n15, c2, a2, i, u2, x2, d2, p, l, h, m2, b2, $2, f, C;
 var init_chunk_GFQRA5P5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-GFQRA5P5.js"() {
     n15 = class extends Error {
       stdout;
       stderr;
@@ -3090,7 +3090,7 @@ var init_chunk_GFQRA5P5 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js
 function $3(e6, t6) {
   for (; t6 < e6.length; ) {
     if (e6[t6] === "\\" && e6[t6 + 1] === `
@@ -8494,7 +8494,7 @@ async function Ve(e6, t6, r10 = false) {
 }
 var Re, w2, p2, pe, Bt, Dr, xr, _r, ve, Qe, Ze, Qt, Ue, Zt, Ut, Ht, G, Tr, Fr, zr, V2, Yr, dn, oe, yn, xi, as, Le, ys, kt;
 var init_chunk_FEIOJCZD = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-FEIOJCZD.js"() {
     init_chunk_YNYSPYQ5();
     init_chunk_GFQRA5P5();
     Re = ["=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "|=", "^="];
@@ -9839,7 +9839,7 @@ var init_chunk_FEIOJCZD = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js
 import * as i2 from "node:fs";
 import * as o from "node:path";
 function c3(t6) {
@@ -9873,14 +9873,14 @@ function v4(t6, e6) {
   return c3(p3(n24, e6));
 }
 var init_chunk_XHM67O4N = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-XHM67O4N.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js
 var r, e2, o2, a3;
 var init_chunk_CWQS3NFK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-CWQS3NFK.js"() {
     r = globalThis.SharedArrayBuffer;
     e2 = globalThis.Atomics;
     o2 = performance.now.bind(performance);
@@ -9888,10 +9888,10 @@ var init_chunk_CWQS3NFK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js
 var h3, e3, i3, j2, k2, l2, m4, n16, o3, p4, g2, q3, r2;
 var init_chunk_DXB73IDG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-DXB73IDG.js"() {
     h3 = Object.create;
     e3 = Object.defineProperty;
     i3 = Object.getOwnPropertyDescriptor;
@@ -9916,7 +9916,7 @@ var init_chunk_DXB73IDG = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js
 function v5() {
   let a15 = [{ prop: "Function", target: globalThis, violationType: "function_constructor", strategy: "throw", reason: "Function constructor allows arbitrary code execution" }, { prop: "eval", target: globalThis, violationType: "eval", strategy: "throw", reason: "eval() allows arbitrary code execution" }, { prop: "setTimeout", target: globalThis, violationType: "setTimeout", strategy: "throw", reason: "setTimeout with string argument allows code execution" }, { prop: "setInterval", target: globalThis, violationType: "setInterval", strategy: "throw", reason: "setInterval with string argument allows code execution" }, { prop: "setImmediate", target: globalThis, violationType: "setImmediate", strategy: "throw", reason: "setImmediate could be used to escape sandbox context" }, { prop: "env", target: process, violationType: "process_env", strategy: "throw", reason: "process.env could leak sensitive environment variables", allowedKeys: /* @__PURE__ */ new Set(["NODE_V8_COVERAGE", "NODE_DEBUG", "NODE_DEBUG_NATIVE", "NODE_COMPILE_CACHE", "WATCH_REPORT_DEPENDENCIES", "FORCE_COLOR", "DEBUG", "UNDICI_NO_FG", "JEST_WORKER_ID", "__MINIMATCH_TESTING_PLATFORM__", "LOG_TOKENS", "LOG_STREAM"]) }, { prop: "binding", target: process, violationType: "process_binding", strategy: "throw", reason: "process.binding provides access to native Node.js modules" }, { prop: "_linkedBinding", target: process, violationType: "process_binding", strategy: "throw", reason: "process._linkedBinding provides access to native Node.js modules" }, { prop: "dlopen", target: process, violationType: "process_dlopen", strategy: "throw", reason: "process.dlopen allows loading native addons" }, { prop: "getBuiltinModule", target: process, violationType: "process_get_builtin_module", strategy: "throw", reason: "process.getBuiltinModule allows loading native Node.js modules (fs, child_process, vm)" }, { prop: "exit", target: process, violationType: "process_exit", strategy: "throw", reason: "process.exit could terminate the interpreter" }, { prop: "abort", target: process, violationType: "process_exit", strategy: "throw", reason: "process.abort could crash the interpreter" }, { prop: "kill", target: process, violationType: "process_kill", strategy: "throw", reason: "process.kill could signal other processes" }, { prop: "setuid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setuid could escalate privileges" }, { prop: "setgid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setgid could escalate privileges" }, { prop: "seteuid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.seteuid could escalate effective user privileges" }, { prop: "setegid", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setegid could escalate effective group privileges" }, { prop: "initgroups", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.initgroups could modify supplementary group IDs" }, { prop: "setgroups", target: process, violationType: "process_setuid", strategy: "throw", reason: "process.setgroups could modify supplementary group IDs" }, { prop: "umask", target: process, violationType: "process_umask", strategy: "throw", reason: "process.umask could modify file creation permissions" }, { prop: "argv", target: process, violationType: "process_argv", strategy: "throw", reason: "process.argv may contain secrets in CLI arguments" }, { prop: "cwd", target: process, violationType: "process_chdir", strategy: "throw", reason: "process.cwd could disclose real host working directory path" }, { prop: "chdir", target: process, violationType: "process_chdir", strategy: "throw", reason: "process.chdir could confuse the interpreter's CWD tracking" }, { prop: "report", target: process, violationType: "process_report", strategy: "throw", reason: "process.report could disclose full environment, host paths, and system info" }, { prop: "loadEnvFile", target: process, violationType: "process_env", strategy: "throw", reason: "process.loadEnvFile could load env files bypassing env proxy" }, { prop: "setUncaughtExceptionCaptureCallback", target: process, violationType: "process_exception_handler", strategy: "throw", reason: "setUncaughtExceptionCaptureCallback could intercept security errors" }, { prop: "send", target: process, violationType: "process_send", strategy: "throw", reason: "process.send could communicate with parent process in IPC contexts" }, { prop: "channel", target: process, violationType: "process_channel", strategy: "throw", reason: "process.channel could access IPC channel to parent process" }, { prop: "cpuUsage", target: process, violationType: "process_timing", strategy: "throw", reason: "process.cpuUsage could enable timing side-channel attacks" }, { prop: "memoryUsage", target: process, violationType: "process_timing", strategy: "throw", reason: "process.memoryUsage could enable timing side-channel attacks" }, { prop: "hrtime", target: process, violationType: "process_timing", strategy: "throw", reason: "process.hrtime could enable timing side-channel attacks" }, { prop: "WeakRef", target: globalThis, violationType: "weak_ref", strategy: "throw", reason: "WeakRef could be used to leak references outside sandbox" }, { prop: "FinalizationRegistry", target: globalThis, violationType: "finalization_registry", strategy: "throw", reason: "FinalizationRegistry could be used to leak references outside sandbox" }, { prop: "Reflect", target: globalThis, violationType: "reflect", strategy: "freeze", reason: "Reflect provides introspection capabilities" }, { prop: "Proxy", target: globalThis, violationType: "proxy", strategy: "throw", reason: "Proxy allows intercepting and modifying object behavior" }, { prop: "WebAssembly", target: globalThis, violationType: "webassembly", strategy: "throw", reason: "WebAssembly allows executing arbitrary compiled code" }, { prop: "SharedArrayBuffer", target: globalThis, violationType: "shared_array_buffer", strategy: "throw", reason: "SharedArrayBuffer could enable side-channel communication or timing attacks" }, { prop: "Atomics", target: globalThis, violationType: "atomics", strategy: "throw", reason: "Atomics could enable side-channel communication or timing attacks" }, { prop: "performance", target: globalThis, violationType: "performance_timing", strategy: "throw", reason: "performance.now() provides sub-millisecond timing for side-channel attacks" }, { prop: "stdout", target: process, violationType: "process_stdout", strategy: "throw", reason: "process.stdout could bypass interpreter output to write to host stdout" }, { prop: "stderr", target: process, violationType: "process_stderr", strategy: "throw", reason: "process.stderr could bypass interpreter output to write to host stderr" }, { prop: "__defineGetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__defineGetter__ allows prototype pollution via getter injection" }, { prop: "__defineSetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__defineSetter__ allows prototype pollution via setter injection" }, { prop: "__lookupGetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__lookupGetter__ enables introspection for prototype pollution attacks" }, { prop: "__lookupSetter__", target: Object.prototype, violationType: "prototype_mutation", strategy: "throw", reason: "__lookupSetter__ enables introspection for prototype pollution attacks" }, { prop: "JSON", target: globalThis, violationType: "json_mutation", strategy: "freeze", reason: "Freeze JSON to prevent mutation of parsing/serialization" }, { prop: "Math", target: globalThis, violationType: "math_mutation", strategy: "freeze", reason: "Freeze Math to prevent mutation of math utilities" }];
   try {
@@ -9963,7 +9963,7 @@ function E2(a15) {
 }
 var f2, x4, k3, d3, u3, T2, m5, _2;
 var init_chunk_5QMZ5MUS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-5QMZ5MUS.js"() {
     init_chunk_DXB73IDG();
     f2 = typeof __BROWSER__ < "u" && __BROWSER__;
     x4 = null;
@@ -10513,13 +10513,13 @@ This is a defense-in-depth measure and indicates a bug in just-bash. Please repo
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js
 function l3(t6) {
   return typeof t6 != "function" ? t6 : _2.bindCurrentContext(t6);
 }
 var i4, r3, s, T3, b3, u4;
 var init_chunk_A5O5YHGN = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A5O5YHGN.js"() {
     init_chunk_5QMZ5MUS();
     i4 = globalThis.setTimeout.bind(globalThis);
     r3 = globalThis.clearTimeout.bind(globalThis);
@@ -10530,7 +10530,7 @@ var init_chunk_A5O5YHGN = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js
 function n17(e6) {
   return `'${e6.replace(/'/g, "'\\''")}'`;
 }
@@ -10538,11 +10538,11 @@ function r4(e6) {
   return e6.map(n17).join(" ");
 }
 var init_chunk_IPJHKYVM = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-IPJHKYVM.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js
 function r5(e6) {
   return Object.assign(/* @__PURE__ */ Object.create(null), Object.fromEntries(e6));
 }
@@ -10553,11 +10553,11 @@ function c4(...e6) {
   return Object.assign(/* @__PURE__ */ Object.create(null), ...e6);
 }
 var init_chunk_OJDRYQWQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-OJDRYQWQ.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js
 function a5(t6, e6, n24) {
   if (!t6 || _2.isInSandboxedContext()) return;
   let r10 = `${e6} ${n24} attempted outside defense context`;
@@ -10573,12 +10573,12 @@ function d4(t6, e6, n24, r10) {
   return t6 ? _2.bindCurrentContext(o14) : o14;
 }
 var init_chunk_24IMIIXA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-24IMIIXA.js"() {
     init_chunk_5QMZ5MUS();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js
 function a6(r10, s10, t6) {
   if (!r10) return r10;
   let e6 = r10.replace(/\n\s+at\s.*/g, "");
@@ -10591,20 +10591,20 @@ function i5(r10) {
   return a6(r10, true, true);
 }
 var init_chunk_3THT3N7L = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-3THT3N7L.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js
 function n20(e6) {
   return e6 instanceof Error ? e6.message : String(e6);
 }
 var init_chunk_44UOCSGV = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-44UOCSGV.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js
 function n21(r10) {
   let s10 = "", e6 = 0;
   for (; e6 < r10.length; ) if (r10[e6] === "\\") {
@@ -10699,7 +10699,7 @@ function n21(r10) {
 }
 var c5, f3;
 var init_chunk_GCTKCWKD = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-GCTKCWKD.js"() {
     c5 = { name: "echo", async execute(r10, s10) {
       let e6 = false, o14 = s10.xpgEcho ?? false, a15 = 0;
       for (; a15 < r10.length; ) {
@@ -10722,20 +10722,20 @@ var init_chunk_GCTKCWKD = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js
+// node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js
 var echo_O45JWWI2_exports = {};
 __export(echo_O45JWWI2_exports, {
   echoCommand: () => c5,
   flagsForFuzzing: () => f3
 });
 var init_echo_O45JWWI2 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/echo-O45JWWI2.js"() {
     init_chunk_GCTKCWKD();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js
 async function y3(t6, n24, s10) {
   let { cmdName: r10, allowStdinMarker: f11 = true, stopOnError: a15 = false, batchSize: u12 = 100 } = s10;
   if (n24.length === 0) return { files: [{ filename: "", content: t6.stdin }], stderr: "", exitCode: 0 };
@@ -10762,11 +10762,11 @@ async function b4(t6, n24, s10) {
   return r10.exitCode !== 0 ? { ok: false, error: { stdout: "", stderr: r10.stderr, exitCode: r10.exitCode } } : { ok: true, content: r10.files.map((a15) => a15.content).join("") };
 }
 var init_chunk_7L36YK2X = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-7L36YK2X.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js
 function s2(t6) {
   let e6 = `${t6.name} - ${t6.summary}
 
@@ -10815,11 +10815,11 @@ function r6(t6, e6) {
 `, exitCode: 1 };
 }
 var init_chunk_74CEPOFO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-74CEPOFO.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js
 function x6(a15, i11, d15) {
   let g17 = /* @__PURE__ */ new Map(), h18 = /* @__PURE__ */ new Map();
   for (let [t6, e6] of Object.entries(d15)) {
@@ -10876,12 +10876,12 @@ function x6(a15, i11, d15) {
   return { ok: true, result: { flags: s10, positional: b26 } };
 }
 var init_chunk_HWKDQ44K = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-HWKDQ44K.js"() {
     init_chunk_74CEPOFO();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js
 function y4(n24, s10) {
   let e6 = n24.split(`
 `), r10 = n24.endsWith(`
@@ -10892,7 +10892,7 @@ function y4(n24, s10) {
 }
 var b5, g3, F3, w4;
 var init_chunk_TXBZCHCQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-TXBZCHCQ.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -10914,14 +10914,14 @@ var init_chunk_TXBZCHCQ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js
+// node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js
 var cat_RDUMLXKC_exports = {};
 __export(cat_RDUMLXKC_exports, {
   catCommand: () => F3,
   flagsForFuzzing: () => w4
 });
 var init_cat_RDUMLXKC = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/cat-RDUMLXKC.js"() {
     init_chunk_TXBZCHCQ();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -10930,7 +10930,7 @@ var init_cat_RDUMLXKC = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js
 function i6(t6, l7, e6) {
   let c15 = t6;
   e6 >= 0 && c15.length > e6 && (c15 = c15.slice(0, e6));
@@ -11021,13 +11021,13 @@ function r7(t6) {
   return l7;
 }
 var init_chunk_EEXR5ZDP = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-EEXR5ZDP.js"() {
   }
 });
 
-// ../../../node_modules/sprintf-js/src/sprintf.js
+// node_modules/sprintf-js/src/sprintf.js
 var require_sprintf = __commonJS({
-  "../../../node_modules/sprintf-js/src/sprintf.js"(exports) {
+  "node_modules/sprintf-js/src/sprintf.js"(exports) {
     !(function() {
       "use strict";
       var re9 = {
@@ -11228,7 +11228,7 @@ var require_sprintf = __commonJS({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js
 function P3(t6, s10, r10) {
   let e6 = new Date(s10 * 1e3), a15 = "", n24 = 0;
   for (; n24 < t6.length; ) if (t6[n24] === "%" && n24 + 1 < t6.length) {
@@ -11707,7 +11707,7 @@ function ae2(t6) {
 }
 var import_sprintf_js, X3, de2, d5, he2;
 var init_chunk_T56QNPHK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-T56QNPHK.js"() {
     init_chunk_EEXR5ZDP();
     init_chunk_GFQRA5P5();
     init_chunk_44UOCSGV();
@@ -11766,14 +11766,14 @@ var init_chunk_T56QNPHK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js
+// node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js
 var printf_CX64KX2P_exports = {};
 __export(printf_CX64KX2P_exports, {
   flagsForFuzzing: () => he2,
   printfCommand: () => de2
 });
 var init_printf_CX64KX2P = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/printf-CX64KX2P.js"() {
     init_chunk_T56QNPHK();
     init_chunk_EEXR5ZDP();
     init_chunk_GFQRA5P5();
@@ -11783,10 +11783,10 @@ var init_printf_CX64KX2P = __esm({
   }
 });
 
-// ../../../node_modules/balanced-match/dist/esm/index.js
+// node_modules/balanced-match/dist/esm/index.js
 var balanced, maybeMatch, range;
 var init_esm = __esm({
-  "../../../node_modules/balanced-match/dist/esm/index.js"() {
+  "node_modules/balanced-match/dist/esm/index.js"() {
     balanced = (a15, b26, str) => {
       const ma3 = a15 instanceof RegExp ? maybeMatch(a15, str) : a15;
       const mb = b26 instanceof RegExp ? maybeMatch(b26, str) : b26;
@@ -11841,7 +11841,7 @@ var init_esm = __esm({
   }
 });
 
-// ../../../node_modules/brace-expansion/dist/esm/index.js
+// node_modules/brace-expansion/dist/esm/index.js
 function numeric(str) {
   return !isNaN(str) ? parseInt(str, 10) : str.charCodeAt(0);
 }
@@ -11986,7 +11986,7 @@ function expand_(str, max, isTop) {
 }
 var escSlash, escOpen, escClose, escComma, escPeriod, escSlashPattern, escOpenPattern, escClosePattern, escCommaPattern, escPeriodPattern, slashPattern, openPattern, closePattern, commaPattern, periodPattern, EXPANSION_MAX;
 var init_esm2 = __esm({
-  "../../../node_modules/brace-expansion/dist/esm/index.js"() {
+  "node_modules/brace-expansion/dist/esm/index.js"() {
     init_esm();
     escSlash = "\0SLASH" + Math.random() + "\0";
     escOpen = "\0OPEN" + Math.random() + "\0";
@@ -12007,10 +12007,10 @@ var init_esm2 = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/assert-valid-pattern.js
+// node_modules/minimatch/dist/esm/assert-valid-pattern.js
 var MAX_PATTERN_LENGTH, assertValidPattern;
 var init_assert_valid_pattern = __esm({
-  "../../../node_modules/minimatch/dist/esm/assert-valid-pattern.js"() {
+  "node_modules/minimatch/dist/esm/assert-valid-pattern.js"() {
     MAX_PATTERN_LENGTH = 1024 * 64;
     assertValidPattern = (pattern) => {
       if (typeof pattern !== "string") {
@@ -12023,10 +12023,10 @@ var init_assert_valid_pattern = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/brace-expressions.js
+// node_modules/minimatch/dist/esm/brace-expressions.js
 var posixClasses, braceEscape, regexpEscape, rangesToString, parseClass;
 var init_brace_expressions = __esm({
-  "../../../node_modules/minimatch/dist/esm/brace-expressions.js"() {
+  "node_modules/minimatch/dist/esm/brace-expressions.js"() {
     posixClasses = {
       "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true],
       "[:alpha:]": ["\\p{L}\\p{Nl}", true],
@@ -12137,10 +12137,10 @@ var init_brace_expressions = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/unescape.js
+// node_modules/minimatch/dist/esm/unescape.js
 var unescape;
 var init_unescape = __esm({
-  "../../../node_modules/minimatch/dist/esm/unescape.js"() {
+  "node_modules/minimatch/dist/esm/unescape.js"() {
     unescape = (s10, { windowsPathsNoEscape = false, magicalBraces = true } = {}) => {
       if (magicalBraces) {
         return windowsPathsNoEscape ? s10.replace(/\[([^/\\])\]/g, "$1") : s10.replace(/((?!\\).|^)\[([^/\\])\]/g, "$1$2").replace(/\\([^/])/g, "$1");
@@ -12150,10 +12150,10 @@ var init_unescape = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/ast.js
+// node_modules/minimatch/dist/esm/ast.js
 var _a, types, isExtglobType, isExtglobAST, adoptionMap, adoptionWithSpaceMap, adoptionAnyMap, usurpMap, startNoTraversal, startNoDot, addPatternStart, justDots, reSpecials, regExpEscape, qmark, star, starNoEmpty, ID, AST;
 var init_ast = __esm({
-  "../../../node_modules/minimatch/dist/esm/ast.js"() {
+  "node_modules/minimatch/dist/esm/ast.js"() {
     init_brace_expressions();
     init_unescape();
     types = /* @__PURE__ */ new Set(["!", "?", "+", "*", "@"]);
@@ -12800,10 +12800,10 @@ var init_ast = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/escape.js
+// node_modules/minimatch/dist/esm/escape.js
 var escape;
 var init_escape = __esm({
-  "../../../node_modules/minimatch/dist/esm/escape.js"() {
+  "node_modules/minimatch/dist/esm/escape.js"() {
     escape = (s10, { windowsPathsNoEscape = false, magicalBraces = false } = {}) => {
       if (magicalBraces) {
         return windowsPathsNoEscape ? s10.replace(/[?*()[\]{}]/g, "[$&]") : s10.replace(/[?*()[\]\\{}]/g, "\\$&");
@@ -12813,10 +12813,10 @@ var init_escape = __esm({
   }
 });
 
-// ../../../node_modules/minimatch/dist/esm/index.js
+// node_modules/minimatch/dist/esm/index.js
 var minimatch, starDotExtRE, starDotExtTest, starDotExtTestDot, starDotExtTestNocase, starDotExtTestNocaseDot, starDotStarRE, starDotStarTest, starDotStarTestDot, dotStarRE, dotStarTest, starRE, starTest, starTestDot, qmarksRE, qmarksTestNocase, qmarksTestNocaseDot, qmarksTestDot, qmarksTest, qmarksTestNoExt, qmarksTestNoExtDot, defaultPlatform, path, sep, GLOBSTAR, qmark2, star2, twoStarDot, twoStarNoDot, filter, ext, defaults, braceExpand, makeRe, match, globMagic, regExpEscape2, Minimatch;
 var init_esm3 = __esm({
-  "../../../node_modules/minimatch/dist/esm/index.js"() {
+  "node_modules/minimatch/dist/esm/index.js"() {
     init_esm2();
     init_assert_valid_pattern();
     init_ast();
@@ -13635,7 +13635,7 @@ var init_esm3 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js
 function M3(n24) {
   if (n24 < 1024) return String(n24);
   if (n24 < 1024 * 1024) {
@@ -13832,7 +13832,7 @@ async function O3(n24, s10, c15, w20, S18, y21, P21, b26 = false, g17 = false, v
 }
 var k4, G3, Z4, q5;
 var init_chunk_V7TAPXDL = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-V7TAPXDL.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     init_esm3();
@@ -13885,14 +13885,14 @@ var init_chunk_V7TAPXDL = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js
+// node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js
 var ls_KSXFZCWH_exports = {};
 __export(ls_KSXFZCWH_exports, {
   flagsForFuzzing: () => q5,
   lsCommand: () => Z4
 });
 var init_ls_KSXFZCWH = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/ls-KSXFZCWH.js"() {
     init_chunk_V7TAPXDL();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -13900,10 +13900,10 @@ var init_ls_KSXFZCWH = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js
 var p5, b6, h5;
 var init_chunk_MDDMCKUK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MDDMCKUK.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -13932,14 +13932,14 @@ var init_chunk_MDDMCKUK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js
+// node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js
 var mkdir_TDEMSB6C_exports = {};
 __export(mkdir_TDEMSB6C_exports, {
   flagsForFuzzing: () => h5,
   mkdirCommand: () => b6
 });
 var init_mkdir_TDEMSB6C = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/mkdir-TDEMSB6C.js"() {
     init_chunk_MDDMCKUK();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -13949,7 +13949,7 @@ var init_mkdir_TDEMSB6C = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js
 async function b7(t6, r10, e6, a15) {
   let o14 = "", s10 = "", n24 = t6.fs.resolvePath(t6.cwd, r10), i11 = await v7(t6, n24, r10, a15);
   if (o14 += i11.stdout, s10 += i11.stderr, i11.exitCode !== 0) return { stdout: o14, stderr: s10, exitCode: i11.exitCode };
@@ -13989,7 +13989,7 @@ function C3(t6) {
 }
 var x7, y5, D3, $4;
 var init_chunk_OCS6LSEM = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-OCS6LSEM.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     x7 = `Usage: rmdir [-pv] DIRECTORY...
@@ -14018,14 +14018,14 @@ Options:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js
+// node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js
 var rmdir_XTQXT7RK_exports = {};
 __export(rmdir_XTQXT7RK_exports, {
   flagsForFuzzing: () => $4,
   rmdirCommand: () => D3
 });
 var init_rmdir_XTQXT7RK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/rmdir-XTQXT7RK.js"() {
     init_chunk_OCS6LSEM();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14034,7 +14034,7 @@ var init_rmdir_XTQXT7RK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js
 function h6(s10) {
   let a15 = s10.replace(/\//g, "-"), r10 = new Date(a15);
   if (!Number.isNaN(r10.getTime())) return r10;
@@ -14052,7 +14052,7 @@ function h6(s10) {
 }
 var N3, b8;
 var init_chunk_OCLXQMOG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-OCLXQMOG.js"() {
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
     N3 = { name: "touch", async execute(s10, a15) {
@@ -14111,14 +14111,14 @@ var init_chunk_OCLXQMOG = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js
+// node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js
 var touch_DX2IJOQ4_exports = {};
 __export(touch_DX2IJOQ4_exports, {
   flagsForFuzzing: () => b8,
   touchCommand: () => N3
 });
 var init_touch_DX2IJOQ4 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/touch-DX2IJOQ4.js"() {
     init_chunk_OCLXQMOG();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14126,10 +14126,10 @@ var init_touch_DX2IJOQ4 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js
 var v8, E3, $5;
 var init_chunk_MIZPJHVH = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MIZPJHVH.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14165,14 +14165,14 @@ var init_chunk_MIZPJHVH = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js
+// node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js
 var rm_RTZG23RL_exports = {};
 __export(rm_RTZG23RL_exports, {
   flagsForFuzzing: () => $5,
   rmCommand: () => E3
 });
 var init_rm_RTZG23RL = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/rm-RTZG23RL.js"() {
     init_chunk_MIZPJHVH();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -14182,10 +14182,10 @@ var init_rm_RTZG23RL = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js
 var D4, E4, A, F4;
 var init_chunk_NUYSJFDK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-NUYSJFDK.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14235,14 +14235,14 @@ var init_chunk_NUYSJFDK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js
+// node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js
 var cp_XOYR4ABJ_exports = {};
 __export(cp_XOYR4ABJ_exports, {
   cpCommand: () => A,
   flagsForFuzzing: () => F4
 });
 var init_cp_XOYR4ABJ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/cp-XOYR4ABJ.js"() {
     init_chunk_NUYSJFDK();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14251,10 +14251,10 @@ var init_cp_XOYR4ABJ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js
 var C4, P4, O4, x8;
 var init_chunk_A4JSPFCI = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A4JSPFCI.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -14302,14 +14302,14 @@ var init_chunk_A4JSPFCI = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js
+// node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js
 var mv_Z6MORUFL_exports = {};
 __export(mv_Z6MORUFL_exports, {
   flagsForFuzzing: () => x8,
   mvCommand: () => O4
 });
 var init_mv_Z6MORUFL = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/mv-Z6MORUFL.js"() {
     init_chunk_A4JSPFCI();
     init_chunk_HWKDQ44K();
     init_chunk_44UOCSGV();
@@ -14318,10 +14318,10 @@ var init_mv_Z6MORUFL = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js
 var y6, v9, $6;
 var init_chunk_PBXLG62G = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-PBXLG62G.js"() {
     init_chunk_3THT3N7L();
     init_chunk_74CEPOFO();
     y6 = { name: "ln", summary: "make links between files", usage: "ln [OPTIONS] TARGET LINK_NAME", options: ["-s      create a symbolic link instead of a hard link", "-f      remove existing destination files", "-n      treat LINK_NAME as a normal file if it is a symbolic link to a directory", "-v      print name of each linked file", "    --help display this help and exit"] };
@@ -14374,14 +14374,14 @@ var init_chunk_PBXLG62G = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js
+// node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js
 var ln_4TRFBYAT_exports = {};
 __export(ln_4TRFBYAT_exports, {
   flagsForFuzzing: () => $6,
   lnCommand: () => v9
 });
 var init_ln_4TRFBYAT = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/ln-4TRFBYAT.js"() {
     init_chunk_PBXLG62G();
     init_chunk_3THT3N7L();
     init_chunk_74CEPOFO();
@@ -14389,7 +14389,7 @@ var init_ln_4TRFBYAT = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js
 async function y7(s10, a15, e6, c15, i11) {
   let n24 = "", l7 = await s10.fs.readdir(a15);
   for (let r10 of l7) {
@@ -14428,7 +14428,7 @@ function p6(s10, a15 = 420) {
 }
 var R3, C5, O5;
 var init_chunk_4GTNDTRF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-4GTNDTRF.js"() {
     init_chunk_74CEPOFO();
     R3 = { name: "chmod", summary: "change file mode bits", usage: "chmod [OPTIONS] MODE FILE...", options: ["-R      change files recursively", "-v      output a diagnostic for every file processed", "    --help display this help and exit"] };
     C5 = { name: "chmod", async execute(s10, a15) {
@@ -14488,24 +14488,24 @@ var init_chunk_4GTNDTRF = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js
+// node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js
 var chmod_SYMGL4JA_exports = {};
 __export(chmod_SYMGL4JA_exports, {
   chmodCommand: () => C5,
   flagsForFuzzing: () => O5
 });
 var init_chmod_SYMGL4JA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chmod-SYMGL4JA.js"() {
     init_chunk_4GTNDTRF();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js
 var o5, f4;
 var init_chunk_A4HU7SVR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A4HU7SVR.js"() {
     o5 = { name: "pwd", async execute(l7, a15) {
       let t6 = false;
       for (let e6 of l7) if (e6 === "-P") t6 = true;
@@ -14526,23 +14526,23 @@ var init_chunk_A4HU7SVR = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js
+// node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js
 var pwd_D4OZ7N27_exports = {};
 __export(pwd_D4OZ7N27_exports, {
   flagsForFuzzing: () => f4,
   pwdCommand: () => o5
 });
 var init_pwd_D4OZ7N27 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/pwd-D4OZ7N27.js"() {
     init_chunk_A4HU7SVR();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js
 var m6, y8, w5;
 var init_chunk_HJWBQKYG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-HJWBQKYG.js"() {
     init_chunk_74CEPOFO();
     m6 = { name: "readlink", summary: "print resolved symbolic links or canonical file names", usage: "readlink [OPTIONS] FILE...", options: ["-f      canonicalize by following every symlink in every component of the given name recursively", "    --help display this help and exit"] };
     y8 = { name: "readlink", async execute(a15, l7) {
@@ -14596,21 +14596,21 @@ var init_chunk_HJWBQKYG = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js
+// node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js
 var readlink_MI4GCHJF_exports = {};
 __export(readlink_MI4GCHJF_exports, {
   flagsForFuzzing: () => w5,
   readlinkCommand: () => y8
 });
 var init_readlink_MI4GCHJF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/readlink-MI4GCHJF.js"() {
     init_chunk_HJWBQKYG();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js
 function I3(t6, r10) {
   let i11 = 10, s10 = null, o14 = false, l7 = false, n24 = false, u12 = [];
   for (let f11 = 0; f11 < t6.length; f11++) {
@@ -14705,15 +14705,15 @@ function g4(t6, r10, i11, s10) {
 `;
 }
 var init_chunk_HDQ56CKY = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-HDQ56CKY.js"() {
     init_chunk_74CEPOFO();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js
 var f5, m7, g5;
 var init_chunk_64BAICW3 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-64BAICW3.js"() {
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
     f5 = { name: "head", summary: "output the first part of files", usage: "head [OPTION]... [FILE]...", options: ["-c, --bytes=NUM    print the first NUM bytes", "-n, --lines=NUM    print the first NUM lines (default 10)", "-q, --quiet        never print headers giving file names", "-v, --verbose      always print headers giving file names", "    --help         display this help and exit"] };
@@ -14728,14 +14728,14 @@ var init_chunk_64BAICW3 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js
+// node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js
 var head_HT2B6D2J_exports = {};
 __export(head_HT2B6D2J_exports, {
   flagsForFuzzing: () => g5,
   headCommand: () => m7
 });
 var init_head_HT2B6D2J = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/head-HT2B6D2J.js"() {
     init_chunk_64BAICW3();
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
@@ -14743,10 +14743,10 @@ var init_head_HT2B6D2J = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js
 var m8, d6, c6;
 var init_chunk_DCAAORBQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-DCAAORBQ.js"() {
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
     m8 = { name: "tail", summary: "output the last part of files", usage: "tail [OPTION]... [FILE]...", options: ["-c, --bytes=NUM    print the last NUM bytes", "-n, --lines=NUM    print the last NUM lines (default 10)", "-n +NUM            print starting from line NUM", "-q, --quiet        never print headers giving file names", "-v, --verbose      always print headers giving file names", "    --help         display this help and exit"] };
@@ -14761,14 +14761,14 @@ var init_chunk_DCAAORBQ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js
+// node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js
 var tail_S5ULNTJU_exports = {};
 __export(tail_S5ULNTJU_exports, {
   flagsForFuzzing: () => c6,
   tailCommand: () => d6
 });
 var init_tail_S5ULNTJU = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tail-S5ULNTJU.js"() {
     init_chunk_DCAAORBQ();
     init_chunk_HDQ56CKY();
     init_chunk_74CEPOFO();
@@ -14776,7 +14776,7 @@ var init_tail_S5ULNTJU = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js
 function C6(a15) {
   let c15 = a15.length, n24 = 0, o14 = 0, e6 = false;
   for (let s10 = 0; s10 < c15; s10++) {
@@ -14794,7 +14794,7 @@ function w6(a15, c15, n24, o14, e6, s10) {
 }
 var $8, H3, E5, I4;
 var init_chunk_GXVXFKBA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-GXVXFKBA.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -14829,14 +14829,14 @@ var init_chunk_GXVXFKBA = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js
+// node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js
 var wc_TQB3VNOX_exports = {};
 __export(wc_TQB3VNOX_exports, {
   flagsForFuzzing: () => I4,
   wcCommand: () => E5
 });
 var init_wc_TQB3VNOX = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/wc-TQB3VNOX.js"() {
     init_chunk_GXVXFKBA();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -14845,20 +14845,20 @@ var init_wc_TQB3VNOX = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js
 function x9(r10, o14) {
   let t6 = o14 ? "d" : "-", n24 = [r10 & 256 ? "r" : "-", r10 & 128 ? "w" : "-", r10 & 64 ? "x" : "-", r10 & 32 ? "r" : "-", r10 & 16 ? "w" : "-", r10 & 8 ? "x" : "-", r10 & 4 ? "r" : "-", r10 & 2 ? "w" : "-", r10 & 1 ? "x" : "-"];
   return t6 + n24.join("");
 }
 var init_chunk_X2AJGDEF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-X2AJGDEF.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js
 var S2, $9, A2, M4;
 var init_chunk_5QVNJEHU = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-5QVNJEHU.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -14899,14 +14899,14 @@ var init_chunk_5QVNJEHU = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js
+// node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js
 var stat_BT5A227F_exports = {};
 __export(stat_BT5A227F_exports, {
   flagsForFuzzing: () => M4,
   statCommand: () => A2
 });
 var init_stat_BT5A227F = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/stat-BT5A227F.js"() {
     init_chunk_5QVNJEHU();
     init_chunk_X2AJGDEF();
     init_chunk_HWKDQ44K();
@@ -14915,7 +14915,7 @@ var init_stat_BT5A227F = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js
 function u5(l7, c15, t6) {
   let s10 = typeof t6 == "boolean" ? { ignoreCase: t6 } : t6 ?? {}, e6 = c15;
   s10.stripQuotes && (e6.startsWith('"') && e6.endsWith('"') || e6.startsWith("'") && e6.endsWith("'")) && (e6 = e6.slice(1, -1));
@@ -14945,14 +14945,14 @@ function a7(l7, c15) {
 }
 var g6, o6;
 var init_chunk_J642UCRS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-J642UCRS.js"() {
     init_chunk_YNYSPYQ5();
     g6 = 2048;
     o6 = /* @__PURE__ */ new Map();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js
 function B3(n24, t6) {
   return n24.replace(/\$(&|\d+|<([^>]+)>)/g, (e6, i11, s10) => {
     if (i11 === "&") return t6[0];
@@ -15409,13 +15409,13 @@ function se2(n24) {
 }
 var q6;
 var init_chunk_VLGZJRPG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-VLGZJRPG.js"() {
     init_chunk_YNYSPYQ5();
     q6 = /* @__PURE__ */ new Map([["alpha", "a-zA-Z"], ["digit", "0-9"], ["alnum", "a-zA-Z0-9"], ["lower", "a-z"], ["upper", "A-Z"], ["xdigit", "0-9A-Fa-f"], ["space", " \\t\\n\\r\\f\\v"], ["blank", " \\t"], ["punct", "!-/:-@\\[-`{-~"], ["graph", "!-~"], ["print", " -~"], ["cntrl", "\\x00-\\x1F\\x7F"], ["ascii", "\\x00-\\x7F"], ["word", "a-zA-Z0-9_"]]);
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js
 async function K4(t6, s10, l7, f11, c15 = 0) {
   if (c15 >= J4) return;
   let p22 = l7.fs.resolvePath(l7.cwd, t6);
@@ -15503,7 +15503,7 @@ async function H5(t6, s10, l7 = [], f11 = [], c15 = [], p22, m26 = 0) {
 }
 var se3, j3, J4, ae3, fe2, ue2, ce2, pe2;
 var init_chunk_YS3AZT3J = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-YS3AZT3J.js"() {
     init_chunk_J642UCRS();
     init_chunk_VLGZJRPG();
     init_chunk_74CEPOFO();
@@ -15652,7 +15652,7 @@ var init_chunk_YS3AZT3J = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js
+// node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js
 var grep_3AIAIJVR_exports = {};
 __export(grep_3AIAIJVR_exports, {
   egrepCommand: () => fe2,
@@ -15663,7 +15663,7 @@ __export(grep_3AIAIJVR_exports, {
   grepCommand: () => j3
 });
 var init_grep_3AIAIJVR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/grep-3AIAIJVR.js"() {
     init_chunk_YS3AZT3J();
     init_chunk_J642UCRS();
     init_chunk_VLGZJRPG();
@@ -15673,7 +15673,7 @@ var init_grep_3AIAIJVR = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js
 function a8(e6, n24) {
   if (Array.isArray(e6)) throw new TypeError(`${n24}: expected object, got array`);
   if (Object.getPrototypeOf(e6) !== null) throw new TypeError(`${n24}: expected null-prototype object, got prototypal object`);
@@ -15719,13 +15719,13 @@ function b9(...e6) {
 }
 var i7, p7;
 var init_chunk_7TSDKFEO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-7TSDKFEO.js"() {
     i7 = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
     p7 = /* @__PURE__ */ new Set([...i7, "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__", "hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString", "toString", "valueOf"]);
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js
 import { gunzipSync as ue3 } from "node:zlib";
 function H6() {
   let e6 = [];
@@ -16174,7 +16174,7 @@ async function be2(e6, t6, n24, s10, r10, l7, i11) {
 }
 var q7, M5, J5, ne5, re2, T5, k5, we2, Be, Ee2;
 var init_chunk_NYQYO467 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-NYQYO467.js"() {
     init_chunk_7TSDKFEO();
     init_chunk_VLGZJRPG();
     init_chunk_IPJHKYVM();
@@ -16513,14 +16513,14 @@ EXAMPLES:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js
+// node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js
 var rg_FOQSCCX3_exports = {};
 __export(rg_FOQSCCX3_exports, {
   flagsForFuzzing: () => Ee2,
   rgCommand: () => Be
 });
 var init_rg_FOQSCCX3 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/rg-FOQSCCX3.js"() {
     init_chunk_NYQYO467();
     init_chunk_7TSDKFEO();
     init_chunk_VLGZJRPG();
@@ -16531,7 +16531,7 @@ var init_rg_FOQSCCX3 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js
 function H7(i11) {
   let e6 = "", t6 = 0, n24 = false;
   for (; t6 < i11.length; ) {
@@ -17177,7 +17177,7 @@ async function K6(i11, e6, t6, n24 = {}) {
 }
 var z4, de4, o7, _6, Z6, xe3, De2, qe2;
 var init_chunk_OL3S66CO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-OL3S66CO.js"() {
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
     init_chunk_YNYSPYQ5();
@@ -17816,14 +17816,14 @@ Addresses:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js
+// node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js
 var sed_VFTTATXJ_exports = {};
 __export(sed_VFTTATXJ_exports, {
   flagsForFuzzing: () => qe2,
   sedCommand: () => De2
 });
 var init_sed_VFTTATXJ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sed-VFTTATXJ.js"() {
     init_chunk_OL3S66CO();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -17835,7 +17835,7 @@ var init_sed_VFTTATXJ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js
 function ie4(e6 = {}) {
   let { fieldSep: t6 = He2, maxIterations: n24 = Ue2, maxRecursionDepth: i11 = Be2, maxOutputSize: s10 = 0, fs: a15, cwd: o14, exec: l7, coverage: u12, requireDefenseContext: N16 } = e6;
   return { FS: " ", OFS: " ", ORS: `
@@ -18954,7 +18954,7 @@ function Ge2(e6) {
 }
 var Ue2, Be2, He2, U3, Re2, Ce3, q8, r8, _t2, ee4, p8, ne7, Wt2, Wn2, Vn2;
 var init_chunk_OARHFVLG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-OARHFVLG.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -19765,14 +19765,14 @@ var init_chunk_OARHFVLG = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js
+// node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js
 var awk2_POPGKRAI_exports = {};
 __export(awk2_POPGKRAI_exports, {
   awkCommand2: () => Wn2,
   flagsForFuzzing: () => Vn2
 });
 var init_awk2_POPGKRAI = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/awk2-POPGKRAI.js"() {
     init_chunk_OARHFVLG();
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
@@ -19784,7 +19784,7 @@ var init_awk2_POPGKRAI = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js
 function O7(u12) {
   let r10 = u12.trim(), e6 = r10.match(/^([+-]?\d*\.?\d+)\s*([kmgtpeKMGTPE])?[iI]?[bB]?$/);
   if (!e6) {
@@ -19919,7 +19919,7 @@ function y11(u12) {
 }
 var A4, P6, q9, j6, U4;
 var init_chunk_KMEYNNUA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-KMEYNNUA.js"() {
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
     A4 = /* @__PURE__ */ new Map([["", 1], ["k", 1024], ["m", 1048576], ["g", 1073741824], ["t", 1099511627776], ["p", 1125899906842624], ["e", 1152921504606847e3]]);
@@ -20018,14 +20018,14 @@ Examples:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js
+// node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js
 var sort_DCNRDA7U_exports = {};
 __export(sort_DCNRDA7U_exports, {
   flagsForFuzzing: () => U4,
   sortCommand: () => j6
 });
 var init_sort_DCNRDA7U = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sort-DCNRDA7U.js"() {
     init_chunk_KMEYNNUA();
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
@@ -20033,10 +20033,10 @@ var init_sort_DCNRDA7U = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js
 var O8, w8, N5, P7;
 var init_chunk_WKFATFPP = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-WKFATFPP.js"() {
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20066,14 +20066,14 @@ var init_chunk_WKFATFPP = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js
+// node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js
 var uniq_SUNANL47_exports = {};
 __export(uniq_SUNANL47_exports, {
   flagsForFuzzing: () => P7,
   uniqCommand: () => N5
 });
 var init_uniq_SUNANL47 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/uniq-SUNANL47.js"() {
     init_chunk_WKFATFPP();
     init_chunk_7L36YK2X();
     init_chunk_HWKDQ44K();
@@ -20082,10 +20082,10 @@ var init_uniq_SUNANL47 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js
 var x12, C7, I6;
 var init_chunk_Z7JVV2SM = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-Z7JVV2SM.js"() {
     init_chunk_74CEPOFO();
     x12 = { name: "comm", summary: "compare two sorted files line by line", usage: "comm [OPTION]... FILE1 FILE2", options: ["-1             suppress column 1 (lines unique to FILE1)", "-2             suppress column 2 (lines unique to FILE2)", "-3             suppress column 3 (lines that appear in both files)", "    --help     display this help and exit"] };
     C7 = { name: "comm", async execute(p22, a15) {
@@ -20136,21 +20136,21 @@ Try 'comm --help' for more information.
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js
+// node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js
 var comm_5SLSESQG_exports = {};
 __export(comm_5SLSESQG_exports, {
   commCommand: () => C7,
   flagsForFuzzing: () => I6
 });
 var init_comm_5SLSESQG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/comm-5SLSESQG.js"() {
     init_chunk_Z7JVV2SM();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js
 function F5(t6) {
   let c15 = [], l7 = t6.split(",");
   for (let n24 of l7) if (n24.includes("-")) {
@@ -20172,7 +20172,7 @@ function L5(t6, c15) {
 }
 var w9, k7, C8;
 var init_chunk_SDNKECQQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-SDNKECQQ.js"() {
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
     w9 = { name: "cut", summary: "remove sections from each line of files", usage: "cut [OPTION]... [FILE]...", options: ["-c LIST              select only these characters", "-d DELIM             use DELIM instead of TAB for field delimiter", "-f LIST              select only these fields", "-s, --only-delimited  do not print lines without delimiters", "    --help           display this help and exit"] };
@@ -20229,14 +20229,14 @@ var init_chunk_SDNKECQQ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js
+// node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js
 var cut_OPC3VAGB_exports = {};
 __export(cut_OPC3VAGB_exports, {
   cutCommand: () => k7,
   flagsForFuzzing: () => C8
 });
 var init_cut_OPC3VAGB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/cut-OPC3VAGB.js"() {
     init_chunk_SDNKECQQ();
     init_chunk_7L36YK2X();
     init_chunk_74CEPOFO();
@@ -20244,7 +20244,7 @@ var init_cut_OPC3VAGB = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js
 function y12(s10, i11) {
   if (s10.length === 0) return "";
   if (s10.length === 1) return s10[0];
@@ -20257,7 +20257,7 @@ function y12(s10, i11) {
 }
 var I7, F6, P8, T7;
 var init_chunk_JVPRLUMK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-JVPRLUMK.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     I7 = { name: "paste", summary: "merge lines of files", usage: "paste [OPTION]... [FILE]...", description: ["Write lines consisting of the sequentially corresponding lines from", "each FILE, separated by TABs, to standard output.", "", "With no FILE, or when FILE is -, read standard input."], options: ["-d, --delimiters=LIST   reuse characters from LIST instead of TABs", "-s, --serial            paste one file at a time instead of in parallel", "    --help              display this help and exit"], examples: ["paste file1 file2       Merge file1 and file2 side by side", "paste -d, file1 file2   Use comma as delimiter", "paste -s file1          Paste all lines of file1 on one line", "paste - - < file        Paste pairs of lines from file"] };
@@ -20306,14 +20306,14 @@ var init_chunk_JVPRLUMK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js
+// node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js
 var paste_7N6AFSDS_exports = {};
 __export(paste_7N6AFSDS_exports, {
   flagsForFuzzing: () => T7,
   pasteCommand: () => P8
 });
 var init_paste_7N6AFSDS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/paste-7N6AFSDS.js"() {
     init_chunk_JVPRLUMK();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20321,7 +20321,7 @@ var init_paste_7N6AFSDS = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js
 function S5(r10) {
   let o14 = "", e6 = 0;
   for (; e6 < r10.length; ) {
@@ -20352,7 +20352,7 @@ function S5(r10) {
 }
 var x13, b11, w10, q10, T8;
 var init_chunk_62RKD26F = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-62RKD26F.js"() {
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -20422,14 +20422,14 @@ var init_chunk_62RKD26F = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js
+// node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js
 var tr_2HXZRDSW_exports = {};
 __export(tr_2HXZRDSW_exports, {
   flagsForFuzzing: () => T8,
   trCommand: () => q10
 });
 var init_tr_2HXZRDSW = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tr-2HXZRDSW.js"() {
     init_chunk_62RKD26F();
     init_chunk_3THT3N7L();
     init_chunk_HWKDQ44K();
@@ -20438,13 +20438,13 @@ var init_tr_2HXZRDSW = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js
 function d7(t6) {
   return Array.from(t6).reverse().join("");
 }
 var u7, v12, m10;
 var init_chunk_QCDB2VPH = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-QCDB2VPH.js"() {
     init_chunk_74CEPOFO();
     u7 = { name: "rev", summary: "reverse lines characterwise", usage: "rev [file ...]", description: "Copies the specified files to standard output, reversing the order of characters in every line. If no files are specified, standard input is read.", examples: ["echo 'hello' | rev     # Output: olleh", "rev file.txt           # Reverse each line in file"] };
     v12 = { name: "rev", execute: async (t6, s10) => {
@@ -20484,21 +20484,21 @@ var init_chunk_QCDB2VPH = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js
+// node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js
 var rev_XOSYPP45_exports = {};
 __export(rev_XOSYPP45_exports, {
   flagsForFuzzing: () => m10,
   rev: () => v12
 });
 var init_rev_XOSYPP45 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/rev-XOSYPP45.js"() {
     init_chunk_QCDB2VPH();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js
 function p9(r10, s10, i11) {
   let l7 = String(r10);
   switch (s10) {
@@ -20543,7 +20543,7 @@ function b12(r10, s10, i11) {
 }
 var h7, y13, x14;
 var init_chunk_F23WWYKW = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-F23WWYKW.js"() {
     init_chunk_74CEPOFO();
     h7 = { name: "nl", summary: "number lines of files", usage: "nl [OPTION]... [FILE]...", description: "Write each FILE to standard output, with line numbers added. If no FILE is specified, standard input is read.", options: ["-b STYLE     Body numbering style: a (all), t (non-empty), n (none)", "-n FORMAT    Number format: ln (left), rn (right), rz (right zeros)", "-w WIDTH     Number width (default: 6)", "-s SEP       Separator after number (default: TAB)", "-v START     Starting line number (default: 1)", "-i INCR      Line number increment (default: 1)"], examples: ["nl file.txt              # Number non-empty lines", "nl -ba file.txt          # Number all lines", "nl -n rz -w 3 file.txt   # Right-justified with zeros", "nl -s ': ' file.txt      # Use ': ' as separator"] };
     y13 = { name: "nl", execute: async (r10, s10) => {
@@ -20628,21 +20628,21 @@ var init_chunk_F23WWYKW = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js
+// node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js
 var nl_U5YJDM32_exports = {};
 __export(nl_U5YJDM32_exports, {
   flagsForFuzzing: () => x14,
   nl: () => y13
 });
 var init_nl_U5YJDM32 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/nl-U5YJDM32.js"() {
     init_chunk_F23WWYKW();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js
 function g8(s10, r10, n24) {
   return n24 ? new TextEncoder().encode(s10).length : s10 === "	" ? 8 - r10 % 8 : s10 === "\b" ? -1 : 1;
 }
@@ -20667,7 +20667,7 @@ function b13(s10, r10) {
 }
 var m11, k8, x15;
 var init_chunk_D4J545R4 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-D4J545R4.js"() {
     init_chunk_74CEPOFO();
     m11 = { name: "fold", summary: "wrap each input line to fit in specified width", usage: "fold [OPTION]... [FILE]...", description: "Wrap input lines in each FILE, writing to standard output. If no FILE is specified, standard input is read.", options: ["-w WIDTH    Use WIDTH columns instead of 80", "-s          Break at spaces", "-b          Count bytes rather than columns"], examples: ["fold -w 40 file.txt           # Wrap at 40 columns", "fold -sw 40 file.txt          # Word wrap at 40 columns", "echo 'long line' | fold -w 5  # Force wrap at 5"] };
     k8 = { name: "fold", execute: async (s10, r10) => {
@@ -20731,21 +20731,21 @@ var init_chunk_D4J545R4 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js
+// node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js
 var fold_LDSORVYE_exports = {};
 __export(fold_LDSORVYE_exports, {
   flagsForFuzzing: () => x15,
   fold: () => k8
 });
 var init_fold_LDSORVYE = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/fold-LDSORVYE.js"() {
     init_chunk_D4J545R4();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js
 function p10(n24) {
   let i11 = n24.split(",").map((o14) => o14.trim()), t6 = [];
   for (let o14 of i11) {
@@ -20789,7 +20789,7 @@ function c7(n24, i11) {
 }
 var h8, m12, v13;
 var init_chunk_VJFXDYWH = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-VJFXDYWH.js"() {
     init_chunk_74CEPOFO();
     h8 = { name: "expand", summary: "convert tabs to spaces", usage: "expand [OPTION]... [FILE]...", description: "Convert TABs in each FILE to spaces, writing to standard output. If no FILE is specified, standard input is read.", options: ["-t N        Use N spaces per tab (default: 8)", "-t LIST     Use comma-separated list of tab stops", "-i          Only convert leading tabs on each line"], examples: ["expand file.txt             # Convert all tabs to 8 spaces", "expand -t 4 file.txt        # Use 4-space tabs", "expand -t 4,8,12 file.txt   # Custom tab stops"] };
     m12 = { name: "expand", execute: async (n24, i11) => {
@@ -20842,21 +20842,21 @@ var init_chunk_VJFXDYWH = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js
+// node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js
 var expand_DTNXU4LQ_exports = {};
 __export(expand_DTNXU4LQ_exports, {
   expand: () => m12,
   flagsForFuzzing: () => v13
 });
 var init_expand_DTNXU4LQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/expand-DTNXU4LQ.js"() {
     init_chunk_VJFXDYWH();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js
 function f7(s10) {
   let i11 = s10.split(",").map((l7) => l7.trim()), e6 = [];
   for (let l7 of i11) {
@@ -20910,7 +20910,7 @@ function C9(s10, i11) {
 }
 var k9, w11, F7;
 var init_chunk_PYSFUGCK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-PYSFUGCK.js"() {
     init_chunk_74CEPOFO();
     k9 = { name: "unexpand", summary: "convert spaces to tabs", usage: "unexpand [OPTION]... [FILE]...", description: "Convert blanks in each FILE to TABs, writing to standard output. If no FILE is specified, standard input is read.", options: ["-t N        Use N spaces per tab (default: 8)", "-t LIST     Use comma-separated list of tab stops", "-a          Convert all sequences of blanks (not just leading)"], examples: ["unexpand file.txt           # Convert leading spaces to tabs", "unexpand -a file.txt        # Convert all space sequences", "unexpand -t 4 file.txt      # Use 4-space tabs"] };
     w11 = { name: "unexpand", execute: async (s10, i11) => {
@@ -20963,21 +20963,21 @@ var init_chunk_PYSFUGCK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js
+// node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js
 var unexpand_RGTMIGZM_exports = {};
 __export(unexpand_RGTMIGZM_exports, {
   flagsForFuzzing: () => F7,
   unexpand: () => w11
 });
 var init_unexpand_RGTMIGZM = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/unexpand-RGTMIGZM.js"() {
     init_chunk_PYSFUGCK();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js
 function p11(n24) {
   return n24 >= 32 && n24 <= 126 || n24 === 9;
 }
@@ -21015,7 +21015,7 @@ function g10(n24, s10) {
 }
 var m13, b14, N7;
 var init_chunk_VYOJP4TV = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-VYOJP4TV.js"() {
     init_chunk_74CEPOFO();
     m13 = { name: "strings", summary: "print the sequences of printable characters in files", usage: "strings [OPTION]... [FILE]...", description: "For each FILE, print the printable character sequences that are at least MIN characters long. If no FILE is specified, standard input is read.", options: ["-n MIN       Print sequences of at least MIN characters (default: 4)", "-t FORMAT    Print offset before each string (o=octal, x=hex, d=decimal)", "-a           Scan the entire file (default behavior)", "-e ENCODING  Select character encoding (s=7-bit, S=8-bit)"], examples: ["strings file.bin          # Extract strings (min 4 chars)", "strings -n 8 file.bin     # Extract strings (min 8 chars)", "strings -t x file.bin     # Show hex offset", "echo 'hello' | strings    # Read from stdin"] };
     b14 = { name: "strings", execute: async (n24, s10) => {
@@ -21092,21 +21092,21 @@ var init_chunk_VYOJP4TV = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js
+// node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js
 var strings_7PLOGTPD_exports = {};
 __export(strings_7PLOGTPD_exports, {
   flagsForFuzzing: () => N7,
   strings: () => b14
 });
 var init_strings_7PLOGTPD = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/strings-7PLOGTPD.js"() {
     init_chunk_VYOJP4TV();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js
 function m14(s10) {
   let l7 = s10.match(/^(\d+)([KMGTPEZY]?)([B]?)$/i);
   if (!l7) return null;
@@ -21154,7 +21154,7 @@ function S6(s10, l7) {
 }
 var k10, p12, I8, $11;
 var init_chunk_MYE6AGBJ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MYE6AGBJ.js"() {
     init_chunk_74CEPOFO();
     k10 = { name: "split", summary: "split a file into pieces", usage: "split [OPTION]... [FILE [PREFIX]]", description: "Output pieces of FILE to PREFIXaa, PREFIXab, ...; default size is 1000 lines, and default PREFIX is 'x'.", options: ["-l N         Put N lines per output file", "-b SIZE      Put SIZE bytes per output file (K, M, G suffixes)", "-n CHUNKS    Split into CHUNKS equal-sized files", "-d           Use numeric suffixes (00, 01, ...) instead of alphabetic", "-a LENGTH    Use suffixes of length LENGTH (default: 2)", "--additional-suffix=SUFFIX  Append SUFFIX to file names"], examples: ["split -l 100 file.txt        # Split into 100-line chunks", "split -b 1M file.bin         # Split into 1MB chunks", "split -n 5 file.txt          # Split into 5 equal parts", "split -d file.txt part_      # part_00, part_01, ...", "split -a 3 -d file.txt x     # x000, x001, ..."] };
     p12 = 1e5;
@@ -21253,21 +21253,21 @@ var init_chunk_MYE6AGBJ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js
+// node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js
 var split_SITCSYCZ_exports = {};
 __export(split_SITCSYCZ_exports, {
   flagsForFuzzing: () => $11,
   split: () => I8
 });
 var init_split_SITCSYCZ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/split-SITCSYCZ.js"() {
     init_chunk_MYE6AGBJ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js
 function C11(t6, e6, l7) {
   return e6 ? l7 ? t6.split(e6) : t6.split(e6).filter((n24) => n24.length > 0) : l7 ? t6.split(/[ \t]/) : t6.split(/[ \t]+/).filter((n24) => n24.length > 0);
 }
@@ -21306,7 +21306,7 @@ function j7(t6, e6, l7) {
 }
 var v15, H8, M8, P9;
 var init_chunk_LWEGUNWT = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-LWEGUNWT.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     v15 = { name: "column", summary: "columnate lists", usage: "column [OPTION]... [FILE]...", description: "Format input into multiple columns. By default, fills rows first. Use -t to create a table based on whitespace-delimited input.", options: ["-t           Create a table (determine columns from input)", "-s SEP       Input field delimiter (default: whitespace)", "-o SEP       Output field delimiter (default: two spaces)", "-c WIDTH     Output width for fill mode (default: 80)", "-n           Don't merge multiple adjacent delimiters"], examples: ["ls | column              # Fill columns with ls output", "cat data | column -t     # Format as table", "column -t -s ',' file    # Format CSV as table", "column -c 40 file        # Fill 40-char wide columns"] };
@@ -21352,14 +21352,14 @@ var init_chunk_LWEGUNWT = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js
+// node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js
 var column_WLPMMSTS_exports = {};
 __export(column_WLPMMSTS_exports, {
   column: () => M8,
   flagsForFuzzing: () => P9
 });
 var init_column_WLPMMSTS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/column-WLPMMSTS.js"() {
     init_chunk_LWEGUNWT();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -21367,7 +21367,7 @@ var init_column_WLPMMSTS = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js
 function N8(i11, s10) {
   return s10 ? i11.split(s10) : i11.split(/[ \t]+/).filter((n24) => n24.length > 0);
 }
@@ -21403,7 +21403,7 @@ function I10(i11) {
 }
 var v16, w12, U5;
 var init_chunk_A7ICOL4V = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A7ICOL4V.js"() {
     init_chunk_74CEPOFO();
     v16 = { name: "join", summary: "join lines of two files on a common field", usage: "join [OPTION]... FILE1 FILE2", description: "For each pair of input lines with identical join fields, write a line to standard output. The default join field is the first, delimited by blanks.", options: ["-1 FIELD     Join on this FIELD of file 1 (default: 1)", "-2 FIELD     Join on this FIELD of file 2 (default: 1)", "-t CHAR      Use CHAR as input and output field separator", "-a FILENUM   Also print unpairable lines from file FILENUM (1 or 2)", "-v FILENUM   Like -a but only output unpairable lines", "-e STRING    Replace missing fields with STRING", "-o FORMAT    Output format (comma-separated list of FILENUM.FIELD)", "-i           Ignore case when comparing fields"], examples: ["join file1 file2               # Join on first field", "join -1 2 -2 1 file1 file2     # Join file1 col 2 with file2 col 1", "join -t ',' file1.csv file2.csv  # Join CSV files", "join -a 1 file1 file2          # Left outer join"] };
     w12 = { name: "join", execute: async (i11, s10) => {
@@ -21487,24 +21487,24 @@ var init_chunk_A7ICOL4V = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js
+// node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js
 var join_GG2LDHE5_exports = {};
 __export(join_GG2LDHE5_exports, {
   flagsForFuzzing: () => U5,
   join: () => w12
 });
 var init_join_GG2LDHE5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/join-GG2LDHE5.js"() {
     init_chunk_A7ICOL4V();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js
 var u8, m16, y16, w13;
 var init_chunk_55VFSPNA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-55VFSPNA.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     u8 = { name: "tee", summary: "read from stdin and write to stdout and files", usage: "tee [OPTION]... [FILE]...", options: ["-a, --append     append to the given FILEs, do not overwrite", "    --help       display this help and exit"] };
@@ -21527,14 +21527,14 @@ var init_chunk_55VFSPNA = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js
+// node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js
 var tee_O7VXZDCO_exports = {};
 __export(tee_O7VXZDCO_exports, {
   flagsForFuzzing: () => w13,
   teeCommand: () => y16
 });
 var init_tee_O7VXZDCO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tee-O7VXZDCO.js"() {
     init_chunk_55VFSPNA();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -21542,7 +21542,7 @@ var init_tee_O7VXZDCO = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js
 function k11(e6, t6) {
   switch (e6.type) {
     case "name": {
@@ -22103,7 +22103,7 @@ function ze3(e6, t6) {
 }
 var ye4, $e3, Re3, je3, Je3;
 var init_chunk_LPQPILI2 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-LPQPILI2.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_J642UCRS();
     init_chunk_IPJHKYVM();
@@ -22326,14 +22326,14 @@ var init_chunk_LPQPILI2 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js
+// node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js
 var find_TPUOAIUQ_exports = {};
 __export(find_TPUOAIUQ_exports, {
   findCommand: () => je3,
   flagsForFuzzing: () => Je3
 });
 var init_find_TPUOAIUQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/find-TPUOAIUQ.js"() {
     init_chunk_LPQPILI2();
     init_chunk_X2AJGDEF();
     init_chunk_J642UCRS();
@@ -22345,10 +22345,10 @@ var init_find_TPUOAIUQ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js
 var p13, c8, h9;
 var init_chunk_ALLTKNUZ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-ALLTKNUZ.js"() {
     init_chunk_74CEPOFO();
     p13 = { name: "basename", summary: "strip directory and suffix from filenames", usage: `basename NAME [SUFFIX]
 basename OPTION... NAME...`, options: ["-a, --multiple   support multiple arguments", "-s, --suffix=SUFFIX  remove a trailing SUFFIX", "    --help       display this help and exit"] };
@@ -22375,24 +22375,24 @@ basename OPTION... NAME...`, options: ["-a, --multiple   support multiple argume
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js
+// node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js
 var basename_AA2KJYZQ_exports = {};
 __export(basename_AA2KJYZQ_exports, {
   basenameCommand: () => c8,
   flagsForFuzzing: () => h9
 });
 var init_basename_AA2KJYZQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/basename-AA2KJYZQ.js"() {
     init_chunk_ALLTKNUZ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js
 var m17, p14, c9;
 var init_chunk_4Q4SM6WR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-4Q4SM6WR.js"() {
     init_chunk_74CEPOFO();
     m17 = { name: "dirname", summary: "strip last component from file name", usage: "dirname [OPTION] NAME...", options: ["    --help       display this help and exit"] };
     p14 = { name: "dirname", async execute(t6, l7) {
@@ -22413,21 +22413,21 @@ var init_chunk_4Q4SM6WR = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js
+// node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js
 var dirname_LEMTZZFS_exports = {};
 __export(dirname_LEMTZZFS_exports, {
   dirnameCommand: () => p14,
   flagsForFuzzing: () => c9
 });
 var init_dirname_LEMTZZFS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/dirname-LEMTZZFS.js"() {
     init_chunk_4Q4SM6WR();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js
 async function T9(i11, o14, s10, f11, d15) {
   let e6 = { output: "", stderr: "", dirCount: 0, fileCount: 0 }, l7 = i11.fs.resolvePath(i11.cwd, o14);
   try {
@@ -22527,7 +22527,7 @@ async function w14(i11, o14, s10, f11, d15) {
 }
 var P10, b15, O9, L8;
 var init_chunk_XVDPCNWR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-XVDPCNWR.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     P10 = { name: "tree", summary: "list contents of directories in a tree-like format", usage: "tree [OPTION]... [DIRECTORY]...", options: ["-a          include hidden files", "-d          list directories only", "-L LEVEL    limit depth of directory tree", "-f          print full path prefix for each file", "    --help  display this help and exit"] };
@@ -22551,14 +22551,14 @@ ${a15} director${a15 === 1 ? "y" : "ies"}`, f11.directoriesOnly || (e6 += `, ${n
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js
+// node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js
 var tree_LYXBS7DC_exports = {};
 __export(tree_LYXBS7DC_exports, {
   flagsForFuzzing: () => L8,
   treeCommand: () => O9
 });
 var init_tree_LYXBS7DC = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tree-LYXBS7DC.js"() {
     init_chunk_XVDPCNWR();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -22566,7 +22566,7 @@ var init_tree_LYXBS7DC = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js
 async function w15(a15, s10, n24, r10, l7) {
   let o14 = { output: "", totalSize: 0, stderr: "" };
   if (l7 > E7) return o14;
@@ -22637,7 +22637,7 @@ function D7(a15, s10) {
 }
 var x17, R4, _8, E7, v17;
 var init_chunk_RPNGRAAP = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-RPNGRAAP.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     x17 = { name: "du", summary: "estimate file space usage", usage: "du [OPTION]... [FILE]...", options: ["-a          write counts for all files, not just directories", "-h          print sizes in human readable format", "-s          display only a total for each argument", "-c          produce a grand total", "--max-depth=N  print total for directory only if N or fewer levels deep", "    --help  display this help and exit"] };
@@ -22668,14 +22668,14 @@ var init_chunk_RPNGRAAP = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js
+// node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js
 var du_WO2ENHXQ_exports = {};
 __export(du_WO2ENHXQ_exports, {
   duCommand: () => _8,
   flagsForFuzzing: () => v17
 });
 var init_du_WO2ENHXQ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/du-WO2ENHXQ.js"() {
     init_chunk_RPNGRAAP();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -22683,10 +22683,10 @@ var init_du_WO2ENHXQ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js
 var g12, w16, x18, E8, M9, N9;
 var init_chunk_NAERJDUW = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-NAERJDUW.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
     g12 = { name: "env", summary: "run a program in a modified environment", usage: "env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]", options: ["-i, --ignore-environment  start with an empty environment", "-u NAME, --unset=NAME     remove NAME from the environment", "    --help                display this help and exit"] };
@@ -22757,7 +22757,7 @@ var init_chunk_NAERJDUW = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js
+// node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js
 var env_5EPCWSXR_exports = {};
 __export(env_5EPCWSXR_exports, {
   envCommand: () => w16,
@@ -22766,7 +22766,7 @@ __export(env_5EPCWSXR_exports, {
   printenvFlagsForFuzzing: () => N9
 });
 var init_env_5EPCWSXR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/env-5EPCWSXR.js"() {
     init_chunk_NAERJDUW();
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
@@ -22774,10 +22774,10 @@ var init_env_5EPCWSXR = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js
 var d9, o8, m18, c10, p15, h10;
 var init_chunk_VOBGTVA6 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-VOBGTVA6.js"() {
     init_chunk_74CEPOFO();
     d9 = { name: "alias", summary: "define or display aliases", usage: "alias [name[=value] ...]", options: ["    --help display this help and exit"] };
     o8 = "BASH_ALIAS_";
@@ -22828,7 +22828,7 @@ var init_chunk_VOBGTVA6 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js
+// node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js
 var alias_JE7RI5QX_exports = {};
 __export(alias_JE7RI5QX_exports, {
   aliasCommand: () => m18,
@@ -22837,17 +22837,17 @@ __export(alias_JE7RI5QX_exports, {
   unaliasFlagsForFuzzing: () => h10
 });
 var init_alias_JE7RI5QX = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/alias-JE7RI5QX.js"() {
     init_chunk_VOBGTVA6();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js
 var p16, h11, m19, u9;
 var init_chunk_NCNPKYJZ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-NCNPKYJZ.js"() {
     init_chunk_74CEPOFO();
     p16 = { name: "history", summary: "display command history", usage: "history [n]", options: ["-c      clear the history list", "    --help display this help and exit"] };
     h11 = "BASH_HISTORY";
@@ -22874,24 +22874,24 @@ var init_chunk_NCNPKYJZ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js
+// node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js
 var history_J4QRNGRO_exports = {};
 __export(history_J4QRNGRO_exports, {
   flagsForFuzzing: () => u9,
   historyCommand: () => m19
 });
 var init_history_J4QRNGRO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/history-J4QRNGRO.js"() {
     init_chunk_NCNPKYJZ();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js
 var $12, P11, H9;
 var init_chunk_TOMNU26N = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-TOMNU26N.js"() {
     init_chunk_IPJHKYVM();
     init_chunk_74CEPOFO();
     $12 = { name: "xargs", summary: "build and execute command lines from standard input", usage: "xargs [OPTION]... [COMMAND [INITIAL-ARGS]]", options: ["-I REPLACE   replace occurrences of REPLACE with input", "-d DELIM     use DELIM as input delimiter (e.g., -d '\\n' for newline)", "-n NUM       use at most NUM arguments per command line", "-P NUM       run at most NUM processes at a time", "-0, --null   items are separated by null, not whitespace", "-t, --verbose  print commands before executing", "-r, --no-run-if-empty  do not run command if input is empty", "    --help   display this help and exit"] };
@@ -22961,14 +22961,14 @@ var init_chunk_TOMNU26N = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js
+// node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js
 var xargs_I6EZUCYF_exports = {};
 __export(xargs_I6EZUCYF_exports, {
   flagsForFuzzing: () => H9,
   xargsCommand: () => P11
 });
 var init_xargs_I6EZUCYF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/xargs-I6EZUCYF.js"() {
     init_chunk_TOMNU26N();
     init_chunk_IPJHKYVM();
     init_chunk_74CEPOFO();
@@ -22976,10 +22976,10 @@ var init_xargs_I6EZUCYF = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js
 var e4, t, s3, r9;
 var init_chunk_R6QSAL5T = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-R6QSAL5T.js"() {
     e4 = { name: "true", async execute() {
       return { stdout: "", stderr: "", exitCode: 0 };
     } };
@@ -22991,7 +22991,7 @@ var init_chunk_R6QSAL5T = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js
+// node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js
 var true_WHJNXCHG_exports = {};
 __export(true_WHJNXCHG_exports, {
   falseCommand: () => t,
@@ -23000,16 +23000,16 @@ __export(true_WHJNXCHG_exports, {
   trueCommand: () => e4
 });
 var init_true_WHJNXCHG = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/true-WHJNXCHG.js"() {
     init_chunk_R6QSAL5T();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js
 var t2, s4, o9;
 var init_chunk_LL3S3NLB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-LL3S3NLB.js"() {
     init_chunk_74CEPOFO();
     t2 = { name: "clear", summary: "clear the terminal screen", usage: "clear [OPTIONS]", options: ["    --help display this help and exit"] };
     s4 = { name: "clear", async execute(r10, c15) {
@@ -23019,21 +23019,21 @@ var init_chunk_LL3S3NLB = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js
+// node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js
 var clear_5CZ5X4YR_exports = {};
 __export(clear_5CZ5X4YR_exports, {
   clearCommand: () => s4,
   flagsForFuzzing: () => o9
 });
 var init_clear_5CZ5X4YR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/clear-5CZ5X4YR.js"() {
     init_chunk_LL3S3NLB();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js
 async function o10(t6, e6, n24, r10) {
   if (!r10.exec) return { stdout: "", stderr: `bash: internal error: exec function not available
 `, exitCode: 1 };
@@ -23051,7 +23051,7 @@ async function o10(t6, e6, n24, r10) {
 }
 var d10, y17, C12, b16, P12;
 var init_chunk_D6CWQ5DW = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-D6CWQ5DW.js"() {
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
     d10 = { name: "bash", summary: "execute shell commands or scripts", usage: "bash [OPTIONS] [SCRIPT_FILE] [ARGUMENTS...]", options: ["-c COMMAND  execute COMMAND string", "    --help  display this help and exit"], notes: ["Without -c, reads and executes commands from SCRIPT_FILE.", "Arguments are passed as $1, $2, etc. to the script.", '$0 is set to the script name (or "bash" with -c).'] };
@@ -23092,7 +23092,7 @@ var init_chunk_D6CWQ5DW = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js
+// node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js
 var bash_IJWYRKFO_exports = {};
 __export(bash_IJWYRKFO_exports, {
   bashCommand: () => y17,
@@ -23101,7 +23101,7 @@ __export(bash_IJWYRKFO_exports, {
   shFlagsForFuzzing: () => P12
 });
 var init_bash_IJWYRKFO = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/bash-IJWYRKFO.js"() {
     init_chunk_D6CWQ5DW();
     init_chunk_OJDRYQWQ();
     init_chunk_74CEPOFO();
@@ -23109,7 +23109,7 @@ var init_bash_IJWYRKFO = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js
 function W8(t6, r10, e6, n24, p22, o14, u12, c15, s10, f11) {
   switch (r10) {
     case "sort":
@@ -25316,7 +25316,7 @@ function Ne3(t6) {
 }
 var Ot3, Nt3, P13, H10, St3, bt3, Ct3, At3, Y5, ut3;
 var init_chunk_BBXLRYSX = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-BBXLRYSX.js"() {
     init_chunk_7TSDKFEO();
     init_chunk_OJDRYQWQ();
     init_chunk_24IMIIXA();
@@ -25713,7 +25713,7 @@ var init_chunk_BBXLRYSX = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js
 function A5(s10) {
   let r10 = [], t6 = 0, l7 = s10.length;
   for (; t6 < l7; ) {
@@ -25778,7 +25778,7 @@ ${i11.repeat(n24)}}`;
 }
 var W9, Y6, Z9;
 var init_chunk_YCFVLTST = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-YCFVLTST.js"() {
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
     init_chunk_24IMIIXA();
@@ -25869,14 +25869,14 @@ var init_chunk_YCFVLTST = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js
+// node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js
 var jq_ODXZBPLY_exports = {};
 __export(jq_ODXZBPLY_exports, {
   flagsForFuzzing: () => Z9,
   jqCommand: () => Y6
 });
 var init_jq_ODXZBPLY = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/jq-ODXZBPLY.js"() {
     init_chunk_YCFVLTST();
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
@@ -25892,7 +25892,7 @@ var init_jq_ODXZBPLY = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js
 async function p17(r10, o14, n24) {
   if (o14.length === 0 || o14.length === 1 && o14[0] === "-") return { ok: true, data: Uint8Array.from(r10.stdin, (e6) => e6.charCodeAt(0)) };
   let d15 = [];
@@ -25915,7 +25915,7 @@ async function p17(r10, o14, n24) {
 }
 var b17, m20, A6, F10;
 var init_chunk_QJ7O6ZN3 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-QJ7O6ZN3.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     b17 = { name: "base64", summary: "base64 encode/decode data and print to standard output", usage: "base64 [OPTION]... [FILE]", options: ["-d, --decode    decode data", "-w, --wrap=COLS wrap encoded lines after COLS character (default 76, 0 to disable)", "    --help      display this help and exit"] };
@@ -25956,14 +25956,14 @@ var init_chunk_QJ7O6ZN3 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js
+// node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js
 var base64_4YMZCVJ5_exports = {};
 __export(base64_4YMZCVJ5_exports, {
   base64Command: () => A6,
   flagsForFuzzing: () => F10
 });
 var init_base64_4YMZCVJ5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/base64-4YMZCVJ5.js"() {
     init_chunk_QJ7O6ZN3();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -25971,10 +25971,10 @@ var init_base64_4YMZCVJ5 = __esm({
   }
 });
 
-// ../../../node_modules/diff/libesm/diff/base.js
+// node_modules/diff/libesm/diff/base.js
 var Diff;
 var init_base = __esm({
-  "../../../node_modules/diff/libesm/diff/base.js"() {
+  "node_modules/diff/libesm/diff/base.js"() {
     Diff = class {
       diff(oldStr, newStr, options = {}) {
         let callback;
@@ -26178,7 +26178,7 @@ var init_base = __esm({
   }
 });
 
-// ../../../node_modules/diff/libesm/diff/line.js
+// node_modules/diff/libesm/diff/line.js
 function diffLines(oldStr, newStr, options) {
   return lineDiff.diff(oldStr, newStr, options);
 }
@@ -26202,7 +26202,7 @@ function tokenize(value, options) {
 }
 var LineDiff, lineDiff;
 var init_line = __esm({
-  "../../../node_modules/diff/libesm/diff/line.js"() {
+  "node_modules/diff/libesm/diff/line.js"() {
     init_base();
     LineDiff = class extends Diff {
       constructor() {
@@ -26232,7 +26232,7 @@ var init_line = __esm({
   }
 });
 
-// ../../../node_modules/diff/libesm/patch/create.js
+// node_modules/diff/libesm/patch/create.js
 function structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options) {
   let optionsObj;
   if (!options) {
@@ -26408,7 +26408,7 @@ function splitLines(text) {
 }
 var INCLUDE_HEADERS;
 var init_create = __esm({
-  "../../../node_modules/diff/libesm/patch/create.js"() {
+  "node_modules/diff/libesm/patch/create.js"() {
     init_line();
     INCLUDE_HEADERS = {
       includeIndex: true,
@@ -26418,17 +26418,17 @@ var init_create = __esm({
   }
 });
 
-// ../../../node_modules/diff/libesm/index.js
+// node_modules/diff/libesm/index.js
 var init_libesm = __esm({
-  "../../../node_modules/diff/libesm/index.js"() {
+  "node_modules/diff/libesm/index.js"() {
     init_create();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js
 var y18, b18, $14, x19;
 var init_chunk_TLSUDHID = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-TLSUDHID.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     init_libesm();
@@ -26463,14 +26463,14 @@ var init_chunk_TLSUDHID = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js
+// node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js
 var diff_HJF2MPDN_exports = {};
 __export(diff_HJF2MPDN_exports, {
   diffCommand: () => $14,
   flagsForFuzzing: () => x19
 });
 var init_diff_HJF2MPDN = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/diff-HJF2MPDN.js"() {
     init_chunk_TLSUDHID();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -26478,7 +26478,7 @@ var init_diff_HJF2MPDN = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js
 function s5(a15, i11 = 2) {
   return String(a15).padStart(i11, "0");
 }
@@ -26579,7 +26579,7 @@ function h12(a15) {
 }
 var g13, T10, S8, M11, D9;
 var init_chunk_D7MEQ3VN = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-D7MEQ3VN.js"() {
     init_chunk_74CEPOFO();
     g13 = { name: "date", summary: "display the current time in the given FORMAT", usage: "date [OPTION]... [+FORMAT]", options: ["-d, --date=STRING   display time described by STRING", "-u, --utc           print Coordinated Universal Time (UTC)", "-I, --iso-8601      output date/time in ISO 8601 format", "-R, --rfc-email     output RFC 5322 date format", "    --help          display this help and exit"] };
     T10 = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -26614,21 +26614,21 @@ var init_chunk_D7MEQ3VN = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js
+// node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js
 var date_DD7FVA2V_exports = {};
 __export(date_DD7FVA2V_exports, {
   dateCommand: () => M11,
   flagsForFuzzing: () => D9
 });
 var init_date_DD7FVA2V = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/date-DD7FVA2V.js"() {
     init_chunk_D7MEQ3VN();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js
 function n22(e6) {
   let r10 = e6.match(/^(\d+\.?\d*)(s|m|h|d)?$/);
   if (!r10) return null;
@@ -26647,14 +26647,14 @@ function n22(e6) {
   }
 }
 var init_chunk_3ZUFRYJ4 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-3ZUFRYJ4.js"() {
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js
 var u10, m21, h13, b20;
 var init_chunk_GOV5EKKI = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-GOV5EKKI.js"() {
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
     init_chunk_74CEPOFO();
@@ -26690,14 +26690,14 @@ NUMBER may be a decimal number.`, options: ["    --help display this help and ex
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js
+// node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js
 var sleep_VZFPZFWA_exports = {};
 __export(sleep_VZFPZFWA_exports, {
   flagsForFuzzing: () => b20,
   sleepCommand: () => h13
 });
 var init_sleep_VZFPZFWA = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sleep-VZFPZFWA.js"() {
     init_chunk_GOV5EKKI();
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
@@ -26707,10 +26707,10 @@ var init_sleep_VZFPZFWA = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js
 var v19, N10, D10;
 var init_chunk_YTNYSM6T = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-YTNYSM6T.js"() {
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
     init_chunk_IPJHKYVM();
@@ -26771,14 +26771,14 @@ DURATION is a number with optional suffix:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js
+// node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js
 var timeout_VRKMCG72_exports = {};
 __export(timeout_VRKMCG72_exports, {
   flagsForFuzzing: () => D10,
   timeoutCommand: () => N10
 });
 var init_timeout_VRKMCG72 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/timeout-VRKMCG72.js"() {
     init_chunk_YTNYSM6T();
     init_chunk_3ZUFRYJ4();
     init_chunk_A5O5YHGN();
@@ -26789,14 +26789,14 @@ var init_timeout_VRKMCG72 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js
 function F11(r10) {
   let s10 = Math.floor(r10 / 3600), a15 = Math.floor(r10 % 3600 / 60), o14 = r10 % 60;
   return s10 > 0 ? `${s10}:${a15.toString().padStart(2, "0")}:${o14.toFixed(2).padStart(5, "0")}` : `${a15}:${o14.toFixed(2).padStart(5, "0")}`;
 }
 var v20, S9;
 var init_chunk_Z6LRHWXI = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-Z6LRHWXI.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_IPJHKYVM();
     init_chunk_OJDRYQWQ();
@@ -26859,14 +26859,14 @@ sys 0.00
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js
+// node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js
 var time_DEUO3QV2_exports = {};
 __export(time_DEUO3QV2_exports, {
   flagsForFuzzing: () => S9,
   timeCommand: () => v20
 });
 var init_time_DEUO3QV2 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/time-DEUO3QV2.js"() {
     init_chunk_Z6LRHWXI();
     init_chunk_CWQS3NFK();
     init_chunk_IPJHKYVM();
@@ -26876,10 +26876,10 @@ var init_time_DEUO3QV2 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js
 var F12, b21;
 var init_chunk_A7A2DBEE = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A7A2DBEE.js"() {
     F12 = { name: "seq", async execute(r10) {
       let d15 = `
 `, f11 = false, s10 = [], t6 = 0;
@@ -26938,20 +26938,20 @@ var init_chunk_A7A2DBEE = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js
+// node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js
 var seq_RN5ZUASB_exports = {};
 __export(seq_RN5ZUASB_exports, {
   flagsForFuzzing: () => b21,
   seqCommand: () => F12
 });
 var init_seq_RN5ZUASB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/seq-RN5ZUASB.js"() {
     init_chunk_A7A2DBEE();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js
 function x20(s10) {
   if (s10.length === 1) return s10[0];
   let r10 = 0;
@@ -27059,7 +27059,7 @@ function x20(s10) {
 }
 var S10, E9;
 var init_chunk_YFG2CMIF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-YFG2CMIF.js"() {
     init_chunk_YNYSPYQ5();
     init_chunk_3THT3N7L();
     S10 = { name: "expr", async execute(s10, r10) {
@@ -27078,14 +27078,14 @@ var init_chunk_YFG2CMIF = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js
+// node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js
 var expr_5T3UU5KE_exports = {};
 __export(expr_5T3UU5KE_exports, {
   exprCommand: () => S10,
   flagsForFuzzing: () => E9
 });
 var init_expr_5T3UU5KE = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/expr-5T3UU5KE.js"() {
     init_chunk_YFG2CMIF();
     init_chunk_YNYSPYQ5();
     init_chunk_3THT3N7L();
@@ -27093,7 +27093,7 @@ var init_expr_5T3UU5KE = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js
 function L10(n24) {
   function h18(r10, u12) {
     return r10 << u12 | r10 >>> 32 - u12;
@@ -27182,30 +27182,30 @@ function S11(n24, h18, g17) {
 }
 var F13;
 var init_chunk_EIZGF4BS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-EIZGF4BS.js"() {
     init_chunk_74CEPOFO();
     F13 = /* @__PURE__ */ new Map([["sha1", "SHA-1"], ["sha256", "SHA-256"]]);
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js
 var s6, o11;
 var init_chunk_APT7OOP2 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-APT7OOP2.js"() {
     init_chunk_EIZGF4BS();
     s6 = S11("md5sum", "md5", "compute MD5 message digest");
     o11 = { name: "md5sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js
+// node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js
 var md5sum_INMIK4DX_exports = {};
 __export(md5sum_INMIK4DX_exports, {
   flagsForFuzzing: () => o11,
   md5sumCommand: () => s6
 });
 var init_md5sum_INMIK4DX = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/md5sum-INMIK4DX.js"() {
     init_chunk_APT7OOP2();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27213,24 +27213,24 @@ var init_md5sum_INMIK4DX = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js
 var a9, m22;
 var init_chunk_XKQRETAK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-XKQRETAK.js"() {
     init_chunk_EIZGF4BS();
     a9 = S11("sha1sum", "sha1", "compute SHA1 message digest");
     m22 = { name: "sha1sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js
+// node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js
 var sha1sum_VJPNLNU6_exports = {};
 __export(sha1sum_VJPNLNU6_exports, {
   flagsForFuzzing: () => m22,
   sha1sumCommand: () => a9
 });
 var init_sha1sum_VJPNLNU6 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sha1sum-VJPNLNU6.js"() {
     init_chunk_XKQRETAK();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27238,24 +27238,24 @@ var init_sha1sum_VJPNLNU6 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js
 var a10, m23;
 var init_chunk_5V6VZH6T = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-5V6VZH6T.js"() {
     init_chunk_EIZGF4BS();
     a10 = S11("sha256sum", "sha256", "compute SHA256 message digest");
     m23 = { name: "sha256sum", flags: [{ flag: "-c", type: "boolean" }], needsFiles: true };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js
+// node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js
 var sha256sum_PI32XWXY_exports = {};
 __export(sha256sum_PI32XWXY_exports, {
   flagsForFuzzing: () => m23,
   sha256sumCommand: () => a10
 });
 var init_sha256sum_PI32XWXY = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sha256sum-PI32XWXY.js"() {
     init_chunk_5V6VZH6T();
     init_chunk_EIZGF4BS();
     init_chunk_74CEPOFO();
@@ -27263,7 +27263,7 @@ var init_sha256sum_PI32XWXY = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js
 import { open as ct4 } from "node:fs/promises";
 function oe4(i11) {
   try {
@@ -27521,7 +27521,7 @@ async function Qt2(i11, e6) {
 }
 var Te3, ze4, fe4, Le3, je4, _e3, He3, We3, nt4, x21, D11, M12, J9, _9, L11, S12, st4, X8, Z10, Q6, $15, ft4, Ae3, ce6, mt4, Be3, d12, R5, h14, Ie4, Oe3, De4, b22, Je4, U7, ue6, Ve3, qe4, Ge3, E10, xe5, Nt4, ie5, H11, W10, ur2, xr2, dr2, Ye3, Ke3, et4, he6, we4, Ht3, Wt3, Vt2, qt, Gt3, Dr2, Mr;
 var init_chunk_CR5AFCPT = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-CR5AFCPT.js"() {
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
     Te3 = o3((ae9) => {
@@ -28796,23 +28796,23 @@ var init_chunk_CR5AFCPT = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js
+// node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js
 var file_ZIGAJ4YS_exports = {};
 __export(file_ZIGAJ4YS_exports, {
   fileCommand: () => Dr2,
   flagsForFuzzing: () => Mr
 });
 var init_file_ZIGAJ4YS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/file-ZIGAJ4YS.js"() {
     init_chunk_CR5AFCPT();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Event.js
+// node_modules/@mixmark-io/domino/lib/Event.js
 var require_Event = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Event.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Event.js"(exports, module) {
     "use strict";
     module.exports = Event;
     Event.CAPTURING_PHASE = 1;
@@ -28867,9 +28867,9 @@ var require_Event = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/UIEvent.js
+// node_modules/@mixmark-io/domino/lib/UIEvent.js
 var require_UIEvent = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/UIEvent.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/UIEvent.js"(exports, module) {
     "use strict";
     var Event = require_Event();
     module.exports = UIEvent;
@@ -28889,9 +28889,9 @@ var require_UIEvent = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/MouseEvent.js
+// node_modules/@mixmark-io/domino/lib/MouseEvent.js
 var require_MouseEvent = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/MouseEvent.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/MouseEvent.js"(exports, module) {
     "use strict";
     var UIEvent = require_UIEvent();
     module.exports = MouseEvent;
@@ -28950,9 +28950,9 @@ var require_MouseEvent = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/DOMException.js
+// node_modules/@mixmark-io/domino/lib/DOMException.js
 var require_DOMException = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/DOMException.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/DOMException.js"(exports, module) {
     "use strict";
     module.exports = DOMException;
     var INDEX_SIZE_ERR = 1;
@@ -29087,16 +29087,16 @@ var require_DOMException = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/config.js
+// node_modules/@mixmark-io/domino/lib/config.js
 var require_config = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/config.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/config.js"(exports) {
     exports.isApiWritable = !globalThis.__domino_frozen__;
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/utils.js
+// node_modules/@mixmark-io/domino/lib/utils.js
 var require_utils = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/utils.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/utils.js"(exports) {
     "use strict";
     var DOMException = require_DOMException();
     var ERR = DOMException;
@@ -29209,9 +29209,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/EventTarget.js
+// node_modules/@mixmark-io/domino/lib/EventTarget.js
 var require_EventTarget = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/EventTarget.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/EventTarget.js"(exports, module) {
     "use strict";
     var Event = require_Event();
     var MouseEvent = require_MouseEvent();
@@ -29455,9 +29455,9 @@ var require_EventTarget = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/LinkedList.js
+// node_modules/@mixmark-io/domino/lib/LinkedList.js
 var require_LinkedList = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/LinkedList.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/LinkedList.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     var LinkedList = module.exports = {
@@ -29505,9 +29505,9 @@ var require_LinkedList = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeUtils.js
+// node_modules/@mixmark-io/domino/lib/NodeUtils.js
 var require_NodeUtils = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeUtils.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeUtils.js"(exports, module) {
     "use strict";
     module.exports = {
       // NOTE: The `serializeOne()` function used to live on the `Node.prototype`
@@ -29705,9 +29705,9 @@ var require_NodeUtils = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Node.js
+// node_modules/@mixmark-io/domino/lib/Node.js
 var require_Node = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Node.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Node.js"(exports, module) {
     "use strict";
     module.exports = Node;
     var EventTarget = require_EventTarget();
@@ -30305,9 +30305,9 @@ var require_Node = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeList.es6.js
+// node_modules/@mixmark-io/domino/lib/NodeList.es6.js
 var require_NodeList_es6 = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeList.es6.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeList.es6.js"(exports, module) {
     "use strict";
     module.exports = class NodeList extends Array {
       constructor(a15) {
@@ -30325,9 +30325,9 @@ var require_NodeList_es6 = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeList.es5.js
+// node_modules/@mixmark-io/domino/lib/NodeList.es5.js
 var require_NodeList_es5 = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeList.es5.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeList.es5.js"(exports, module) {
     "use strict";
     function item(i11) {
       return this[i11] || null;
@@ -30341,9 +30341,9 @@ var require_NodeList_es5 = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeList.js
+// node_modules/@mixmark-io/domino/lib/NodeList.js
 var require_NodeList = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeList.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeList.js"(exports, module) {
     "use strict";
     var NodeList;
     try {
@@ -30355,9 +30355,9 @@ var require_NodeList = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/ContainerNode.js
+// node_modules/@mixmark-io/domino/lib/ContainerNode.js
 var require_ContainerNode = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/ContainerNode.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/ContainerNode.js"(exports, module) {
     "use strict";
     module.exports = ContainerNode;
     var Node = require_Node();
@@ -30426,9 +30426,9 @@ var require_ContainerNode = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/xmlnames.js
+// node_modules/@mixmark-io/domino/lib/xmlnames.js
 var require_xmlnames = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/xmlnames.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/xmlnames.js"(exports) {
     "use strict";
     exports.isValidName = isValidName;
     exports.isValidQName = isValidQName;
@@ -30470,9 +30470,9 @@ var require_xmlnames = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/attributes.js
+// node_modules/@mixmark-io/domino/lib/attributes.js
 var require_attributes = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/attributes.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/attributes.js"(exports) {
     "use strict";
     var utils = require_utils();
     exports.property = function(attr) {
@@ -30602,9 +30602,9 @@ var require_attributes = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/FilteredElementList.js
+// node_modules/@mixmark-io/domino/lib/FilteredElementList.js
 var require_FilteredElementList = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/FilteredElementList.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/FilteredElementList.js"(exports, module) {
     "use strict";
     module.exports = FilteredElementList;
     var Node = require_Node();
@@ -30674,9 +30674,9 @@ var require_FilteredElementList = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/DOMTokenList.js
+// node_modules/@mixmark-io/domino/lib/DOMTokenList.js
 var require_DOMTokenList = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/DOMTokenList.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/DOMTokenList.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     module.exports = DOMTokenList;
@@ -30840,9 +30840,9 @@ var require_DOMTokenList = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/select.js
+// node_modules/@mixmark-io/domino/lib/select.js
 var require_select = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/select.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/select.js"(exports, module) {
     "use strict";
     var window2 = Object.create(null, {
       location: { get: function() {
@@ -31574,9 +31574,9 @@ var require_select = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/ChildNode.js
+// node_modules/@mixmark-io/domino/lib/ChildNode.js
 var require_ChildNode = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/ChildNode.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/ChildNode.js"(exports, module) {
     "use strict";
     var Node = require_Node();
     var LinkedList = require_LinkedList();
@@ -31675,9 +31675,9 @@ var require_ChildNode = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js
+// node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js
 var require_NonDocumentTypeChildNode = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NonDocumentTypeChildNode.js"(exports, module) {
     "use strict";
     var Node = require_Node();
     var NonDocumentTypeChildNode = {
@@ -31702,9 +31702,9 @@ var require_NonDocumentTypeChildNode = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NamedNodeMap.js
+// node_modules/@mixmark-io/domino/lib/NamedNodeMap.js
 var require_NamedNodeMap = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NamedNodeMap.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NamedNodeMap.js"(exports, module) {
     "use strict";
     module.exports = NamedNodeMap;
     var utils = require_utils();
@@ -31742,9 +31742,9 @@ var require_NamedNodeMap = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Element.js
+// node_modules/@mixmark-io/domino/lib/Element.js
 var require_Element = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Element.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Element.js"(exports, module) {
     "use strict";
     module.exports = Element;
     var xml = require_xmlnames();
@@ -32778,9 +32778,9 @@ var require_Element = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Leaf.js
+// node_modules/@mixmark-io/domino/lib/Leaf.js
 var require_Leaf = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Leaf.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Leaf.js"(exports, module) {
     "use strict";
     module.exports = Leaf;
     var Node = require_Node();
@@ -32819,9 +32819,9 @@ var require_Leaf = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/CharacterData.js
+// node_modules/@mixmark-io/domino/lib/CharacterData.js
 var require_CharacterData = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/CharacterData.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/CharacterData.js"(exports, module) {
     "use strict";
     module.exports = CharacterData;
     var Leaf = require_Leaf();
@@ -32930,9 +32930,9 @@ var require_CharacterData = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Text.js
+// node_modules/@mixmark-io/domino/lib/Text.js
 var require_Text = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Text.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Text.js"(exports, module) {
     "use strict";
     module.exports = Text;
     var utils = require_utils();
@@ -33006,9 +33006,9 @@ var require_Text = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Comment.js
+// node_modules/@mixmark-io/domino/lib/Comment.js
 var require_Comment = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Comment.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Comment.js"(exports, module) {
     "use strict";
     module.exports = Comment;
     var Node = require_Node();
@@ -33053,9 +33053,9 @@ var require_Comment = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/DocumentFragment.js
+// node_modules/@mixmark-io/domino/lib/DocumentFragment.js
 var require_DocumentFragment = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/DocumentFragment.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/DocumentFragment.js"(exports, module) {
     "use strict";
     module.exports = DocumentFragment;
     var Node = require_Node();
@@ -33118,9 +33118,9 @@ var require_DocumentFragment = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js
+// node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js
 var require_ProcessingInstruction = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/ProcessingInstruction.js"(exports, module) {
     "use strict";
     module.exports = ProcessingInstruction;
     var Node = require_Node();
@@ -33170,9 +33170,9 @@ var require_ProcessingInstruction = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeFilter.js
+// node_modules/@mixmark-io/domino/lib/NodeFilter.js
 var require_NodeFilter = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeFilter.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeFilter.js"(exports, module) {
     "use strict";
     var NodeFilter = {
       // Constants for acceptNode()
@@ -33203,9 +33203,9 @@ var require_NodeFilter = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeTraversal.js
+// node_modules/@mixmark-io/domino/lib/NodeTraversal.js
 var require_NodeTraversal = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeTraversal.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeTraversal.js"(exports, module) {
     "use strict";
     var NodeTraversal = module.exports = {
       nextSkippingChildren,
@@ -33270,9 +33270,9 @@ var require_NodeTraversal = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/TreeWalker.js
+// node_modules/@mixmark-io/domino/lib/TreeWalker.js
 var require_TreeWalker = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/TreeWalker.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/TreeWalker.js"(exports, module) {
     "use strict";
     module.exports = TreeWalker;
     var Node = require_Node();
@@ -33551,9 +33551,9 @@ var require_TreeWalker = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NodeIterator.js
+// node_modules/@mixmark-io/domino/lib/NodeIterator.js
 var require_NodeIterator = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NodeIterator.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NodeIterator.js"(exports, module) {
     "use strict";
     module.exports = NodeIterator;
     var NodeFilter = require_NodeFilter();
@@ -33723,9 +33723,9 @@ var require_NodeIterator = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/URL.js
+// node_modules/@mixmark-io/domino/lib/URL.js
 var require_URL = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/URL.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/URL.js"(exports, module) {
     "use strict";
     module.exports = URL2;
     function URL2(url) {
@@ -33889,9 +33889,9 @@ var require_URL = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/CustomEvent.js
+// node_modules/@mixmark-io/domino/lib/CustomEvent.js
 var require_CustomEvent = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/CustomEvent.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/CustomEvent.js"(exports, module) {
     "use strict";
     module.exports = CustomEvent;
     var Event = require_Event();
@@ -33904,9 +33904,9 @@ var require_CustomEvent = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/events.js
+// node_modules/@mixmark-io/domino/lib/events.js
 var require_events = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/events.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/events.js"(exports, module) {
     "use strict";
     module.exports = {
       Event: require_Event(),
@@ -33917,9 +33917,9 @@ var require_events = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/style_parser.js
+// node_modules/@mixmark-io/domino/lib/style_parser.js
 var require_style_parser = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/style_parser.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/style_parser.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.hyphenate = exports.parse = void 0;
@@ -33987,9 +33987,9 @@ var require_style_parser = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js
+// node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js
 var require_CSSStyleDeclaration = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/CSSStyleDeclaration.js"(exports, module) {
     "use strict";
     var { parse } = require_style_parser();
     module.exports = function(elt) {
@@ -34171,9 +34171,9 @@ var require_CSSStyleDeclaration = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/URLUtils.js
+// node_modules/@mixmark-io/domino/lib/URLUtils.js
 var require_URLUtils = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/URLUtils.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/URLUtils.js"(exports, module) {
     "use strict";
     var URL2 = require_URL();
     module.exports = URLUtils;
@@ -34418,9 +34418,9 @@ var require_URLUtils = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/defineElement.js
+// node_modules/@mixmark-io/domino/lib/defineElement.js
 var require_defineElement = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/defineElement.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/defineElement.js"(exports, module) {
     "use strict";
     var attributes = require_attributes();
     var isApiWritable = require_config().isApiWritable;
@@ -34482,9 +34482,9 @@ var require_defineElement = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/htmlelts.js
+// node_modules/@mixmark-io/domino/lib/htmlelts.js
 var require_htmlelts = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/htmlelts.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/htmlelts.js"(exports) {
     "use strict";
     var Node = require_Node();
     var Element = require_Element();
@@ -36037,9 +36037,9 @@ var require_htmlelts = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/svg.js
+// node_modules/@mixmark-io/domino/lib/svg.js
 var require_svg = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/svg.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/svg.js"(exports) {
     "use strict";
     var Element = require_Element();
     var defineElement = require_defineElement();
@@ -36166,9 +36166,9 @@ var require_svg = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/MutationConstants.js
+// node_modules/@mixmark-io/domino/lib/MutationConstants.js
 var require_MutationConstants = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/MutationConstants.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/MutationConstants.js"(exports, module) {
     "use strict";
     module.exports = {
       VALUE: 1,
@@ -36187,9 +36187,9 @@ var require_MutationConstants = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Document.js
+// node_modules/@mixmark-io/domino/lib/Document.js
 var require_Document = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Document.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Document.js"(exports, module) {
     "use strict";
     module.exports = Document;
     var Node = require_Node();
@@ -36931,9 +36931,9 @@ var require_Document = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/DocumentType.js
+// node_modules/@mixmark-io/domino/lib/DocumentType.js
 var require_DocumentType = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/DocumentType.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/DocumentType.js"(exports, module) {
     "use strict";
     module.exports = DocumentType;
     var Node = require_Node();
@@ -36970,9 +36970,9 @@ var require_DocumentType = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/HTMLParser.js
+// node_modules/@mixmark-io/domino/lib/HTMLParser.js
 var require_HTMLParser = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/HTMLParser.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/HTMLParser.js"(exports, module) {
     "use strict";
     module.exports = HTMLParser;
     var Document = require_Document();
@@ -45132,9 +45132,9 @@ var require_HTMLParser = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/DOMImplementation.js
+// node_modules/@mixmark-io/domino/lib/DOMImplementation.js
 var require_DOMImplementation = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/DOMImplementation.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/DOMImplementation.js"(exports, module) {
     "use strict";
     module.exports = DOMImplementation;
     var Document = require_Document();
@@ -45211,9 +45211,9 @@ var require_DOMImplementation = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Location.js
+// node_modules/@mixmark-io/domino/lib/Location.js
 var require_Location = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Location.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Location.js"(exports, module) {
     "use strict";
     var URL2 = require_URL();
     var URLUtils = require_URLUtils();
@@ -45251,9 +45251,9 @@ var require_Location = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/NavigatorID.js
+// node_modules/@mixmark-io/domino/lib/NavigatorID.js
 var require_NavigatorID = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/NavigatorID.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/NavigatorID.js"(exports, module) {
     "use strict";
     var NavigatorID = Object.create(null, {
       appCodeName: { value: "Mozilla" },
@@ -45273,9 +45273,9 @@ var require_NavigatorID = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/WindowTimers.js
+// node_modules/@mixmark-io/domino/lib/WindowTimers.js
 var require_WindowTimers = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/WindowTimers.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/WindowTimers.js"(exports, module) {
     "use strict";
     var WindowTimers = {
       setTimeout,
@@ -45287,9 +45287,9 @@ var require_WindowTimers = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/impl.js
+// node_modules/@mixmark-io/domino/lib/impl.js
 var require_impl = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/impl.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/impl.js"(exports, module) {
     "use strict";
     var utils = require_utils();
     exports = module.exports = {
@@ -45318,9 +45318,9 @@ var require_impl = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/Window.js
+// node_modules/@mixmark-io/domino/lib/Window.js
 var require_Window = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/Window.js"(exports, module) {
+  "node_modules/@mixmark-io/domino/lib/Window.js"(exports, module) {
     "use strict";
     var DOMImplementation = require_DOMImplementation();
     var EventTarget = require_EventTarget();
@@ -45386,9 +45386,9 @@ var require_Window = __commonJS({
   }
 });
 
-// ../../../node_modules/@mixmark-io/domino/lib/index.js
+// node_modules/@mixmark-io/domino/lib/index.js
 var require_lib = __commonJS({
-  "../../../node_modules/@mixmark-io/domino/lib/index.js"(exports) {
+  "node_modules/@mixmark-io/domino/lib/index.js"(exports) {
     "use strict";
     var DOMImplementation = require_DOMImplementation();
     var HTMLParser = require_HTMLParser();
@@ -45469,9 +45469,9 @@ var require_lib = __commonJS({
   }
 });
 
-// ../../../node_modules/turndown/lib/turndown.cjs.js
+// node_modules/turndown/lib/turndown.cjs.js
 var require_turndown_cjs = __commonJS({
-  "../../../node_modules/turndown/lib/turndown.cjs.js"(exports, module) {
+  "node_modules/turndown/lib/turndown.cjs.js"(exports, module) {
     "use strict";
     function extend(destination) {
       for (var i11 = 1; i11 < arguments.length; i11++) {
@@ -46114,10 +46114,10 @@ var require_turndown_cjs = __commonJS({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js
 var import_turndown, p18, g14, x22;
 var init_chunk_MDLLFABN = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MDLLFABN.js"() {
     init_chunk_74CEPOFO();
     import_turndown = __toESM(require_turndown_cjs(), 1);
     p18 = { name: "html-to-markdown", summary: "convert HTML to Markdown (BashEnv extension)", usage: "html-to-markdown [OPTION]... [FILE]", description: ["Convert HTML content to Markdown format using the turndown library.", "This is a non-standard BashEnv extension command, not available in regular bash.", "", "Read HTML from FILE or standard input and output Markdown to standard output.", "Commonly used with curl to convert web pages:", "  curl -s https://example.com | html-to-markdown", "", "Supported HTML elements:", "  - Headings (h1-h6) \u2192 # Markdown headings", "  - Paragraphs (p) \u2192 Plain text with blank lines", "  - Links (a) \u2192 [text](url)", "  - Images (img) \u2192 ![alt](src)", "  - Bold/Strong \u2192 **text**", "  - Italic/Em \u2192 _text_", "  - Code (code, pre) \u2192 `inline` or fenced blocks", "  - Lists (ul, ol, li) \u2192 - or 1. items", "  - Blockquotes \u2192 > quoted text", "  - Horizontal rules (hr) \u2192 ---"], options: ["-b, --bullet=CHAR     bullet character for unordered lists (-, +, or *)", "-c, --code=FENCE      fence style for code blocks (``` or ~~~)", "-r, --hr=STRING       string for horizontal rules (default: ---)", "    --heading-style=STYLE", "                      heading style: 'atx' for # headings (default),", "                      'setext' for underlined headings (h1/h2 only)", "    --help            display this help and exit"], examples: ["echo '<h1>Hello</h1><p>World</p>' | html-to-markdown", "html-to-markdown page.html", "curl -s https://example.com | html-to-markdown > page.md"] };
@@ -46165,21 +46165,21 @@ var init_chunk_MDLLFABN = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js
+// node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js
 var html_to_markdown_TFCECAGV_exports = {};
 __export(html_to_markdown_TFCECAGV_exports, {
   flagsForFuzzing: () => x22,
   htmlToMarkdownCommand: () => g14
 });
 var init_html_to_markdown_TFCECAGV = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/html-to-markdown-TFCECAGV.js"() {
     init_chunk_MDLLFABN();
     init_chunk_74CEPOFO();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js
 function d13(n24) {
   let e6 = [], s10 = new Set(n24);
   e6.push(`Available commands:
@@ -46201,7 +46201,7 @@ function d13(n24) {
 }
 var c11, h15, p19;
 var init_chunk_MLXIYONF = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MLXIYONF.js"() {
     init_chunk_IPJHKYVM();
     c11 = /* @__PURE__ */ new Map([["File operations", ["ls", "cat", "head", "tail", "wc", "touch", "mkdir", "rm", "cp", "mv", "ln", "chmod", "stat", "readlink"]], ["Text processing", ["grep", "sed", "awk", "sort", "uniq", "cut", "tr", "tee", "diff"]], ["Search", ["find"]], ["Navigation & paths", ["pwd", "basename", "dirname", "tree", "du"]], ["Environment & shell", ["echo", "printf", "env", "printenv", "export", "alias", "unalias", "history", "clear", "true", "false", "bash", "sh"]], ["Data processing", ["xargs", "jq", "base64", "date"]], ["Network", ["curl", "html-to-markdown"]]]);
     h15 = { name: "help", async execute(n24, e6) {
@@ -46226,24 +46226,24 @@ Otherwise, lists all available commands.
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js
+// node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js
 var help_VVWX7SA5_exports = {};
 __export(help_VVWX7SA5_exports, {
   flagsForFuzzing: () => p19,
   helpCommand: () => h15
 });
 var init_help_VVWX7SA5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/help-VVWX7SA5.js"() {
     init_chunk_MLXIYONF();
     init_chunk_IPJHKYVM();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js
 var g15, w17, A8, v21;
 var init_chunk_A65PWWJC = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-A65PWWJC.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     g15 = { name: "which", summary: "locate a command", usage: "which [-as] program ...", options: ["-a         List all instances of executables found", "-s         No output, just return 0 if found, 1 if not", "--help     display this help and exit"] };
@@ -46271,14 +46271,14 @@ var init_chunk_A65PWWJC = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js
+// node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js
 var which_XZHEH76L_exports = {};
 __export(which_XZHEH76L_exports, {
   flagsForFuzzing: () => v21,
   whichCommand: () => A8
 });
 var init_which_XZHEH76L = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/which-XZHEH76L.js"() {
     init_chunk_A65PWWJC();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -46286,7 +46286,7 @@ var init_which_XZHEH76L = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js
 async function c12(e6, t6) {
   if (e6.length > 0 && e6[0] !== "-") {
     let i11 = t6.fs.resolvePath(t6.cwd, e6[0]);
@@ -46313,78 +46313,78 @@ async function c12(e6, t6) {
 }
 var l5, a11;
 var init_chunk_MHTUABJP = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-MHTUABJP.js"() {
     l5 = { name: "tac", execute: c12 };
     a11 = { name: "tac", flags: [], stdinType: "text", needsFiles: true };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js
+// node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js
 var tac_SJGXQ4T2_exports = {};
 __export(tac_SJGXQ4T2_exports, {
   flagsForFuzzing: () => a11,
   tac: () => l5
 });
 var init_tac_SJGXQ4T2 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tac-SJGXQ4T2.js"() {
     init_chunk_MHTUABJP();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js
 async function t5(e6, n24) {
   return { stdout: `localhost
 `, stderr: "", exitCode: 0 };
 }
 var o12, s7;
 var init_chunk_4HHKTUW3 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-4HHKTUW3.js"() {
     o12 = { name: "hostname", execute: t5 };
     s7 = { name: "hostname", flags: [] };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js
+// node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js
 var hostname_BK6HG2DE_exports = {};
 __export(hostname_BK6HG2DE_exports, {
   flagsForFuzzing: () => s7,
   hostname: () => o12
 });
 var init_hostname_BK6HG2DE = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/hostname-BK6HG2DE.js"() {
     init_chunk_4HHKTUW3();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js
 async function e5(t6, o14) {
   return { stdout: `user
 `, stderr: "", exitCode: 0 };
 }
 var a12, n23;
 var init_chunk_HJQJAYMS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-HJQJAYMS.js"() {
     a12 = { name: "whoami", execute: e5 };
     n23 = { name: "whoami", flags: [] };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js
+// node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js
 var whoami_DGKU3D2X_exports = {};
 __export(whoami_DGKU3D2X_exports, {
   flagsForFuzzing: () => n23,
   whoami: () => a12
 });
 var init_whoami_DGKU3D2X = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/whoami-DGKU3D2X.js"() {
     init_chunk_HJQJAYMS();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js
 async function x23(a15, u12) {
   let o14 = "octal", n24 = [], i11 = [];
   for (let t6 = 0; t6 < a15.length; t6++) {
@@ -46435,26 +46435,26 @@ async function x23(a15, u12) {
 }
 var $16, v22;
 var init_chunk_PP6PSHAB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-PP6PSHAB.js"() {
     $16 = { name: "od", execute: x23 };
     v22 = { name: "od", flags: [{ flag: "-c", type: "boolean" }, { flag: "-A", type: "value", valueHint: "string" }, { flag: "-t", type: "value", valueHint: "string" }, { flag: "-N", type: "value", valueHint: "number" }], stdinType: "text", needsFiles: true };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js
+// node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js
 var od_VJEF2UR5_exports = {};
 __export(od_VJEF2UR5_exports, {
   flagsForFuzzing: () => v22,
   od: () => $16
 });
 var init_od_VJEF2UR5 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/od-VJEF2UR5.js"() {
     init_chunk_PP6PSHAB();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js
 import { constants as x24, gunzipSync as F14, gzipSync as S13 } from "node:zlib";
 function E11(e6) {
   return e6.best ? x24.Z_BEST_COMPRESSION : e6.level8 ? 8 : e6.level7 ? 7 : e6.level6 ? 6 : e6.level5 ? 5 : e6.level4 ? 4 : e6.level3 ? 3 : e6.level2 ? 2 : e6.fast ? x24.Z_BEST_SPEED : x24.Z_DEFAULT_COMPRESSION;
@@ -46678,7 +46678,7 @@ async function C14(e6, t6, r10) {
 }
 var O10, U8, D12, T11, G5, M13, Z11, R6, K9, j10;
 var init_chunk_LTZRCH7N = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-LTZRCH7N.js"() {
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
     O10 = { name: "gzip", summary: "compress or expand files", usage: "gzip [OPTION]... [FILE]...", description: `Compress FILEs (by default, in-place).
@@ -46708,7 +46708,7 @@ When no FILE is given, or when FILE is -, read from standard input.`, options: [
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js
+// node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js
 var gzip_AQXSGOVS_exports = {};
 __export(gzip_AQXSGOVS_exports, {
   flagsForFuzzing: () => R6,
@@ -46719,7 +46719,7 @@ __export(gzip_AQXSGOVS_exports, {
   zcatFlagsForFuzzing: () => j10
 });
 var init_gzip_AQXSGOVS = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/gzip-AQXSGOVS.js"() {
     init_chunk_LTZRCH7N();
     init_chunk_HWKDQ44K();
     init_chunk_74CEPOFO();
@@ -46727,9 +46727,9 @@ var init_gzip_AQXSGOVS = __esm({
   }
 });
 
-// ../../../node_modules/amdefine/amdefine.js
+// node_modules/amdefine/amdefine.js
 var require_amdefine = __commonJS({
-  "../../../node_modules/amdefine/amdefine.js"(exports, module) {
+  "node_modules/amdefine/amdefine.js"(exports, module) {
     "use strict";
     function amdefine(module2, requireFn) {
       "use strict";
@@ -46918,9 +46918,9 @@ var require_amdefine = __commonJS({
   }
 });
 
-// ../../../node_modules/compressjs/main.js
+// node_modules/compressjs/main.js
 var require_main = __commonJS({
-  "../../../node_modules/compressjs/main.js"(exports, module) {
+  "node_modules/compressjs/main.js"(exports, module) {
     if (typeof define2 !== "function") {
       define2 = require_amdefine()(module);
     }
@@ -46956,7 +46956,7 @@ var require_main = __commonJS({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js
 function v24(e6, t6, n24, r10) {
   r10 && F15.encodeInto(r10, e6.subarray(t6, t6 + n24));
 }
@@ -48111,7 +48111,7 @@ async function pt4(e6, t6, n24) {
 }
 var import_compressjs, j11, ue7, fe5, Z12, Be4, Ne4, De5, $17, F15, de7, b24, X9, Le4, We4, Ye4, O11, W12, k13, M14, ye5, B5, N11, D13, L13, y20, xe6, ve5, Me4, ot4, Ft3, zt2;
 var init_chunk_ZXL7TQLN = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-ZXL7TQLN.js"() {
     init_chunk_X2AJGDEF();
     init_chunk_5QMZ5MUS();
     init_chunk_YNYSPYQ5();
@@ -48193,14 +48193,14 @@ var init_chunk_ZXL7TQLN = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js
+// node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js
 var tar_232RCEFK_exports = {};
 __export(tar_232RCEFK_exports, {
   flagsForFuzzing: () => zt2,
   tarCommand: () => Ft3
 });
 var init_tar_232RCEFK = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/tar-232RCEFK.js"() {
     init_chunk_ZXL7TQLN();
     init_chunk_X2AJGDEF();
     init_chunk_5QMZ5MUS();
@@ -48210,10 +48210,10 @@ var init_tar_232RCEFK = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js
 var xe7;
 var init_chunk_SYMJJMQ4 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-SYMJJMQ4.js"() {
     init_chunk_DXB73IDG();
     xe7 = o3((de10, pe7) => {
       (function(oe7, R13) {
@@ -48821,7 +48821,7 @@ var init_chunk_SYMJJMQ4 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js
 function St4(s10, e6) {
   let t6 = [], n24 = e6.exec(s10);
   for (; n24; ) {
@@ -49774,7 +49774,7 @@ function Mh(s10) {
 }
 var Xi, O12, Ke5, Us, Pt3, Js, z9, Mt4, Je6, C16, We5, xt5, Ge5, Tr2, Qe5, He5, Cr2, nn, Jt3, an2, se9, cn2, ie7, Te5, re5, Oe5, tt5, Zt3, hn2, ke5, mn2, yn2, to, io, Nn2, os2, Tn2, mo, go, bo, Cn2, Pn2, vo, Mo, Vn3, xo, lt5, ut6, dt6, gs2, Xn2, Dn2, Xo, Qo, Ce5, ta, na, ei, si, ca, ua, pa2, ya, oi, va, Ta, Ia, Ss2, gi, bi, Si, Ra, Ua, Pi, Ha, za, Za, be6, el, tl, sl, il, cl, ji, Nt5, V11, _e5, x26, fl, ul, dl, hl, Be5, Sl2, El, Al2, Ps2, we6, $l, As2, Ei, T12, Kl, Fe4, Rl, Yl, Ul, Jl, Qi, Gl, tr2, bt4, kh, qh, Ja, Ph, hg, pg;
 var init_chunk_XORM457F = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-XORM457F.js"() {
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
     init_chunk_7TSDKFEO();
@@ -54259,14 +54259,14 @@ EXAMPLES:
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js
+// node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js
 var yq_MJMAR36V_exports = {};
 __export(yq_MJMAR36V_exports, {
   flagsForFuzzing: () => pg,
   yqCommand: () => hg
 });
 var init_yq_MJMAR36V = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/yq-MJMAR36V.js"() {
     init_chunk_XORM457F();
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
@@ -54282,7 +54282,7 @@ var init_yq_MJMAR36V = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js
 function j12() {
   return /* @__PURE__ */ Object.create(null);
 }
@@ -54369,28 +54369,28 @@ async function k14(e6, o14) {
 }
 var w18;
 var init_chunk_F55TLFGB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-F55TLFGB.js"() {
     init_chunk_SYMJJMQ4();
     init_chunk_DXB73IDG();
     w18 = q3(xe7(), 1);
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js
+// node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js
 var xan_view_ECQUO7AJ_exports = {};
 __export(xan_view_ECQUO7AJ_exports, {
   cmdFlatten: () => W13,
   cmdView: () => k14
 });
 var init_xan_view_ECQUO7AJ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/xan-view-ECQUO7AJ.js"() {
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
     init_chunk_DXB73IDG();
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js
 function V12(e6) {
   let n24 = [], s10 = new q14(e6).tokenize(), r10 = 0, o14 = () => s10[r10] || { type: "eof", value: "", pos: 0 }, i11 = () => s10[r10++];
   for (; o14().type !== "eof"; ) {
@@ -55454,7 +55454,7 @@ async function Ve6(e6, n24) {
 }
 var q14, He6, Je7, R9, J11, U10, z10, nt6, me7, Be6, lt6, Ye5, ut7, fn2, dn2;
 var init_chunk_UNYNJIFU = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-UNYNJIFU.js"() {
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
     init_chunk_BBXLRYSX();
@@ -56080,14 +56080,14 @@ Run 'xan --help' for usage.
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js
+// node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js
 var xan_BXDXYEIB_exports = {};
 __export(xan_BXDXYEIB_exports, {
   flagsForFuzzing: () => dn2,
   xanCommand: () => fn2
 });
 var init_xan_BXDXYEIB = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/xan-BXDXYEIB.js"() {
     init_chunk_UNYNJIFU();
     init_chunk_F55TLFGB();
     init_chunk_SYMJJMQ4();
@@ -56104,9 +56104,9 @@ var init_xan_BXDXYEIB = __esm({
   }
 });
 
-// ../../../node_modules/sql.js/dist/sql-wasm.js
+// node_modules/sql.js/dist/sql-wasm.js
 var require_sql_wasm = __commonJS({
-  "../../../node_modules/sql.js/dist/sql-wasm.js"(exports, module) {
+  "node_modules/sql.js/dist/sql-wasm.js"(exports, module) {
     var initSqlJsPromise = void 0;
     var initSqlJs = function(moduleConfig) {
       if (initSqlJsPromise) {
@@ -58247,7 +58247,7 @@ var require_sql_wasm = __commonJS({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js
 import { randomBytes as z11 } from "node:crypto";
 import { existsSync as T13 } from "node:fs";
 import { dirname as X10, join as x27 } from "node:path";
@@ -58536,7 +58536,7 @@ async function ie9(e6, t6, r10) {
 }
 var import_sql, Z14, v25, ne10, $e7, ye7;
 var init_chunk_HWBSOZZR = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-HWBSOZZR.js"() {
     init_chunk_A5O5YHGN();
     init_chunk_24IMIIXA();
     init_chunk_5QMZ5MUS();
@@ -58600,7 +58600,7 @@ var init_chunk_HWBSOZZR = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js
+// node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js
 var sqlite3_56UMWEY3_exports = {};
 __export(sqlite3_56UMWEY3_exports, {
   _internals: () => ne10,
@@ -58608,7 +58608,7 @@ __export(sqlite3_56UMWEY3_exports, {
   sqlite3Command: () => $e7
 });
 var init_sqlite3_56UMWEY3 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/sqlite3-56UMWEY3.js"() {
     init_chunk_HWBSOZZR();
     init_chunk_A5O5YHGN();
     init_chunk_24IMIIXA();
@@ -58619,13 +58619,13 @@ var init_sqlite3_56UMWEY3 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js
+// node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js
 function _13() {
   return new r(E13.TOTAL);
 }
 var h16, a13, u11, s9, E13, S16, l6, R11, A11;
 var init_chunk_S4EYC6T6 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/chunk-S4EYC6T6.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_A5O5YHGN();
     init_chunk_IPJHKYVM();
@@ -59109,7 +59109,7 @@ ${this.commandName}: execution timeout exceeded
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js
+// node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js
 var python3_SG3DOKBZ_exports = {};
 __export(python3_SG3DOKBZ_exports, {
   _resetExecutionQueue: () => ie10,
@@ -59228,7 +59228,7 @@ async function j13(r10, e6, t6, o14 = []) {
 }
 var U12, H13, I15, k16, N13, Y10, ce10;
 var init_python3_SG3DOKBZ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/python3-SG3DOKBZ.js"() {
     init_chunk_S4EYC6T6();
     init_chunk_XHM67O4N();
     init_chunk_CWQS3NFK();
@@ -59280,7 +59280,7 @@ var init_python3_SG3DOKBZ = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js
+// node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js
 var js_exec_4CW5N6RM_exports = {};
 __export(js_exec_4CW5N6RM_exports, {
   jsExecCommand: () => de9,
@@ -59378,7 +59378,7 @@ async function X11(t6, e6, r10, s10 = [], n24, u12, a15) {
 }
 var N14, H14, B9, _14, i10, w19, c13, o13, $19, de9, fe8;
 var init_js_exec_4CW5N6RM = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/js-exec-4CW5N6RM.js"() {
     init_chunk_S4EYC6T6();
     init_chunk_XHM67O4N();
     init_chunk_CWQS3NFK();
@@ -59518,7 +59518,7 @@ ${_14}`, exitCode: 1 };
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js
+// node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js
 var curl_COE4TZE6_exports = {};
 __export(curl_COE4TZE6_exports, {
   curlCommand: () => q15
@@ -59751,7 +59751,7 @@ function H15(s10, t6, a15) {
 }
 var F18, q15;
 var init_curl_COE4TZE6 = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/curl-COE4TZE6.js"() {
     init_chunk_CWQS3NFK();
     init_chunk_44UOCSGV();
     init_chunk_74CEPOFO();
@@ -59787,7 +59787,7 @@ var init_curl_COE4TZE6 = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js
+// node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js
 var flag_coverage_LMTH7T5F_exports = {};
 __export(flag_coverage_LMTH7T5F_exports, {
   emitFlagCoverage: () => Fa
@@ -59801,7 +59801,7 @@ function Fa(r10, o14, Dr4) {
 }
 var Er2, Br;
 var init_flag_coverage_LMTH7T5F = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/flag-coverage-LMTH7T5F.js"() {
     init_chunk_ZXL7TQLN();
     init_chunk_XORM457F();
     init_chunk_UNYNJIFU();
@@ -59908,7 +59908,7 @@ var init_flag_coverage_LMTH7T5F = __esm({
   }
 });
 
-// ../../../node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js
+// node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js
 var expansion_ENLSRCXJ_exports = {};
 __export(expansion_ENLSRCXJ_exports, {
   escapeGlobChars: () => X2,
@@ -59925,7 +59925,7 @@ __export(expansion_ENLSRCXJ_exports, {
   isWordFullyQuoted: () => Al
 });
 var init_expansion_ENLSRCXJ = __esm({
-  "../../../node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js"() {
+  "node_modules/just-bash/dist/bundle/chunks/expansion-ENLSRCXJ.js"() {
     init_chunk_FEIOJCZD();
     init_chunk_YNYSPYQ5();
     init_chunk_GFQRA5P5();
@@ -59936,7 +59936,7 @@ var init_expansion_ENLSRCXJ = __esm({
 // dist/src/shell/deeplake-shell.js
 import { createInterface } from "node:readline";
 
-// ../../../node_modules/just-bash/dist/bundle/index.js
+// node_modules/just-bash/dist/bundle/index.js
 init_chunk_FEIOJCZD();
 init_chunk_XHM67O4N();
 init_chunk_CWQS3NFK();
@@ -67556,11 +67556,11 @@ var DeeplakeFs = class _DeeplakeFs {
   }
 };
 
-// ../../../node_modules/yargs-parser/build/lib/index.js
+// node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
 import { normalize, resolve as resolve4 } from "path";
 
-// ../../../node_modules/yargs-parser/build/lib/string-utils.js
+// node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase(str) {
   const isCamelCase = str !== str.toLowerCase() && str !== str.toUpperCase();
   if (!isCamelCase) {
@@ -67614,7 +67614,7 @@ function looksLikeNumber(x28) {
   return /^[-]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x28);
 }
 
-// ../../../node_modules/yargs-parser/build/lib/tokenize-arg-string.js
+// node_modules/yargs-parser/build/lib/tokenize-arg-string.js
 function tokenizeArgString(argString) {
   if (Array.isArray(argString)) {
     return argString.map((e6) => typeof e6 !== "string" ? e6 + "" : e6);
@@ -67646,7 +67646,7 @@ function tokenizeArgString(argString) {
   return args;
 }
 
-// ../../../node_modules/yargs-parser/build/lib/yargs-parser-types.js
+// node_modules/yargs-parser/build/lib/yargs-parser-types.js
 var DefaultValuesForTypeKey;
 (function(DefaultValuesForTypeKey2) {
   DefaultValuesForTypeKey2["BOOLEAN"] = "boolean";
@@ -67655,7 +67655,7 @@ var DefaultValuesForTypeKey;
   DefaultValuesForTypeKey2["ARRAY"] = "array";
 })(DefaultValuesForTypeKey || (DefaultValuesForTypeKey = {}));
 
-// ../../../node_modules/yargs-parser/build/lib/yargs-parser.js
+// node_modules/yargs-parser/build/lib/yargs-parser.js
 var mixin;
 var YargsParser = class {
   constructor(_mixin) {
@@ -68495,7 +68495,7 @@ function stripQuotes(val) {
   return typeof val === "string" && (val[0] === "'" || val[0] === '"') && val[val.length - 1] === val[0] ? val.substring(1, val.length - 1) : val;
 }
 
-// ../../../node_modules/yargs-parser/build/lib/index.js
+// node_modules/yargs-parser/build/lib/index.js
 import { readFileSync as readFileSync2 } from "fs";
 import { createRequire } from "node:module";
 var _a3;

--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -12,6 +12,7 @@
  *   node auth-login.js invite <email> <mode> — invite member
  *   node auth-login.js members            — list members
  *   node auth-login.js whoami             — show current user/org
+ *   node auth-login.js sessions prune     — list/delete own sessions
  *   node auth-login.js update            — update plugin to latest version
  *   node auth-login.js autoupdate [on|off] — toggle automatic updates (default: on)
  */
@@ -21,6 +22,7 @@ import {
   listWorkspaces, switchWorkspace,
   inviteMember, listMembers, removeMember,
 } from "./auth.js";
+import { sessionPrune } from "./session-prune.js";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -105,6 +107,16 @@ async function main(): Promise<void> {
       break;
     }
 
+    case "sessions": {
+      const sub = args[1];
+      if (sub === "prune") {
+        await sessionPrune(args.slice(2));
+      } else {
+        console.log("Usage: sessions prune [--all | --before <date> | --session-id <id>] [--yes]");
+      }
+      break;
+    }
+
     case "autoupdate": {
       if (!creds) { console.log("Not logged in."); process.exit(1); }
       const val = args[1]?.toLowerCase();
@@ -123,7 +135,7 @@ async function main(): Promise<void> {
     }
 
     default:
-      console.log("Commands: login, whoami, org list, org switch, workspaces, workspace, invite, members, remove, autoupdate");
+      console.log("Commands: login, whoami, org list, org switch, workspaces, workspace, sessions prune, invite, members, remove, autoupdate");
   }
 }
 

--- a/src/commands/session-prune.ts
+++ b/src/commands/session-prune.ts
@@ -13,7 +13,7 @@
 
 import { loadConfig, type Config } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
-import { sqlStr, sqlLike } from "../utils/sql.js";
+import { sqlStr } from "../utils/sql.js";
 import { createInterface } from "node:readline";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -68,14 +68,11 @@ function confirm(message: string): Promise<boolean> {
 /**
  * Extract session ID from a session path.
  * Path format: /sessions/<user>/<user>_<org>_<workspace>_<sessionId>.jsonl
+ * Uses the same regex as deeplake-fs.ts to handle underscores in user/org/workspace.
  */
 function extractSessionId(path: string): string {
-  const filename = path.split("/").pop() ?? "";
-  // Remove .jsonl, then take the last segment after the third underscore
-  const base = filename.replace(/\.jsonl$/, "");
-  const parts = base.split("_");
-  // session ID is everything after <user>_<org>_<workspace>_
-  return parts.length >= 4 ? parts.slice(3).join("_") : base;
+  const m = path.match(/\/sessions\/[^/]+\/[^/]+_([^.]+)\.jsonl$/);
+  return m ? m[1] : path.split("/").pop()?.replace(/\.jsonl$/, "") ?? path;
 }
 
 // ── Core ─────────────────────────────────────────────────────────────────────

--- a/src/commands/session-prune.ts
+++ b/src/commands/session-prune.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+/**
+ * Session prune CLI — scoped cleanup of session data by the logged-in author.
+ *
+ * Usage:
+ *   hivemind sessions prune                          — list pruneable sessions (dry run)
+ *   hivemind sessions prune --before 2026-04-01      — delete sessions older than date
+ *   hivemind sessions prune --session-id <id>        — delete a specific session
+ *   hivemind sessions prune --all                    — delete all own sessions
+ *   hivemind sessions prune ... --yes                — skip confirmation prompt
+ */
+
+import { loadConfig, type Config } from "../config.js";
+import { DeeplakeApi } from "../deeplake-api.js";
+import { sqlStr, sqlLike } from "../utils/sql.js";
+import { createInterface } from "node:readline";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface SessionInfo {
+  path: string;
+  rowCount: number;
+  firstEvent: string;
+  lastEvent: string;
+  project: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): {
+  before?: string;
+  sessionId?: string;
+  all: boolean;
+  yes: boolean;
+} {
+  let before: string | undefined;
+  let sessionId: string | undefined;
+  let all = false;
+  let yes = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--before" && argv[i + 1]) {
+      before = argv[++i];
+    } else if (arg === "--session-id" && argv[i + 1]) {
+      sessionId = argv[++i];
+    } else if (arg === "--all") {
+      all = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      yes = true;
+    }
+  }
+
+  return { before, sessionId, all, yes };
+}
+
+function confirm(message: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise(resolve => {
+    rl.question(`${message} [y/N] `, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}
+
+/**
+ * Extract session ID from a session path.
+ * Path format: /sessions/<user>/<user>_<org>_<workspace>_<sessionId>.jsonl
+ */
+function extractSessionId(path: string): string {
+  const filename = path.split("/").pop() ?? "";
+  // Remove .jsonl, then take the last segment after the third underscore
+  const base = filename.replace(/\.jsonl$/, "");
+  const parts = base.split("_");
+  // session ID is everything after <user>_<org>_<workspace>_
+  return parts.length >= 4 ? parts.slice(3).join("_") : base;
+}
+
+// ── Core ─────────────────────────────────────────────────────────────────────
+
+async function listSessions(
+  api: DeeplakeApi,
+  sessionsTable: string,
+  author: string,
+): Promise<SessionInfo[]> {
+  const rows = await api.query(
+    `SELECT path, COUNT(*) as cnt, MIN(creation_date) as first_event, ` +
+    `MAX(creation_date) as last_event, MAX(project) as project ` +
+    `FROM "${sessionsTable}" WHERE author = '${sqlStr(author)}' ` +
+    `GROUP BY path ORDER BY first_event DESC`
+  );
+
+  return rows.map(r => ({
+    path: String(r.path),
+    rowCount: Number(r.cnt),
+    firstEvent: String(r.first_event),
+    lastEvent: String(r.last_event),
+    project: String(r.project ?? ""),
+  }));
+}
+
+async function deleteSessions(
+  config: Config,
+  sessionPaths: string[],
+): Promise<{ sessionsDeleted: number; summariesDeleted: number }> {
+  if (sessionPaths.length === 0) return { sessionsDeleted: 0, summariesDeleted: 0 };
+
+  const sessionsApi = new DeeplakeApi(
+    config.token, config.apiUrl, config.orgId, config.workspaceId,
+    config.sessionsTableName,
+  );
+  const memoryApi = new DeeplakeApi(
+    config.token, config.apiUrl, config.orgId, config.workspaceId,
+    config.tableName,
+  );
+
+  let sessionsDeleted = 0;
+  let summariesDeleted = 0;
+
+  for (const sessionPath of sessionPaths) {
+    // Delete all rows for this session from the sessions table
+    await sessionsApi.query(
+      `DELETE FROM "${config.sessionsTableName}" WHERE path = '${sqlStr(sessionPath)}'`
+    );
+    sessionsDeleted++;
+
+    // Delete the corresponding summary from the memory table
+    // Summary path: /summaries/<user>/<sessionId>.md
+    const sessionId = extractSessionId(sessionPath);
+    const summaryPath = `/summaries/${config.userName}/${sessionId}.md`;
+
+    const existing = await memoryApi.query(
+      `SELECT path FROM "${config.tableName}" WHERE path = '${sqlStr(summaryPath)}' LIMIT 1`
+    );
+    if (existing.length > 0) {
+      await memoryApi.query(
+        `DELETE FROM "${config.tableName}" WHERE path = '${sqlStr(summaryPath)}'`
+      );
+      summariesDeleted++;
+    }
+  }
+
+  return { sessionsDeleted, summariesDeleted };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+export async function sessionPrune(argv: string[]): Promise<void> {
+  const config = loadConfig();
+  if (!config) {
+    console.error("Not logged in. Run: deeplake login");
+    process.exit(1);
+  }
+
+  const { before, sessionId, all, yes } = parseArgs(argv);
+  const author = config.userName;
+
+  const sessionsApi = new DeeplakeApi(
+    config.token, config.apiUrl, config.orgId, config.workspaceId,
+    config.sessionsTableName,
+  );
+
+  // Fetch all sessions for this author
+  const sessions = await listSessions(sessionsApi, config.sessionsTableName, author);
+
+  if (sessions.length === 0) {
+    console.log(`No sessions found for author "${author}".`);
+    return;
+  }
+
+  // Filter based on flags
+  let targets: SessionInfo[];
+
+  if (sessionId) {
+    targets = sessions.filter(s => extractSessionId(s.path) === sessionId);
+    if (targets.length === 0) {
+      console.error(`Session not found: ${sessionId}`);
+      console.error(`\nYour sessions:`);
+      for (const s of sessions.slice(0, 10)) {
+        console.error(`  ${extractSessionId(s.path)}  ${s.firstEvent.slice(0, 10)}  ${s.project}`);
+      }
+      process.exit(1);
+    }
+  } else if (before) {
+    const cutoff = new Date(before);
+    if (isNaN(cutoff.getTime())) {
+      console.error(`Invalid date: ${before}`);
+      process.exit(1);
+    }
+    targets = sessions.filter(s => new Date(s.lastEvent) < cutoff);
+  } else if (all) {
+    targets = sessions;
+  } else {
+    // Dry run — just list sessions
+    console.log(`Sessions for "${author}" (${sessions.length} total):\n`);
+    console.log("  Session ID".padEnd(42) + "Date".padEnd(14) + "Events".padEnd(10) + "Project");
+    console.log("  " + "─".repeat(80));
+    for (const s of sessions) {
+      const id = extractSessionId(s.path);
+      const date = s.firstEvent.slice(0, 10);
+      console.log(`  ${id.padEnd(40)}${date.padEnd(14)}${String(s.rowCount).padEnd(10)}${s.project}`);
+    }
+    console.log(`\nTo delete, use: --all, --before <date>, or --session-id <id>`);
+    return;
+  }
+
+  if (targets.length === 0) {
+    console.log("No sessions match the given criteria.");
+    return;
+  }
+
+  // Show what will be deleted
+  console.log(`Will delete ${targets.length} session(s) for "${author}":\n`);
+  for (const s of targets) {
+    const id = extractSessionId(s.path);
+    console.log(`  ${id}  ${s.firstEvent.slice(0, 10)}  ${s.rowCount} events  ${s.project}`);
+  }
+  console.log();
+
+  // Confirm unless --yes
+  if (!yes) {
+    const ok = await confirm("Proceed with deletion?");
+    if (!ok) {
+      console.log("Aborted.");
+      return;
+    }
+  }
+
+  const { sessionsDeleted, summariesDeleted } = await deleteSessions(
+    config,
+    targets.map(t => t.path),
+  );
+
+  console.log(`Deleted ${sessionsDeleted} session(s) and ${summariesDeleted} summary file(s).`);
+}


### PR DESCRIPTION
## Summary

- Add `sessions prune` CLI subcommand for scoped session cleanup by author
- Supports `--all`, `--before <date>`, `--session-id <id>` modes with `--yes` to skip confirmation
- Deletes both session rows (sessions table) and corresponding summary files (memory table)
- Only operates on sessions owned by the logged-in user

## Test plan

- [x] 174 unit tests passing (vitest)
- [x] E2E `claude -p --plugin-dir`: capture creates sessions, `sessions prune` lists them, `--all --yes` deletes sessions + summaries
- [x] Verified empty state message after full prune
- [x] Tested against `memory_test`/`sessions_test` tables to avoid polluting production data

Closes #34