### PR TITLE
fix: auto-update broken since Claude Code v2.1.94 (cache layout)

### DIFF
--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -343,6 +343,13 @@ function wikiLog(msg) {
   }
 }
 function getInstalledVersion() {
+  try {
+    const pluginJson = join4(__bundleDir, "..", ".claude-plugin", "plugin.json");
+    const plugin = JSON.parse(readFileSync3(pluginJson, "utf-8"));
+    if (plugin.version)
+      return plugin.version;
+  } catch {
+  }
   let dir = __bundleDir;
   for (let i = 0; i < 5; i++) {
     const candidate = join4(dir, "package.json");

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -364,6 +364,13 @@ Debugging: Set DEEPLAKE_DEBUG=1 to enable verbose logging to ~/.deeplake/hook-de
 var GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/hivemind/main/package.json";
 var VERSION_CHECK_TIMEOUT = 3e3;
 function getInstalledVersion() {
+  try {
+    const pluginJson = join4(__bundleDir, "..", ".claude-plugin", "plugin.json");
+    const plugin = JSON.parse(readFileSync3(pluginJson, "utf-8"));
+    if (plugin.version)
+      return plugin.version;
+  } catch {
+  }
   let dir = __bundleDir;
   for (let i = 0; i < 5; i++) {
     const candidate = join4(dir, "package.json");

--- a/claude-code/tests/session-start.test.ts
+++ b/claude-code/tests/session-start.test.ts
@@ -64,6 +64,33 @@ describe("claude-code bundle: session-start-setup.js exists", () => {
   });
 });
 
+// ── getInstalledVersion: must read .claude-plugin/plugin.json ────────────────
+
+describe("claude-code: version detection from plugin.json", () => {
+  it("session-start.js reads version from .claude-plugin/plugin.json", () => {
+    // This is the cache layout — no package.json with version exists,
+    // only .claude-plugin/plugin.json has it. If this test fails,
+    // auto-update will break for all installed users (CC v2.1.94+).
+    const bundle = readFileSync(join(bundleDir, "session-start.js"), "utf-8");
+    expect(bundle).toContain(".claude-plugin");
+    expect(bundle).toContain("plugin.json");
+  });
+
+  it("session-start-setup.js reads version from .claude-plugin/plugin.json", () => {
+    const bundle = readFileSync(join(bundleDir, "session-start-setup.js"), "utf-8");
+    expect(bundle).toContain(".claude-plugin");
+    expect(bundle).toContain("plugin.json");
+  });
+
+  it(".claude-plugin/plugin.json exists and has a version", () => {
+    const pluginJsonPath = join(ccRoot, ".claude-plugin", "plugin.json");
+    expect(existsSync(pluginJsonPath)).toBe(true);
+    const plugin = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    expect(plugin.version).toBeDefined();
+    expect(plugin.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
 // ── session-start.js integration tests ──────────────────────────────────────
 
 function runHook(bundle: string, input: Record<string, unknown>, extraEnv: Record<string, string> = {}): string {

--- a/src/hooks/session-start-setup.ts
+++ b/src/hooks/session-start-setup.ts
@@ -35,6 +35,11 @@ function wikiLog(msg: string): void {
 }
 
 function getInstalledVersion(): string | null {
+  try {
+    const pluginJson = join(__bundleDir, "..", ".claude-plugin", "plugin.json");
+    const plugin = JSON.parse(readFileSync(pluginJson, "utf-8"));
+    if (plugin.version) return plugin.version;
+  } catch { /* fall through */ }
   let dir = __bundleDir;
   for (let i = 0; i < 5; i++) {
     const candidate = join(dir, "package.json");

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -57,6 +57,12 @@ const GITHUB_RAW_PKG = "https://raw.githubusercontent.com/activeloopai/hivemind/
 const VERSION_CHECK_TIMEOUT = 3000; // 3s — don't block session start
 
 function getInstalledVersion(): string | null {
+  // Try plugin manifest first (works in both cache and marketplace layouts)
+  try {
+    const pluginJson = join(__bundleDir, "..", ".claude-plugin", "plugin.json");
+    const plugin = JSON.parse(readFileSync(pluginJson, "utf-8"));
+    if (plugin.version) return plugin.version;
+  } catch { /* fall through */ }
   // Walk up from the bundle directory to find the nearest package.json.
   // Depending on install method the layout varies:
   //   marketplace: <root>/claude-code/bundle/  → package.json is 2 levels up


### PR DESCRIPTION
## Problem

Auto-update has been silently broken for all Claude Code users since **v2.1.94** (April 7, 2026 — 9 days ago).

In v2.1.94, Claude Code changed `CLAUDE_PLUGIN_ROOT` to resolve to the **cache directory** instead of the marketplace source. The cache layout does not include a `package.json` with the plugin version:

```
# Marketplace (before v2.1.94) — worked
marketplaces/hivemind/package.json → {"name":"hivemind","version":"0.6.30"}

# Cache (v2.1.94+) — broken
cache/hivemind/hivemind/0.6.31/package.json → does not exist
cache/hivemind/hivemind/0.6.31/bundle/package.json → {"type":"module"} (no version)
```

`getInstalledVersion()` walks up from `bundle/` looking for `package.json` with `name: "hivemind"`, never finds one, returns `null`, and the version check is skipped entirely.

The Codex hook was not affected because it already reads `.codex-plugin/plugin.json` as a primary source.

## Fix

Read `.claude-plugin/plugin.json` as the primary version source in both `session-start.ts` and `session-start-setup.ts`, matching what Codex already does. This file exists in both cache and marketplace layouts:

```
cache/hivemind/hivemind/0.6.31/.claude-plugin/plugin.json → {"name":"hivemind","version":"0.6.31"}
```

Also removes the last `deeplake_sync_table()` call that was missed in the previous cleanup.

## Test plan

- [x] 534 unit tests passing
- [x] 3 new tests: verify bundles contain plugin.json read + plugin.json exists with valid semver
- [x] Tested manually from cache directory: `getInstalledVersion()` returns `"0.6.31"` (was `null`)
- [x] Verified auto-update log: `"version up to date: 0.6.31"` (was silent skip)