### PR TITLE
Fix MODULE_TYPELESS_PACKAGE_JSON warning

### DIFF
--- a/claude-code/bundle/package.json
+++ b/claude-code/bundle/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/codex/bundle/package.json
+++ b/codex/bundle/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,5 +1,7 @@
 import { build } from "esbuild";
-import { chmodSync } from "node:fs";
+import { chmodSync, writeFileSync } from "node:fs";
+
+const esmPackageJson = '{"type":"module"}\n';
 
 // Claude Code plugin
 const ccHooks = [
@@ -32,6 +34,7 @@ await build({
 for (const h of ccAll) {
   chmodSync(`claude-code/bundle/${h.out}.js`, 0o755);
 }
+writeFileSync("claude-code/bundle/package.json", esmPackageJson);
 
 // Codex plugin
 const codexHooks = [
@@ -64,6 +67,7 @@ await build({
 for (const h of codexAll) {
   chmodSync(`codex/bundle/${h.out}.js`, 0o755);
 }
+writeFileSync("codex/bundle/package.json", esmPackageJson);
 
 // OpenClaw plugin
 await build({
@@ -74,5 +78,6 @@ await build({
   outdir: "openclaw/dist",
   external: ["node:*"],
 });
+writeFileSync("openclaw/dist/package.json", esmPackageJson);
 
 console.log(`Built: ${ccAll.length} CC + ${codexAll.length} Codex + 1 OpenClaw bundles`);


### PR DESCRIPTION
## Summary
- esbuild outputs ESM (`format: "esm"`) but bundle directories had no `package.json` with `"type": "module"`, so Node reparsed every `.js` file as CommonJS before detecting ESM syntax
- Added `writeFileSync` calls in `esbuild.config.mjs` to emit `{"type":"module"}` into `claude-code/bundle/`, `codex/bundle/`, and `openclaw/dist/` after each build step
- Eliminates the `MODULE_TYPELESS_PACKAGE_JSON` warning and the associated reparse overhead

## Test plan
- [x] `npm run build` succeeds
- [x] `node bundle/commands/auth-login.js` runs without warning