### PR TITLE
fix: respect DEEPLAKE_CAPTURE=false in claude-code session-start hook

### DIFF
--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -455,6 +455,7 @@ async function main() {
       }
     }
   }
+  const captureEnabled = process.env.DEEPLAKE_CAPTURE !== "false";
   if (input.session_id && creds?.token) {
     try {
       const config = loadConfig();
@@ -464,8 +465,12 @@ async function main() {
         const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, table);
         await api.ensureTable();
         await api.ensureSessionsTable(sessionsTable);
-        await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);
-        log3("placeholder created");
+        if (captureEnabled) {
+          await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);
+          log3("placeholder created");
+        } else {
+          log3("placeholder skipped (DEEPLAKE_CAPTURE=false)");
+        }
       }
     } catch (e) {
       log3(`placeholder failed: ${e.message}`);

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -171,7 +171,12 @@ async function main(): Promise<void> {
     }
   }
 
-  // Create placeholder summary + ensure sessions table via direct SQL (no DeeplakeFs bootstrap)
+  // Ensure tables exist and (when capture is enabled) create the placeholder
+  // summary via direct SQL. Tables must always be synced so queries return
+  // fresh data — only the placeholder INSERT is skipped when DEEPLAKE_CAPTURE=false
+  // (benchmark runs, explicit opt-out). Mirrors the guard already in
+  // session-start-setup.ts / session-end.ts / codex hooks.
+  const captureEnabled = process.env.DEEPLAKE_CAPTURE !== "false";
   if (input.session_id && creds?.token) {
     try {
       const config = loadConfig();
@@ -179,11 +184,14 @@ async function main(): Promise<void> {
         const table = config.tableName;
         const sessionsTable = config.sessionsTableName;
         const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, table);
-        // Ensure both tables exist (once per session)
         await api.ensureTable();
         await api.ensureSessionsTable(sessionsTable);
-        await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);
-        log("placeholder created");
+        if (captureEnabled) {
+          await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);
+          log("placeholder created");
+        } else {
+          log("placeholder skipped (DEEPLAKE_CAPTURE=false)");
+        }
       }
     } catch (e: any) {
       log(`placeholder failed: ${e.message}`);


### PR DESCRIPTION
## Summary

- The sync claude-code `session-start.ts` hook was creating placeholder summaries unconditionally, ignoring `DEEPLAKE_CAPTURE=false`.
- Commit [39a5a42](https://github.com/activeloopai/hivemind/commit/39a5a42) added the `captureEnabled` guard to `session-end.ts`, `session-start-setup.ts`, and the codex hooks, but `session-start.ts` was missed after the sync/async split.
- This PR adds the same guard around `createPlaceholder`. `ensureTable` / `ensureSessionsTable` still run unconditionally so fast-path queries continue to see fresh data.

## Impact observed

During a 250-question locomo retrieval benchmark the memory table grew from the expected **272 rows** (one summary per session) to **416 rows** — 144 stray placeholder rows written by each `claude -p` subprocess the benchmark spawned, despite those subprocesses being launched with `DEEPLAKE_CAPTURE=false`. The extra rows diluted grep/BM25 results and measurably hurt retrieval accuracy for that run.

## Test plan

- [ ] `npm run ci` (typecheck + vitest)
- [ ] Start a session with `DEEPLAKE_CAPTURE=false claude -p 'hello'` and confirm no new row appears in the `memory` table and the wiki log shows `placeholder skipped (DEEPLAKE_CAPTURE=false)`.
- [ ] Start a normal session without the env var and confirm the placeholder is still created (default behavior unchanged).
- [ ] Re-run the locomo plugin benchmark and verify the memory table stays at 272 rows.