### PR TITLE
fix: codex auto-update install path + SKILL.md bash guidance

### DIFF
--- a/claude-code/skills/hivemind-memory/SKILL.md
+++ b/claude-code/skills/hivemind-memory/SKILL.md
@@ -48,6 +48,10 @@ The auth command path is injected at session start. Use the exact path from the 
 - `node "<AUTH_CMD>" remove <user-id>` — remove member
 - `node "<AUTH_CMD>" --help` — show all commands
 
+## Important: Bash Only
+
+Only use bash commands (cat, ls, grep, echo, jq, head, tail, sed, awk, etc.) to interact with `~/.deeplake/memory/`. Do NOT use python, python3, node, curl, or other interpreters — they are not available in the memory filesystem. If a task seems to require Python, rewrite it using bash tools (e.g., `cat file.json | jq 'keys | length'`).
+
 ## Limits
 
 If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.

--- a/codex/bundle/session-start.js
+++ b/codex/bundle/session-start.js
@@ -434,7 +434,7 @@ async function main() {
           log3(`autoupdate: updating ${current} \u2192 ${latest}`);
           try {
             const tag = `v${latest}`;
-            const findCmd = `PLUGIN_DIR=$(find ~/.codex/plugins/cache -maxdepth 3 -name "hivemind" -type d 2>/dev/null | head -1); if [ -n "$PLUGIN_DIR" ]; then VERSION_DIR=$(ls -1d "$PLUGIN_DIR"/*/ 2>/dev/null | tail -1); TMPDIR=$(mktemp -d); git clone --depth 1 --branch ${tag} -q https://github.com/activeloopai/hivemind.git "$TMPDIR/hivemind" 2>/dev/null && cp -r "$TMPDIR/hivemind/codex/"* "$VERSION_DIR/" 2>/dev/null; rm -rf "$TMPDIR"; fi`;
+            const findCmd = `INSTALL_DIR=""; CACHE_DIR=$(find ~/.codex/plugins/cache -maxdepth 3 -name "hivemind" -type d 2>/dev/null | head -1); if [ -n "$CACHE_DIR" ]; then INSTALL_DIR=$(ls -1d "$CACHE_DIR"/*/ 2>/dev/null | tail -1); fi; if [ -z "$INSTALL_DIR" ] && [ -d ~/.codex/hivemind ]; then INSTALL_DIR=~/.codex/hivemind; fi; if [ -n "$INSTALL_DIR" ]; then TMPDIR=$(mktemp -d); git clone --depth 1 --branch ${tag} -q https://github.com/activeloopai/hivemind.git "$TMPDIR/hivemind" 2>/dev/null && cp -r "$TMPDIR/hivemind/codex/"* "$INSTALL_DIR/" 2>/dev/null; rm -rf "$TMPDIR"; fi`;
             execSync2(findCmd, { stdio: "ignore", timeout: 6e4 });
             updateNotice = `
 

--- a/codex/skills/deeplake-memory/SKILL.md
+++ b/codex/skills/deeplake-memory/SKILL.md
@@ -45,6 +45,10 @@ Each argument is separate — do NOT quote subcommands together. The auth comman
 - `node "<path>/auth-login.js" remove <user-id>` — remove member
 - `node "<path>/auth-login.js" --help` — show all commands
 
+## Important: Bash Only
+
+Only use bash commands (cat, ls, grep, echo, jq, head, tail, sed, awk, etc.) to interact with `~/.deeplake/memory/`. Do NOT use python, python3, node, curl, or other interpreters — they are not available in the memory filesystem. If a task seems to require Python, rewrite it using bash tools (e.g., `cat file.json | jq 'keys | length'`).
+
 ## Limits
 
 Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.

--- a/src/hooks/codex/session-start.ts
+++ b/src/hooks/codex/session-start.ts
@@ -186,12 +186,15 @@ async function main(): Promise<void> {
           log(`autoupdate: updating ${current} → ${latest}`);
           try {
             const tag = `v${latest}`;
-            const findCmd = `PLUGIN_DIR=$(find ~/.codex/plugins/cache -maxdepth 3 -name "hivemind" -type d 2>/dev/null | head -1); ` +
-              `if [ -n "$PLUGIN_DIR" ]; then ` +
-              `VERSION_DIR=$(ls -1d "$PLUGIN_DIR"/*/ 2>/dev/null | tail -1); ` +
+            // Try two install locations: ~/.codex/plugins/cache (plugin system) and ~/.codex/hivemind/ (manual install)
+            const findCmd = `INSTALL_DIR=""; ` +
+              `CACHE_DIR=$(find ~/.codex/plugins/cache -maxdepth 3 -name "hivemind" -type d 2>/dev/null | head -1); ` +
+              `if [ -n "$CACHE_DIR" ]; then INSTALL_DIR=$(ls -1d "$CACHE_DIR"/*/ 2>/dev/null | tail -1); fi; ` +
+              `if [ -z "$INSTALL_DIR" ] && [ -d ~/.codex/hivemind ]; then INSTALL_DIR=~/.codex/hivemind; fi; ` +
+              `if [ -n "$INSTALL_DIR" ]; then ` +
               `TMPDIR=$(mktemp -d); ` +
               `git clone --depth 1 --branch ${tag} -q https://github.com/activeloopai/hivemind.git "$TMPDIR/hivemind" 2>/dev/null && ` +
-              `cp -r "$TMPDIR/hivemind/codex/"* "$VERSION_DIR/" 2>/dev/null; ` +
+              `cp -r "$TMPDIR/hivemind/codex/"* "$INSTALL_DIR/" 2>/dev/null; ` +
               `rm -rf "$TMPDIR"; fi`;
             execSync(findCmd, { stdio: "ignore", timeout: 60_000 });
             updateNotice = `\n\nHivemind auto-updated: ${current} → ${latest}. Restart Codex to apply.`;


### PR DESCRIPTION
## Summary

Followup to #40 addressing Kamo's review feedback.

- **Codex auto-update install path**: The update script searched only `~/.codex/plugins/cache` but manual installs live at `~/.codex/hivemind/`. Now checks both locations. Verified end-to-end: version 0.6.7 -> 0.6.19 auto-update succeeds.

- **SKILL.md bash-only guidance**: Added "Important: Bash Only" section to both CC and Codex SKILL.md files so the guidance persists throughout the session if the skill is loaded, not just at session start.

## Test plan

- [x] 490 tests pass
- [x] Codex auto-update tested: 0.6.7 detected, 0.6.19 cloned and installed to `~/.codex/hivemind/`
- [x] Second run confirms version 0.6.19 up to date (no update loop)