### PR TITLE
fix: listWorkspaces — API returns {data:[...]} not plain array

### DIFF
--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -130,7 +130,7 @@ async function switchOrg(orgId, orgName) {
 }
 async function listWorkspaces(token, apiUrl = DEFAULT_API_URL, orgId) {
   const raw = await apiGet("/workspaces", token, apiUrl, orgId);
-  const data = raw?.data ?? raw;
+  const data = raw.data ?? raw;
   return Array.isArray(data) ? data : [];
 }
 async function switchWorkspace(workspaceId) {

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -129,7 +129,8 @@ async function switchOrg(orgId, orgName) {
   saveCredentials({ ...creds, orgId, orgName });
 }
 async function listWorkspaces(token, apiUrl = DEFAULT_API_URL, orgId) {
-  const data = await apiGet("/workspaces", token, apiUrl, orgId);
+  const raw = await apiGet("/workspaces", token, apiUrl, orgId);
+  const data = raw?.data ?? raw;
   return Array.isArray(data) ? data : [];
 }
 async function switchWorkspace(workspaceId) {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -192,7 +192,8 @@ export async function switchOrg(orgId: string, orgName?: string): Promise<void> 
 // ── Workspace Commands ───────────────────────────────────────────────────────
 
 export async function listWorkspaces(token: string, apiUrl = DEFAULT_API_URL, orgId?: string): Promise<{ id: string; name: string }[]> {
-  const data = await apiGet("/workspaces", token, apiUrl, orgId) as { id: string; name: string }[];
+  const raw = await apiGet("/workspaces", token, apiUrl, orgId) as any;
+  const data = raw?.data ?? raw;
   return Array.isArray(data) ? data : [];
 }
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -192,8 +192,8 @@ export async function switchOrg(orgId: string, orgName?: string): Promise<void> 
 // ── Workspace Commands ───────────────────────────────────────────────────────
 
 export async function listWorkspaces(token: string, apiUrl = DEFAULT_API_URL, orgId?: string): Promise<{ id: string; name: string }[]> {
-  const raw = await apiGet("/workspaces", token, apiUrl, orgId) as any;
-  const data = raw?.data ?? raw;
+  const raw = await apiGet("/workspaces", token, apiUrl, orgId) as { data?: { id: string; name: string }[] } | { id: string; name: string }[];
+  const data = (raw as { data?: { id: string; name: string }[] }).data ?? (raw as { id: string; name: string }[]);
   return Array.isArray(data) ? data : [];
 }
 


### PR DESCRIPTION
The /workspaces endpoint returns `{data: [...]}` but listWorkspaces expected a plain array. Added `raw?.data ?? raw` unwrapping.