### PR TITLE
Fix OpenClaw plugin: stop replacing memory-core, add org commands, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,24 @@ The plugin auto-updates on each session start. To manually update:
 #### Install from ClawHub (Telegram, TUI, WhatsApp):
 
 ```
-openclaw plugins install hivemind
+openclaw plugins install clawhub:hivemind
 ```
 
-Send a message. The plugin sends you an auth link. Click, sign in, done.
+Then type `/hivemind_login` in chat, click the auth link, and sign in.
+
+#### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/hivemind_login` | Sign in via device flow |
+| `/hivemind_capture` | Toggle capture on/off |
+| `/hivemind_whoami` | Show current org and workspace |
+| `/hivemind_orgs` | List organizations |
+| `/hivemind_switch_org <name>` | Switch organization |
+| `/hivemind_workspaces` | List workspaces |
+| `/hivemind_switch_workspace <id>` | Switch workspace |
+
+Auto-recall and auto-capture are enabled by default. Data is stored in the same `sessions` table as Claude Code and Codex.
 </details>
 <details>
   <summary><b> Codex Setup </b></summary>

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,0 +1,64 @@
+# Hivemind
+
+Cloud-backed shared memory for AI agents. Install once, memory persists across sessions, machines, and channels — and is shared with every teammate in your Deeplake org.
+
+Powered by [Deeplake](https://deeplake.ai/hivemind).
+
+## Install
+
+```bash
+openclaw plugins install clawhub:hivemind
+```
+
+Then in chat:
+
+```
+/hivemind_login
+```
+
+Click the auth link, sign in, send another message. That's it.
+
+## What it does
+
+- **Auto-recall** — before each agent turn, relevant memories surface automatically via keyword search.
+- **Auto-capture** — after each turn, the conversation is stored to your Deeplake workspace.
+- **Cross-platform** — same memory accessible from Claude Code, Codex CLI, and OpenClaw plugins.
+- **Team-wide** — every user in your Deeplake org shares the same memory.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `/hivemind_login` | Sign in via device flow |
+| `/hivemind_capture` | Toggle conversation capture on/off |
+| `/hivemind_whoami` | Show current org and workspace |
+| `/hivemind_orgs` | List organizations |
+| `/hivemind_switch_org <name>` | Switch organization |
+| `/hivemind_workspaces` | List workspaces |
+| `/hivemind_switch_workspace <id>` | Switch workspace |
+
+You can also just ask the agent naturally — "switch org to activeloop", "list my orgs", "invite alice@example.com as admin", etc.
+
+## Privacy & data
+
+- **What's captured**: every user message and assistant reply, sent to `api.deeplake.ai`.
+- **Where credentials live**: a long-lived API token at `~/.deeplake/credentials.json` (file permissions 0600).
+- **Where it sends data**: only `api.deeplake.ai`. Nothing else.
+- **How to pause**: run `/hivemind_capture` to stop capture; run it again to resume.
+- **How to fully sign out**: delete `~/.deeplake/credentials.json` and revoke the token in the Deeplake dashboard.
+
+The plugin does **not** modify OpenClaw's configuration or replace the built-in memory plugin. It runs alongside `memory-core` via lifecycle hooks.
+
+## Sharing memory with teammates
+
+Invite teammates to your Deeplake org:
+
+```
+invite alice@example.com as admin
+```
+
+Their agents will see your memory; your agents will see theirs.
+
+## Source
+
+[github.com/activeloopai/hivemind](https://github.com/activeloopai/hivemind)

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,6 +1,5 @@
 {
   "id": "hivemind",
-  "kind": "memory",
   "name": "Hivemind",
   "description": "Cloud-backed shared memory powered by Deeplake — auto-capture and auto-recall across sessions, agents, and teammates",
   "uiHints": {

--- a/openclaw/skills/SKILL.md
+++ b/openclaw/skills/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hivemind
 description: Cloud-backed shared memory for AI agents. Install once, memory persists across sessions, machines, and channels.
-allowed-tools: Read
+allowed-tools: Read, Bash
 ---
 
-# Hivemind Memory
+# Hivemind
 
 Cloud-backed shared memory powered by Deeplake.
 
@@ -14,14 +14,25 @@ Cloud-backed shared memory powered by Deeplake.
 
 ## Authentication
 
-The user types `/hivemind_login` in chat. The plugin returns an auth URL. The user clicks it, signs in, and memory activates on the next message.
+The user types `/hivemind_login` in chat. The plugin returns an auth URL. The user clicks it, signs in, and memory activates on the next message. A long-lived API token is stored at `~/.deeplake/credentials.json`.
 
-## How it works
+## What the plugin does
 
-The plugin automatically:
-- **Captures** every conversation (user + assistant messages) to Deeplake cloud
-- **Recalls** relevant memories before each agent turn via keyword search
-- All data stored as structured rows — searchable, persistent, shared
+- **Captures** every conversation (user + assistant messages) and sends them to `api.deeplake.ai`. Disable anytime with `/hivemind_capture`.
+- **Recalls** relevant memories before each agent turn via keyword search.
+- **Stores** a long-lived API token at `~/.deeplake/credentials.json` after login.
+- **Does NOT** modify OpenClaw configuration or replace the built-in memory plugin.
+- All network requests go to `api.deeplake.ai` only.
+
+## Commands
+
+- `/hivemind_login` — sign in via device flow
+- `/hivemind_capture` — toggle capture on/off (off = no data sent)
+- `/hivemind_whoami` — show current org and workspace
+- `/hivemind_orgs` — list organizations
+- `/hivemind_switch_org <name-or-id>` — switch organization
+- `/hivemind_workspaces` — list workspaces
+- `/hivemind_switch_workspace <id>` — switch workspace
 
 ## Sharing memory
 

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -1,8 +1,4 @@
 function definePluginEntry<T>(entry: T): T { return entry; }
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 // Shared core imports
 import { loadConfig } from "../../src/config.js";
 import { loadCredentials, saveCredentials, requestDeviceCode, pollForToken, listOrgs } from "../../src/commands/auth.js";
@@ -107,22 +103,6 @@ async function requestAuth(): Promise<string> {
   }
 }
 
-// --- OpenClaw-specific: ensure plugin is in load.paths for hook wiring ---
-function addToLoadPaths(): void {
-  const ocConfigPath = join(homedir(), ".openclaw", "openclaw.json");
-  if (!existsSync(ocConfigPath)) return;
-  try {
-    const ocConfig = JSON.parse(readFileSync(ocConfigPath, "utf-8"));
-    const installPath = ocConfig?.plugins?.installs?.["hivemind"]?.installPath;
-    if (!installPath) return;
-    const loadPaths: string[] = ocConfig?.plugins?.load?.paths ?? [];
-    if (loadPaths.includes(installPath)) return;
-    if (!ocConfig.plugins.load) ocConfig.plugins.load = {};
-    ocConfig.plugins.load.paths = [...loadPaths, installPath];
-    writeFileSync(ocConfigPath, JSON.stringify(ocConfig, null, 2));
-  } catch {}
-}
-
 // --- API instance ---
 let api: DeeplakeApi | null = null;
 let sessionsTable = "sessions";
@@ -154,12 +134,9 @@ export default definePluginEntry({
   id: "hivemind",
   name: "Hivemind",
   description: "Cloud-backed shared memory powered by Deeplake",
-  kind: "memory",
 
   register(pluginApi: PluginAPI) {
     try {
-    addToLoadPaths();
-
     // Login command — works immediately after install, no hook dependency
     if (pluginApi.registerCommand) {
       pluginApi.registerCommand({


### PR DESCRIPTION
## Summary

- Remove `kind: "memory"` from plugin manifest and code — hivemind now coexists with memory-core instead of replacing it
- Remove `addToLoadPaths()` — no longer modifies `~/.openclaw/openclaw.json`
- Add org/workspace management commands: `hivemind_whoami`, `hivemind_orgs`, `hivemind_switch_org`, `hivemind_workspaces`, `hivemind_switch_workspace`
- Add `openclaw/README.md` for ClawHub listing
- Update main README with OpenClaw commands table
- Update SKILL.md with full command list, privacy disclosures, and correct `allowed-tools`

## Fixes

- Hivemind no longer disables `memory-core` on install (fixes cron job failures)
- Hivemind no longer modifies OpenClaw config files (fixes "persistence & privilege" security flag)
- SKILL.md now discloses credential storage, auto-capture, and network target (fixes "instruction scope" security flag)
- Source file no longer contains `readFileSync` import (fixes static analysis flag on src/index.ts)

## Test plan

- [x] Build passes, bundle clean (0 scanner flags in src and dist)
- [x] Plugin registers without replacing memory-core
- [x] Auto-recall working (5 memories per turn)
- [x] Auto-capture working (messages in Deeplake sessions table)
- [x] `/hivemind_capture` toggle confirmed via API query