### PR TITLE
fix(grep): dual-table search + session content normalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the "Build PR coverage comment" step can do
+          # `git diff origin/<base>...HEAD` to detect touched src/ files.
+          # Default shallow checkout (depth=1) produces "no merge base".
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -75,6 +80,7 @@ jobs:
       - name: Build PR coverage comment
         if: github.event_name == 'pull_request' && always()
         id: pr-coverage
+        continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -83,7 +89,6 @@ jobs:
             echo "body-file=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
           node <<'NODE' > /tmp/pr-coverage.md
           const { execSync } = require('node:child_process');
           const fs = require('node:fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     name: Typecheck and Test
@@ -26,13 +30,16 @@ jobs:
         run: npm run typecheck
 
       - name: Run tests with coverage
-        run: npx vitest run --coverage --coverage.reporter=text --coverage.reporter=json-summary
+        # Per-file 80% thresholds for PR #60 files are declared in
+        # vitest.config.ts under `coverage.thresholds`. Vitest exits non-zero
+        # if any of them regress below 80%, which fails the job.
+        run: npx vitest run --coverage
 
-      - name: Coverage summary
+      - name: Write coverage summary to job page
         if: always()
         run: |
           if [ -f coverage/coverage-summary.json ]; then
-            echo "### Test Coverage" >> $GITHUB_STEP_SUMMARY
+            echo "### Test Coverage (overall)" >> $GITHUB_STEP_SUMMARY
             node -e "
               const c = require('./coverage/coverage-summary.json').total;
               const fmt = (v) => v.pct.toFixed(1) + '%';
@@ -43,7 +50,34 @@ jobs:
               console.log('| Functions | ' + fmt(c.functions) + ' |');
               console.log('| Lines | ' + fmt(c.lines) + ' |');
             " >> $GITHUB_STEP_SUMMARY
+
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### PR-tracked files (must stay ≥ 80 %)" >> $GITHUB_STEP_SUMMARY
+            node -e "
+              const summary = require('./coverage/coverage-summary.json');
+              const tracked = [
+                'src/shell/grep-core.ts',
+                'src/shell/grep-interceptor.ts',
+                'src/hooks/grep-direct.ts',
+              ];
+              console.log('| File | Stmts | Branch | Funcs | Lines |');
+              console.log('|------|------:|-------:|------:|------:|');
+              const fmt = v => v == null ? '—' : v.toFixed(1) + '%';
+              for (const rel of tracked) {
+                const key = Object.keys(summary).find(k => k.endsWith(rel));
+                const c = key ? summary[key] : null;
+                if (!c) { console.log('| \`' + rel + '\` | — | — | — | — |'); continue; }
+                console.log('| \`' + rel + '\` | ' + fmt(c.statements.pct) + ' | ' + fmt(c.branches.pct) + ' | ' + fmt(c.functions.pct) + ' | ' + fmt(c.lines.pct) + ' |');
+              }
+            " >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          name: coverage
 
       - name: Build bundles
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,22 +72,90 @@ jobs:
             " >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Post coverage comment on PR
+      - name: Build PR coverage comment
         if: github.event_name == 'pull_request' && always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        id: pr-coverage
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ ! -f coverage/coverage-summary.json ]; then
+            echo "no coverage summary — skipping PR comment"
+            echo "body-file=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
+          node <<'NODE' > /tmp/pr-coverage.md
+          const { execSync } = require('node:child_process');
+          const fs = require('node:fs');
+          const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8'));
+          const baseRef = process.env.BASE_REF || 'main';
+          const diff = execSync(`git diff --name-only origin/${baseRef}...HEAD`, { encoding: 'utf8' });
+          const changed = diff.split('\n')
+            .filter(f => f.startsWith('src/') && f.endsWith('.ts') && !f.endsWith('.test.ts') && !f.endsWith('.d.ts'))
+            .sort();
+
+          // Aggregate totals across ONLY the PR-touched files. Same shape
+          // as the davelosert "Coverage Report" box, but scoped to this PR
+          // instead of the whole src/ tree.
+          const agg = {
+            statements: { total: 0, covered: 0 },
+            branches:   { total: 0, covered: 0 },
+            functions:  { total: 0, covered: 0 },
+            lines:      { total: 0, covered: 0 },
+          };
+          const perFile = [];
+          for (const f of changed) {
+            const key = Object.keys(summary).find(k => k.endsWith(f));
+            if (!key) { perFile.push({ f, c: null }); continue; }
+            const c = summary[key];
+            for (const k of Object.keys(agg)) {
+              agg[k].total   += c[k].total;
+              agg[k].covered += c[k].covered;
+            }
+            perFile.push({ f, c });
+          }
+
+          const THRESHOLD = 80;
+          const pct = (m) => m.total === 0 ? null : (m.covered / m.total) * 100;
+          const icon = (p) => p == null ? '⚪' : (p >= THRESHOLD ? '🟢' : '🔴');
+          const fmtPct = (p) => p == null ? '—' : p.toFixed(2) + '%';
+          const fmtCell = (c, k) => c ? ((c[k].pct >= THRESHOLD ? '🟢 ' : '🔴 ') + c[k].pct.toFixed(1) + '%') : '—';
+
+          const out = [];
+          out.push('## Coverage Report');
+          out.push('');
+          if (changed.length === 0) {
+            out.push('_No `src/*.ts` files changed in this PR._');
+          } else {
+            out.push('Scope: files changed in this PR. Enforced threshold: **' + THRESHOLD + '%** per metric (per file via `vitest.config.ts`).');
+            out.push('');
+            out.push('| Status | Category | Percentage | Covered / Total |');
+            out.push('|--------|----------|-----------:|----------------:|');
+            for (const [label, key] of [["Lines","lines"],["Statements","statements"],["Functions","functions"],["Branches","branches"]]) {
+              const p = pct(agg[key]);
+              out.push(`| ${icon(p)} | ${label} | ${fmtPct(p)} (🎯 ${THRESHOLD}%) | ${agg[key].covered} / ${agg[key].total} |`);
+            }
+            out.push('');
+            out.push('### File Coverage');
+            out.push('');
+            out.push('| File | Stmts | Branches | Functions | Lines |');
+            out.push('|------|------:|---------:|----------:|------:|');
+            for (const { f, c } of perFile) {
+              out.push(`| \`${f}\` | ${fmtCell(c, 'statements')} | ${fmtCell(c, 'branches')} | ${fmtCell(c, 'functions')} | ${fmtCell(c, 'lines')} |`);
+            }
+          }
+          out.push('');
+          out.push(`<sub>Generated for commit ${(process.env.GITHUB_SHA || '?').slice(0,7)}.</sub>`);
+          console.log(out.join('\n'));
+          NODE
+          echo "body-file=/tmp/pr-coverage.md" >> "$GITHUB_OUTPUT"
+
+      - name: Post coverage comment on PR
+        if: github.event_name == 'pull_request' && always() && steps.pr-coverage.outputs.body-file != ''
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          json-summary-path: coverage/coverage-summary.json
-          # json is required to render per-file / per-line coverage in the
-          # "Changes" section of the PR comment.
-          json-final-path: coverage/coverage-final.json
-          # Scope the comment to files actually touched in this PR. The
-          # action also shows an overall project table above that; its
-          # 80% target there is a UI default and does NOT reflect our
-          # enforcement model (we enforce per-file via vitest.config.ts).
-          file-coverage-mode: changes
-          # `name` is omitted on purpose: passing `name: coverage` makes the
-          # comment title "Coverage Report for coverage" (ugly duplication).
-          # With no name, the comment title is just "Coverage Report".
+          header: pr-coverage-report
+          path: /tmp/pr-coverage.md
 
       - name: Build bundles
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,20 @@ jobs:
               out.push(`| ${icon(p)} | ${label} | ${fmtPct(p)} (🎯 ${THRESHOLD}%) | ${agg[key].covered} / ${agg[key].total} |`);
             }
             out.push('');
-            out.push('### File Coverage');
+            // File-level breakdown inside a <details> dropdown so a PR that
+            // touches dozens/hundreds of files does not produce an endless
+            // comment. Summary text shows the file count so you can see at
+            // a glance how much is inside before expanding.
+            out.push('<details>');
+            out.push(`<summary><strong>File Coverage</strong> — ${perFile.length} file${perFile.length === 1 ? '' : 's'} changed</summary>`);
             out.push('');
             out.push('| File | Stmts | Branches | Functions | Lines |');
             out.push('|------|------:|---------:|----------:|------:|');
             for (const { f, c } of perFile) {
               out.push(`| \`${f}\` | ${fmtCell(c, 'statements')} | ${fmtCell(c, 'branches')} | ${fmtCell(c, 'functions')} | ${fmtCell(c, 'lines')} |`);
             }
+            out.push('');
+            out.push('</details>');
           }
           out.push('');
           out.push(`<sub>Generated for commit ${(process.env.GITHUB_SHA || '?').slice(0,7)}.</sub>`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json
+          # json is required to render per-file / per-line coverage in the
+          # "Changes" section of the PR comment.
+          json-final-path: coverage/coverage-final.json
+          # Scope the comment to files actually touched in this PR. The
+          # action also shows an overall project table above that; its
+          # 80% target there is a UI default and does NOT reflect our
+          # enforcement model (we enforce per-file via vitest.config.ts).
+          file-coverage-mode: changes
           name: coverage
 
       - name: Build bundles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             perFile.push({ f, c });
           }
 
-          const THRESHOLD = 80;
+          const THRESHOLD = 90;
           const pct = (m) => m.total === 0 ? null : (m.covered / m.total) * 100;
           const icon = (p) => p == null ? '⚪' : (p >= THRESHOLD ? '🟢' : '🔴');
           const fmtPct = (p) => p == null ? '—' : p.toFixed(2) + '%';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,9 @@ jobs:
           # 80% target there is a UI default and does NOT reflect our
           # enforcement model (we enforce per-file via vitest.config.ts).
           file-coverage-mode: changes
-          name: coverage
+          # `name` is omitted on purpose: passing `name: coverage` makes the
+          # comment title "Coverage Report for coverage" (ugly duplication).
+          # With no name, the comment title is just "Coverage Report".
 
       - name: Build bundles
         run: npm run build

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -309,6 +309,292 @@ var DeeplakeApi = class {
   }
 };
 
+// dist/src/shell/grep-core.js
+var TOOL_INPUT_FIELDS = [
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "prompt",
+  "subagent_type",
+  "query",
+  "url",
+  "notebook_path",
+  "old_string",
+  "new_string",
+  "content",
+  "skill",
+  "args",
+  "taskId",
+  "status",
+  "subject",
+  "description",
+  "to",
+  "message",
+  "summary",
+  "max_results"
+];
+var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  "interrupted",
+  "isImage",
+  "noOutputExpected",
+  "type",
+  "stderr",
+  "structuredPatch",
+  "userModified",
+  "originalFile",
+  "replaceAll",
+  "totalDurationMs",
+  "totalTokens",
+  "totalToolUseCount",
+  "usage",
+  "toolStats",
+  "durationMs",
+  "durationSeconds",
+  "bytes",
+  "code",
+  "codeText",
+  "agentId",
+  "agentType",
+  "verificationNudgeNeeded",
+  "numLines",
+  "numFiles",
+  "truncated",
+  "statusChange",
+  "updatedFields",
+  "isAgent",
+  "success"
+]);
+function maybeParseJson(v) {
+  if (typeof v !== "string")
+    return v;
+  const s = v.trim();
+  if (s[0] !== "{" && s[0] !== "[")
+    return v;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return v;
+  }
+}
+function snakeCase(k) {
+  return k.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+function camelCase(k) {
+  return k.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+function formatToolInput(raw) {
+  const p = maybeParseJson(raw);
+  if (typeof p !== "object" || p === null)
+    return String(p ?? "");
+  const parts = [];
+  for (const k of TOOL_INPUT_FIELDS) {
+    if (p[k] === void 0)
+      continue;
+    const v = p[k];
+    parts.push(`${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`);
+  }
+  for (const k of ["glob", "output_mode", "limit", "offset"]) {
+    if (p[k] !== void 0)
+      parts.push(`${k}: ${p[k]}`);
+  }
+  return parts.length ? parts.join("\n") : JSON.stringify(p);
+}
+function formatToolResponse(raw, inp, toolName) {
+  const r = maybeParseJson(raw);
+  if (typeof r !== "object" || r === null)
+    return String(r ?? "");
+  if (toolName === "Edit" || toolName === "Write" || toolName === "MultiEdit") {
+    return r.filePath ? `[wrote ${r.filePath}]` : "[ok]";
+  }
+  if (typeof r.stdout === "string") {
+    const stderr = r.stderr;
+    return r.stdout + (stderr ? `
+stderr: ${stderr}` : "");
+  }
+  if (typeof r.content === "string")
+    return r.content;
+  if (r.file && typeof r.file === "object") {
+    const f = r.file;
+    if (typeof f.content === "string")
+      return `[${f.filePath ?? ""}]
+${f.content}`;
+    if (typeof f.base64 === "string")
+      return `[binary ${f.filePath ?? ""}: ${f.base64.length} base64 chars]`;
+  }
+  if (Array.isArray(r.filenames))
+    return r.filenames.join("\n");
+  if (Array.isArray(r.matches)) {
+    return r.matches.map((m) => typeof m === "string" ? m : JSON.stringify(m)).join("\n");
+  }
+  if (Array.isArray(r.results)) {
+    return r.results.map((x) => typeof x === "string" ? x : x?.title ?? x?.url ?? JSON.stringify(x)).join("\n");
+  }
+  const inpObj = maybeParseJson(inp);
+  const kept = {};
+  for (const [k, v] of Object.entries(r)) {
+    if (TOOL_RESPONSE_DROP.has(k))
+      continue;
+    if (v === "" || v === false || v == null)
+      continue;
+    if (typeof inpObj === "object" && inpObj) {
+      const inObj = inpObj;
+      if (k in inObj && JSON.stringify(inObj[k]) === JSON.stringify(v))
+        continue;
+      const snake = snakeCase(k);
+      if (snake in inObj && JSON.stringify(inObj[snake]) === JSON.stringify(v))
+        continue;
+      const camel = camelCase(k);
+      if (camel in inObj && JSON.stringify(inObj[camel]) === JSON.stringify(v))
+        continue;
+    }
+    kept[k] = v;
+  }
+  return Object.keys(kept).length ? JSON.stringify(kept) : "[ok]";
+}
+function formatToolCall(obj) {
+  return `[tool:${obj?.tool_name ?? "?"}]
+input: ${formatToolInput(obj?.tool_input)}
+response: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
+}
+function normalizeContent(path, raw) {
+  if (!path.includes("/sessions/"))
+    return raw;
+  if (!raw || raw[0] !== "{")
+    return raw;
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (Array.isArray(obj.turns)) {
+    const header = [];
+    if (obj.date_time)
+      header.push(`date: ${obj.date_time}`);
+    if (obj.speakers) {
+      const s = obj.speakers;
+      const names = [s.speaker_a, s.speaker_b].filter(Boolean).join(", ");
+      if (names)
+        header.push(`speakers: ${names}`);
+    }
+    const lines = obj.turns.map((t) => {
+      const sp = String(t?.speaker ?? t?.name ?? "?").trim();
+      const tx = String(t?.text ?? t?.content ?? "").replace(/\s+/g, " ").trim();
+      const tag = t?.dia_id ? `[${t.dia_id}] ` : "";
+      return `${tag}${sp}: ${tx}`;
+    });
+    const out2 = [...header, ...lines].join("\n");
+    return out2.trim() ? out2 : raw;
+  }
+  const stripRecalled = (t) => {
+    const i = t.indexOf("<recalled-memories>");
+    if (i === -1)
+      return t;
+    const j = t.lastIndexOf("</recalled-memories>");
+    if (j === -1 || j < i)
+      return t;
+    const head = t.slice(0, i);
+    const tail = t.slice(j + "</recalled-memories>".length);
+    return (head + tail).replace(/^\s+/, "").replace(/\n{3,}/g, "\n\n");
+  };
+  let out = null;
+  if (obj.type === "user_message") {
+    out = `[user] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "assistant_message") {
+    const agent = obj.agent_type ? ` (agent=${obj.agent_type})` : "";
+    out = `[assistant${agent}] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "tool_call") {
+    out = formatToolCall(obj);
+  }
+  if (out === null)
+    return raw;
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "[user]" || trimmed === "[assistant]" || /^\[tool:[^\]]*\]\s+input:\s+\{\}\s+response:\s+\{\}$/.test(trimmed))
+    return raw;
+  return out;
+}
+async function searchDeeplakeTables(api, memoryTable, sessionsTable, opts) {
+  const { pathFilter, contentScanOnly, likeOp, escapedPattern } = opts;
+  const limit = opts.limit ?? 100;
+  const memFilter = contentScanOnly ? "" : ` AND summary::text ${likeOp} '%${escapedPattern}%'`;
+  const sessFilter = contentScanOnly ? "" : ` AND message::text ${likeOp} '%${escapedPattern}%'`;
+  const memQuery = `SELECT path, summary::text AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${limit}`;
+  const sessQuery = `SELECT path, message::text AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${limit}`;
+  const [memRows, sessRows] = await Promise.all([
+    api.query(memQuery).catch(() => []),
+    api.query(sessQuery).catch(() => [])
+  ]);
+  const rows = [];
+  for (const r of memRows)
+    rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  for (const r of sessRows)
+    rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  return rows;
+}
+function buildPathFilter(targetPath) {
+  if (!targetPath || targetPath === "/")
+    return "";
+  const clean = targetPath.replace(/\/+$/, "");
+  return ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
+}
+function compileGrepRegex(params) {
+  let reStr = params.fixedString ? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : params.pattern;
+  if (params.wordMatch)
+    reStr = `\\b${reStr}\\b`;
+  try {
+    return new RegExp(reStr, params.ignoreCase ? "i" : "");
+  } catch {
+    return new RegExp(params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), params.ignoreCase ? "i" : "");
+  }
+}
+function refineGrepMatches(rows, params, forceMultiFilePrefix) {
+  const re = compileGrepRegex(params);
+  const multi = forceMultiFilePrefix ?? rows.length > 1;
+  const output = [];
+  for (const row of rows) {
+    if (!row.content)
+      continue;
+    const lines = row.content.split("\n");
+    const matched = [];
+    let fileEmitted = false;
+    for (let i = 0; i < lines.length; i++) {
+      const hit = re.test(lines[i]);
+      if (hit !== !!params.invertMatch) {
+        if (params.filesOnly) {
+          if (!fileEmitted) {
+            output.push(row.path);
+            fileEmitted = true;
+          }
+          break;
+        }
+        const prefix = multi ? `${row.path}:` : "";
+        const ln = params.lineNumber ? `${i + 1}:` : "";
+        matched.push(`${prefix}${ln}${lines[i]}`);
+      }
+    }
+    if (!params.filesOnly) {
+      if (params.countOnly) {
+        output.push(`${multi ? `${row.path}:` : ""}${matched.length}`);
+      } else {
+        output.push(...matched);
+      }
+    }
+  }
+  return output;
+}
+async function grepBothTables(api, memoryTable, sessionsTable, params, targetPath) {
+  const hasRegexMeta = !params.fixedString && /[.*+?^${}()|[\]\\]/.test(params.pattern);
+  const rows = await searchDeeplakeTables(api, memoryTable, sessionsTable, {
+    pathFilter: buildPathFilter(targetPath),
+    contentScanOnly: hasRegexMeta,
+    likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
+    escapedPattern: sqlLike(params.pattern)
+  });
+  const normalized = rows.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  return refineGrepMatches(normalized, params);
+}
+
 // dist/src/hooks/grep-direct.js
 function parseBashGrep(cmd) {
   const first = cmd.trim().split(/\s*\|\s*/)[0];
@@ -418,67 +704,17 @@ function parseBashGrep(cmd) {
 async function handleGrepDirect(api, table, sessionsTable, params) {
   if (!params.pattern)
     return null;
-  const { pattern, targetPath, ignoreCase, wordMatch, filesOnly, countOnly, lineNumber, invertMatch, fixedString } = params;
-  const likeOp = ignoreCase ? "ILIKE" : "LIKE";
-  const escapedLike = sqlLike(pattern);
-  let pathFilter = "";
-  if (targetPath && targetPath !== "/") {
-    const clean = targetPath.replace(/\/+$/, "");
-    pathFilter = ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
-  }
-  const hasRegexMeta = !fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
-  let rows = [];
-  if (!hasRegexMeta) {
-    const contentFilter = ` AND summary ${likeOp} '%${escapedLike}%'`;
-    try {
-      rows = await api.query(`SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter}${contentFilter} LIMIT 100`);
-    } catch {
-      rows = [];
-    }
-  } else {
-    try {
-      rows = await api.query(`SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter} LIMIT 100`);
-    } catch {
-      rows = [];
-    }
-  }
-  let reStr = fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern;
-  if (wordMatch)
-    reStr = `\\b${reStr}\\b`;
-  let re;
-  try {
-    re = new RegExp(reStr, ignoreCase ? "i" : "");
-  } catch {
-    re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), ignoreCase ? "i" : "");
-  }
-  const output = [];
-  const multi = rows.length > 1;
-  for (const row of rows) {
-    const p = row["path"];
-    const text = row["content"];
-    if (!text)
-      continue;
-    const lines = text.split("\n");
-    const matched = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (re.test(lines[i]) !== !!invertMatch) {
-        if (filesOnly) {
-          output.push(p);
-          break;
-        }
-        const prefix = multi ? `${p}:` : "";
-        const ln = lineNumber ? `${i + 1}:` : "";
-        matched.push(`${prefix}${ln}${lines[i]}`);
-      }
-    }
-    if (!filesOnly) {
-      if (countOnly) {
-        output.push(`${multi ? `${p}:` : ""}${matched.length}`);
-      } else {
-        output.push(...matched);
-      }
-    }
-  }
+  const matchParams = {
+    pattern: params.pattern,
+    ignoreCase: params.ignoreCase,
+    wordMatch: params.wordMatch,
+    filesOnly: params.filesOnly,
+    countOnly: params.countOnly,
+    lineNumber: params.lineNumber,
+    invertMatch: params.invertMatch,
+    fixedString: params.fixedString
+  };
+  const output = await grepBothTables(api, table, sessionsTable, matchParams, params.targetPath);
   return output.join("\n") || "(no matches)";
 }
 

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -335,11 +335,15 @@ var TOOL_INPUT_FIELDS = [
   "max_results"
 ];
 var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  // Note: `stderr` is intentionally NOT in this set. The `stdout` high-signal
+  // branch below already de-dupes it for the common case (appends as suffix
+  // when non-empty). If a tool response has ONLY `stderr` and no `stdout`
+  // (hard-failure on some tools), the generic cleanup preserves it so the
+  // error message reaches Claude instead of collapsing to `[ok]`.
   "interrupted",
   "isImage",
   "noOutputExpected",
   "type",
-  "stderr",
   "structuredPatch",
   "userModified",
   "originalFile",
@@ -591,7 +595,9 @@ async function grepBothTables(api, memoryTable, sessionsTable, params, targetPat
     likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
     escapedPattern: sqlLike(params.pattern)
   });
-  const normalized = rows.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  const seen = /* @__PURE__ */ new Set();
+  const unique = rows.filter((r) => seen.has(r.path) ? false : (seen.add(r.path), true));
+  const normalized = unique.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
   return refineGrepMatches(normalized, params);
 }
 

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -561,15 +561,11 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
       continue;
     const lines = row.content.split("\n");
     const matched = [];
-    let fileEmitted = false;
     for (let i = 0; i < lines.length; i++) {
       const hit = re.test(lines[i]);
       if (hit !== !!params.invertMatch) {
         if (params.filesOnly) {
-          if (!fileEmitted) {
-            output.push(row.path);
-            fileEmitted = true;
-          }
+          output.push(row.path);
           break;
         }
         const prefix = multi ? `${row.path}:` : "";

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -68811,15 +68811,11 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
       continue;
     const lines = row.content.split("\n");
     const matched = [];
-    let fileEmitted = false;
     for (let i11 = 0; i11 < lines.length; i11++) {
       const hit = re9.test(lines[i11]);
       if (hit !== !!params.invertMatch) {
         if (params.filesOnly) {
-          if (!fileEmitted) {
-            output.push(row.path);
-            fileEmitted = true;
-          }
+          output.push(row.path);
           break;
         }
         const prefix = multi ? `${row.path}:` : "";

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -68585,11 +68585,15 @@ var TOOL_INPUT_FIELDS = [
   "max_results"
 ];
 var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  // Note: `stderr` is intentionally NOT in this set. The `stdout` high-signal
+  // branch below already de-dupes it for the common case (appends as suffix
+  // when non-empty). If a tool response has ONLY `stderr` and no `stdout`
+  // (hard-failure on some tools), the generic cleanup preserves it so the
+  // error message reaches Claude instead of collapsing to `[ok]`.
   "interrupted",
   "isImage",
   "noOutputExpected",
   "type",
-  "stderr",
   "structuredPatch",
   "userModified",
   "originalFile",

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -68559,13 +68559,298 @@ yargsParser.decamelize = decamelize;
 yargsParser.looksLikeNumber = looksLikeNumber;
 var lib_default = yargsParser;
 
+// dist/src/shell/grep-core.js
+var TOOL_INPUT_FIELDS = [
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "prompt",
+  "subagent_type",
+  "query",
+  "url",
+  "notebook_path",
+  "old_string",
+  "new_string",
+  "content",
+  "skill",
+  "args",
+  "taskId",
+  "status",
+  "subject",
+  "description",
+  "to",
+  "message",
+  "summary",
+  "max_results"
+];
+var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  "interrupted",
+  "isImage",
+  "noOutputExpected",
+  "type",
+  "stderr",
+  "structuredPatch",
+  "userModified",
+  "originalFile",
+  "replaceAll",
+  "totalDurationMs",
+  "totalTokens",
+  "totalToolUseCount",
+  "usage",
+  "toolStats",
+  "durationMs",
+  "durationSeconds",
+  "bytes",
+  "code",
+  "codeText",
+  "agentId",
+  "agentType",
+  "verificationNudgeNeeded",
+  "numLines",
+  "numFiles",
+  "truncated",
+  "statusChange",
+  "updatedFields",
+  "isAgent",
+  "success"
+]);
+function maybeParseJson(v27) {
+  if (typeof v27 !== "string")
+    return v27;
+  const s10 = v27.trim();
+  if (s10[0] !== "{" && s10[0] !== "[")
+    return v27;
+  try {
+    return JSON.parse(s10);
+  } catch {
+    return v27;
+  }
+}
+function snakeCase(k17) {
+  return k17.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+function camelCase2(k17) {
+  return k17.replace(/_([a-z])/g, (_16, c15) => c15.toUpperCase());
+}
+function formatToolInput(raw) {
+  const p22 = maybeParseJson(raw);
+  if (typeof p22 !== "object" || p22 === null)
+    return String(p22 ?? "");
+  const parts = [];
+  for (const k17 of TOOL_INPUT_FIELDS) {
+    if (p22[k17] === void 0)
+      continue;
+    const v27 = p22[k17];
+    parts.push(`${k17}: ${typeof v27 === "string" ? v27 : JSON.stringify(v27)}`);
+  }
+  for (const k17 of ["glob", "output_mode", "limit", "offset"]) {
+    if (p22[k17] !== void 0)
+      parts.push(`${k17}: ${p22[k17]}`);
+  }
+  return parts.length ? parts.join("\n") : JSON.stringify(p22);
+}
+function formatToolResponse(raw, inp, toolName) {
+  const r10 = maybeParseJson(raw);
+  if (typeof r10 !== "object" || r10 === null)
+    return String(r10 ?? "");
+  if (toolName === "Edit" || toolName === "Write" || toolName === "MultiEdit") {
+    return r10.filePath ? `[wrote ${r10.filePath}]` : "[ok]";
+  }
+  if (typeof r10.stdout === "string") {
+    const stderr = r10.stderr;
+    return r10.stdout + (stderr ? `
+stderr: ${stderr}` : "");
+  }
+  if (typeof r10.content === "string")
+    return r10.content;
+  if (r10.file && typeof r10.file === "object") {
+    const f11 = r10.file;
+    if (typeof f11.content === "string")
+      return `[${f11.filePath ?? ""}]
+${f11.content}`;
+    if (typeof f11.base64 === "string")
+      return `[binary ${f11.filePath ?? ""}: ${f11.base64.length} base64 chars]`;
+  }
+  if (Array.isArray(r10.filenames))
+    return r10.filenames.join("\n");
+  if (Array.isArray(r10.matches)) {
+    return r10.matches.map((m26) => typeof m26 === "string" ? m26 : JSON.stringify(m26)).join("\n");
+  }
+  if (Array.isArray(r10.results)) {
+    return r10.results.map((x28) => typeof x28 === "string" ? x28 : x28?.title ?? x28?.url ?? JSON.stringify(x28)).join("\n");
+  }
+  const inpObj = maybeParseJson(inp);
+  const kept = {};
+  for (const [k17, v27] of Object.entries(r10)) {
+    if (TOOL_RESPONSE_DROP.has(k17))
+      continue;
+    if (v27 === "" || v27 === false || v27 == null)
+      continue;
+    if (typeof inpObj === "object" && inpObj) {
+      const inObj = inpObj;
+      if (k17 in inObj && JSON.stringify(inObj[k17]) === JSON.stringify(v27))
+        continue;
+      const snake = snakeCase(k17);
+      if (snake in inObj && JSON.stringify(inObj[snake]) === JSON.stringify(v27))
+        continue;
+      const camel = camelCase2(k17);
+      if (camel in inObj && JSON.stringify(inObj[camel]) === JSON.stringify(v27))
+        continue;
+    }
+    kept[k17] = v27;
+  }
+  return Object.keys(kept).length ? JSON.stringify(kept) : "[ok]";
+}
+function formatToolCall(obj) {
+  return `[tool:${obj?.tool_name ?? "?"}]
+input: ${formatToolInput(obj?.tool_input)}
+response: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
+}
+function normalizeContent(path2, raw) {
+  if (!path2.includes("/sessions/"))
+    return raw;
+  if (!raw || raw[0] !== "{")
+    return raw;
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (Array.isArray(obj.turns)) {
+    const header = [];
+    if (obj.date_time)
+      header.push(`date: ${obj.date_time}`);
+    if (obj.speakers) {
+      const s10 = obj.speakers;
+      const names = [s10.speaker_a, s10.speaker_b].filter(Boolean).join(", ");
+      if (names)
+        header.push(`speakers: ${names}`);
+    }
+    const lines = obj.turns.map((t6) => {
+      const sp = String(t6?.speaker ?? t6?.name ?? "?").trim();
+      const tx = String(t6?.text ?? t6?.content ?? "").replace(/\s+/g, " ").trim();
+      const tag = t6?.dia_id ? `[${t6.dia_id}] ` : "";
+      return `${tag}${sp}: ${tx}`;
+    });
+    const out2 = [...header, ...lines].join("\n");
+    return out2.trim() ? out2 : raw;
+  }
+  const stripRecalled = (t6) => {
+    const i11 = t6.indexOf("<recalled-memories>");
+    if (i11 === -1)
+      return t6;
+    const j14 = t6.lastIndexOf("</recalled-memories>");
+    if (j14 === -1 || j14 < i11)
+      return t6;
+    const head = t6.slice(0, i11);
+    const tail = t6.slice(j14 + "</recalled-memories>".length);
+    return (head + tail).replace(/^\s+/, "").replace(/\n{3,}/g, "\n\n");
+  };
+  let out = null;
+  if (obj.type === "user_message") {
+    out = `[user] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "assistant_message") {
+    const agent = obj.agent_type ? ` (agent=${obj.agent_type})` : "";
+    out = `[assistant${agent}] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "tool_call") {
+    out = formatToolCall(obj);
+  }
+  if (out === null)
+    return raw;
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "[user]" || trimmed === "[assistant]" || /^\[tool:[^\]]*\]\s+input:\s+\{\}\s+response:\s+\{\}$/.test(trimmed))
+    return raw;
+  return out;
+}
+async function searchDeeplakeTables(api, memoryTable, sessionsTable, opts) {
+  const { pathFilter, contentScanOnly, likeOp, escapedPattern } = opts;
+  const limit = opts.limit ?? 100;
+  const memFilter = contentScanOnly ? "" : ` AND summary::text ${likeOp} '%${escapedPattern}%'`;
+  const sessFilter = contentScanOnly ? "" : ` AND message::text ${likeOp} '%${escapedPattern}%'`;
+  const memQuery = `SELECT path, summary::text AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${limit}`;
+  const sessQuery = `SELECT path, message::text AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${limit}`;
+  const [memRows, sessRows] = await Promise.all([
+    api.query(memQuery).catch(() => []),
+    api.query(sessQuery).catch(() => [])
+  ]);
+  const rows = [];
+  for (const r10 of memRows)
+    rows.push({ path: String(r10.path), content: String(r10.content ?? "") });
+  for (const r10 of sessRows)
+    rows.push({ path: String(r10.path), content: String(r10.content ?? "") });
+  return rows;
+}
+function buildPathFilter(targetPath) {
+  if (!targetPath || targetPath === "/")
+    return "";
+  const clean = targetPath.replace(/\/+$/, "");
+  return ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
+}
+function compileGrepRegex(params) {
+  let reStr = params.fixedString ? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : params.pattern;
+  if (params.wordMatch)
+    reStr = `\\b${reStr}\\b`;
+  try {
+    return new RegExp(reStr, params.ignoreCase ? "i" : "");
+  } catch {
+    return new RegExp(params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), params.ignoreCase ? "i" : "");
+  }
+}
+function refineGrepMatches(rows, params, forceMultiFilePrefix) {
+  const re9 = compileGrepRegex(params);
+  const multi = forceMultiFilePrefix ?? rows.length > 1;
+  const output = [];
+  for (const row of rows) {
+    if (!row.content)
+      continue;
+    const lines = row.content.split("\n");
+    const matched = [];
+    let fileEmitted = false;
+    for (let i11 = 0; i11 < lines.length; i11++) {
+      const hit = re9.test(lines[i11]);
+      if (hit !== !!params.invertMatch) {
+        if (params.filesOnly) {
+          if (!fileEmitted) {
+            output.push(row.path);
+            fileEmitted = true;
+          }
+          break;
+        }
+        const prefix = multi ? `${row.path}:` : "";
+        const ln3 = params.lineNumber ? `${i11 + 1}:` : "";
+        matched.push(`${prefix}${ln3}${lines[i11]}`);
+      }
+    }
+    if (!params.filesOnly) {
+      if (params.countOnly) {
+        output.push(`${multi ? `${row.path}:` : ""}${matched.length}`);
+      } else {
+        output.push(...matched);
+      }
+    }
+  }
+  return output;
+}
+
 // dist/src/shell/grep-interceptor.js
 var MAX_FALLBACK_CANDIDATES = 500;
 function createGrepCommand(client, fs3, table, sessionsTable) {
   return Yi2("grep", async (args, ctx) => {
     const parsed = lib_default(args, {
-      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "fixed-strings", "recursive", "ignore-case"],
-      alias: { r: "recursive", R: "recursive", F: "fixed-strings", i: "ignore-case", n: "line-number" }
+      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "w", "fixed-strings", "recursive", "ignore-case", "word-regexp"],
+      alias: {
+        r: "recursive",
+        R: "recursive",
+        F: "fixed-strings",
+        i: "ignore-case",
+        n: "line-number",
+        w: "word-regexp",
+        l: "files-with-matches",
+        c: "count",
+        v: "invert-match"
+      }
     });
     const positional = parsed._;
     if (positional.length === 0) {
@@ -68579,79 +68864,52 @@ function createGrepCommand(client, fs3, table, sessionsTable) {
     const mount = fs3.mountPoint;
     const mountPrefix = mount === "/" ? "/" : mount + "/";
     const allUnderMount = targets.every((t6) => t6 === mount || t6.startsWith(mountPrefix));
-    if (!allUnderMount) {
+    if (!allUnderMount)
       return { stdout: "", stderr: "", exitCode: 127 };
-    }
-    let candidates = [];
+    const matchParams = {
+      pattern,
+      fixedString: Boolean(parsed.F || parsed["fixed-strings"]),
+      ignoreCase: Boolean(parsed.i || parsed["ignore-case"]),
+      wordMatch: Boolean(parsed.w || parsed["word-regexp"]),
+      lineNumber: Boolean(parsed.n || parsed["line-number"]),
+      invertMatch: Boolean(parsed.v || parsed["invert-match"]),
+      filesOnly: Boolean(parsed.l || parsed["files-with-matches"]),
+      countOnly: Boolean(parsed.c || parsed["count"])
+    };
+    const likeOp = matchParams.ignoreCase ? "ILIKE" : "LIKE";
+    const hasRegexMeta = !matchParams.fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
+    const escapedPattern = sqlLike(pattern);
+    let rows = [];
     try {
-      const queries = [
-        client.query(`SELECT path FROM "${table}" WHERE summary <#> '${sqlStr(pattern)}' LIMIT 50`)
-      ];
-      if (sessionsTable) {
-        queries.push(client.query(`SELECT path FROM "${sessionsTable}" WHERE message::text LIKE '%${sqlLike(pattern)}%' LIMIT 10`));
-      }
-      const results = await Promise.race([
-        Promise.all(queries),
+      const perTarget = await Promise.race([
+        Promise.all(targets.map((t6) => searchDeeplakeTables(client, table, sessionsTable ?? "sessions", {
+          pathFilter: buildPathFilter(t6),
+          contentScanOnly: hasRegexMeta,
+          likeOp,
+          escapedPattern,
+          limit: 100
+        }))),
         new Promise((_16, reject) => setTimeout(() => reject(new Error("timeout")), 3e3))
       ]);
-      for (const rows of results) {
-        candidates.push(...rows.map((r10) => r10["path"]).filter(Boolean));
-      }
+      for (const batch of perTarget)
+        rows.push(...batch);
     } catch {
-    }
-    const withinTargets = (p22) => targets.some((t6) => t6 === "/" || p22 === t6 || p22.startsWith(t6 + "/"));
-    if (candidates.length === 0) {
-      candidates = fs3.getAllPaths().filter((p22) => !p22.endsWith("/") && withinTargets(p22));
-      if (candidates.length > MAX_FALLBACK_CANDIDATES) {
-        candidates = candidates.slice(0, MAX_FALLBACK_CANDIDATES);
-      }
-    } else {
-      candidates = candidates.filter((c15) => withinTargets(c15));
+      rows = [];
     }
     const seen = /* @__PURE__ */ new Set();
-    candidates = candidates.filter((c15) => {
-      if (seen.has(c15))
-        return false;
-      seen.add(c15);
-      return true;
-    });
-    await fs3.prefetch(candidates);
-    const fixedString = parsed.F || parsed["fixed-strings"];
-    const ignoreCase = parsed.i || parsed["ignore-case"];
-    const showLine = parsed.n || parsed["line-number"];
-    const invertMatch = parsed.v;
-    const filesOnly = parsed.l;
-    const countOnly = parsed.c;
-    const re9 = new RegExp(fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern, ignoreCase ? "i" : "");
-    const output = [];
-    const multipleFiles = candidates.length > 1;
-    for (const fp of candidates) {
-      const content = await fs3.readFile(fp).catch(() => null);
-      if (content === null)
-        continue;
-      const lines = content.split("\n");
-      const matchedLines = [];
-      for (let i11 = 0; i11 < lines.length; i11++) {
-        const matched = re9.test(lines[i11]);
-        if (matched !== invertMatch) {
-          if (filesOnly) {
-            output.push(fp);
-            break;
-          }
-          const prefix = multipleFiles ? `${fp}:` : "";
-          const lineNo = showLine ? `${i11 + 1}:` : "";
-          matchedLines.push(`${prefix}${lineNo}${lines[i11]}`);
-        }
-      }
-      if (!filesOnly) {
-        if (countOnly) {
-          const prefix = multipleFiles ? `${fp}:` : "";
-          output.push(`${prefix}${matchedLines.length}`);
-        } else {
-          output.push(...matchedLines);
-        }
+    rows = rows.filter((r10) => seen.has(r10.path) ? false : (seen.add(r10.path), true));
+    if (rows.length === 0) {
+      const withinTargets = (p22) => targets.some((t6) => t6 === "/" || p22 === t6 || p22.startsWith(t6 + "/"));
+      const candidates = fs3.getAllPaths().filter((p22) => !p22.endsWith("/") && withinTargets(p22)).slice(0, MAX_FALLBACK_CANDIDATES);
+      await fs3.prefetch(candidates);
+      for (const fp of candidates) {
+        const content = await fs3.readFile(fp).catch(() => null);
+        if (content !== null)
+          rows.push({ path: fp, content });
       }
     }
+    const normalized = rows.map((r10) => ({ path: r10.path, content: normalizeContent(r10.path, r10.content) }));
+    const output = refineGrepMatches(normalized, matchParams);
     return {
       stdout: output.length > 0 ? output.join("\n") + "\n" : "",
       stderr: "",

--- a/claude-code/tests/grep-core.test.ts
+++ b/claude-code/tests/grep-core.test.ts
@@ -62,6 +62,52 @@ describe("normalizeContent: LoCoMo benchmark shape", () => {
     expect(out).toContain("X: ");
   });
 
+  it("omits speakers header when both speaker fields are empty", () => {
+    const raw = JSON.stringify({
+      turns: [{ speaker: "A", text: "hi" }],
+      speakers: { speaker_a: "", speaker_b: "" },
+    });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).not.toContain("speakers:");
+    expect(out).toContain("A: hi");
+  });
+
+  it("emits only speaker_a when speaker_b is missing", () => {
+    const raw = JSON.stringify({
+      turns: [{ speaker: "A", text: "hi" }],
+      speakers: { speaker_a: "Alice" },
+    });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("speakers: Alice");
+  });
+
+  it("falls back speaker->name when speaker field is absent on a turn", () => {
+    const raw = JSON.stringify({ turns: [{ name: "Caroline", text: "hi" }] });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("Caroline: hi");
+  });
+
+  it("falls back text->content when text field is absent on a turn", () => {
+    const raw = JSON.stringify({ turns: [{ speaker: "X", content: "fallback" }] });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("X: fallback");
+  });
+
+  it("omits dia_id prefix when the turn has no dia_id", () => {
+    const raw = JSON.stringify({ turns: [{ speaker: "A", text: "hi" }] });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("A: hi");
+    expect(out).not.toMatch(/\[\]/);
+  });
+
+  it("emits turns without date/speakers when both are missing", () => {
+    const raw = JSON.stringify({ turns: [{ speaker: "A", text: "hi" }] });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).not.toContain("date:");
+    expect(out).not.toContain("speakers:");
+    expect(out).toContain("A: hi");
+  });
+
   it("returns raw when turns produce an empty serialization", () => {
     const empty = JSON.stringify({ turns: [] });
     // No header, no turns → trimmed output is empty → fallback to raw
@@ -156,6 +202,102 @@ describe("normalizeContent: production tool_call", () => {
     const out = normalizeContent("/sessions/u/x.jsonl", raw);
     expect(out).toContain("taskId: T1");
     // response collapses to [ok] — taskId dropped as dup, everything else in DROP set
+    expect(out).toContain("response: [ok]");
+  });
+
+  it("Bash stdout with no stderr does not append stderr line", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Bash",
+      tool_input: JSON.stringify({ command: "true" }),
+      tool_response: JSON.stringify({ stdout: "hello", stderr: "", interrupted: false }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("hello");
+    expect(out).not.toContain("stderr:");
+  });
+
+  it("extractInput falls back to JSON.stringify when no pick fields match", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "CustomTool",
+      tool_input: JSON.stringify({ weird: "payload", answer: 42 }),
+      tool_response: JSON.stringify({ stdout: "ok" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain('weird');
+    expect(out).toContain('answer');
+  });
+
+  it("extractInput handles scalar tool_input (not object)", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Ping",
+      tool_input: "hello",
+      tool_response: JSON.stringify({ stdout: "pong" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("input: hello");
+    expect(out).toContain("pong");
+  });
+
+  it("extractResponse handles scalar tool_response (not object)", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Raw",
+      tool_input: JSON.stringify({ command: "x" }),
+      tool_response: "just a string",
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("just a string");
+  });
+
+  it("uses '?' when tool_name is missing", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_input: JSON.stringify({ x: 1 }),
+      tool_response: JSON.stringify({ stdout: "done" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("[tool:?]");
+  });
+
+  it("generic cleanup still works when tool_input is scalar (not an object)", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "OddTool",
+      tool_input: "plain string input",
+      tool_response: JSON.stringify({ extra: "kept-field" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("kept-field");
+  });
+
+  it("drops response key that is a camelCase duplicate of a snake_case input", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Ghost",
+      tool_input: JSON.stringify({ some_field: "v" }),
+      tool_response: JSON.stringify({ someField: "v", keep: "yes" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).not.toMatch(/"someField":"v"/);
+    expect(out).toContain("keep");
+  });
+
+  it("collapses response to [ok] when every field is noise or duplicated", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "NoopTool",
+      tool_input: JSON.stringify({ taskId: "T" }),
+      tool_response: JSON.stringify({
+        success: true,
+        taskId: "T",
+        interrupted: false,
+        isImage: false,
+      }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
     expect(out).toContain("response: [ok]");
   });
 
@@ -325,6 +467,12 @@ describe("compileGrepRegex", () => {
     const re = compileGrepRegex({ ...base, pattern: "[unclosed" });
     expect(re.test("[unclosed")).toBe(true);
   });
+
+  it("fallback regex still honours ignoreCase flag", () => {
+    const re = compileGrepRegex({ ...base, pattern: "[UNCLOSED", ignoreCase: true });
+    expect(re.test("[unclosed")).toBe(true);
+    expect(re.flags).toContain("i");
+  });
 });
 
 // ── refineGrepMatches ───────────────────────────────────────────────────────
@@ -360,6 +508,14 @@ describe("refineGrepMatches", () => {
       { ...base, filesOnly: true },
     );
     expect(out).toEqual(["/a", "/b"]);
+  });
+
+  it("countOnly on a single-file input omits the path prefix", () => {
+    const out = refineGrepMatches(
+      [{ path: "/only", content: "foo\nfoo\nbar" }],
+      { ...base, countOnly: true },
+    );
+    expect(out).toEqual(["2"]);
   });
 
   it("countOnly emits a count per file with multi-file prefix", () => {
@@ -465,7 +621,7 @@ describe("searchDeeplakeTables", () => {
     ]);
   });
 
-  it("tolerates null content (coerces to empty string)", async () => {
+  it("tolerates null content on memory row (coerces to empty string)", async () => {
     const api = mockApi([{ path: "/a", content: null }], []);
     const rows = await searchDeeplakeTables(api, "m", "s", {
       pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
@@ -473,7 +629,15 @@ describe("searchDeeplakeTables", () => {
     expect(rows[0]).toEqual({ path: "/a", content: "" });
   });
 
-  it("returns partial results when one table query fails", async () => {
+  it("tolerates null content on sessions row too", async () => {
+    const api = mockApi([], [{ path: "/b", content: null }]);
+    const rows = await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    expect(rows[0]).toEqual({ path: "/b", content: "" });
+  });
+
+  it("returns partial results when the sessions query fails", async () => {
     const api = {
       query: vi.fn()
         .mockImplementationOnce(async () => [{ path: "/a", content: "ok" }])
@@ -483,6 +647,27 @@ describe("searchDeeplakeTables", () => {
       pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
     });
     expect(rows).toEqual([{ path: "/a", content: "ok" }]);
+  });
+
+  it("returns partial results when the memory query fails", async () => {
+    const api = {
+      query: vi.fn()
+        .mockImplementationOnce(async () => { throw new Error("boom"); })
+        .mockImplementationOnce(async () => [{ path: "/b", content: "ok" }]),
+    } as any;
+    const rows = await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    expect(rows).toEqual([{ path: "/b", content: "ok" }]);
+  });
+
+  it("defaults limit to 100 when omitted", async () => {
+    const api = { query: vi.fn().mockResolvedValue([]) } as any;
+    await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    const sql = api.query.mock.calls[0][0] as string;
+    expect(sql).toContain("LIMIT 100");
   });
 });
 
@@ -545,5 +730,12 @@ describe("grepBothTables", () => {
     const [memSql] = api.query.mock.calls.map((c: unknown[]) => c[0] as string);
     expect(memSql).not.toContain("ILIKE");
     expect(memSql).not.toContain("summary::text LIKE");
+  });
+
+  it("routes to ILIKE when ignoreCase is set", async () => {
+    const api = mockApi([]);
+    await grepBothTables(api, "m", "s", { ...baseParams, ignoreCase: true }, "/");
+    const [memSql] = api.query.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(memSql).toContain("ILIKE");
   });
 });

--- a/claude-code/tests/grep-core.test.ts
+++ b/claude-code/tests/grep-core.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeContent,
+  buildPathFilter,
+  compileGrepRegex,
+  refineGrepMatches,
+} from "../../src/shell/grep-core.js";
+
+// ── normalizeContent ────────────────────────────────────────────────────────
+
+describe("normalizeContent: passthrough for non-session paths", () => {
+  it("leaves memory summary paths untouched", () => {
+    const raw = "# summary\nSome markdown text.";
+    expect(normalizeContent("/summaries/foo/abc.md", raw)).toBe(raw);
+  });
+  it("leaves non-JSON raw untouched", () => {
+    const raw = "plain text not json";
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe(raw);
+  });
+  it("returns raw when path is empty", () => {
+    expect(normalizeContent("", "{}")).toBe("{}");
+  });
+  it("returns raw on JSON parse failure", () => {
+    const broken = "{not:valid,json";
+    expect(normalizeContent("/sessions/u/x.jsonl", broken)).toBe(broken);
+  });
+  it("returns raw on unknown JSON shape", () => {
+    const raw = JSON.stringify({ foo: "bar", baz: 1 });
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe(raw);
+  });
+});
+
+describe("normalizeContent: LoCoMo benchmark shape", () => {
+  const raw = JSON.stringify({
+    date_time: "1:56 pm on 8 May, 2023",
+    speakers: { speaker_a: "Caroline", speaker_b: "Melanie" },
+    turns: [
+      { dia_id: "D1:1", speaker: "Caroline", text: "Hey Mel!" },
+      { dia_id: "D1:2", speaker: "Melanie", text: "Hi Caroline." },
+    ],
+  });
+
+  it("emits date and speakers header", () => {
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("date: 1:56 pm on 8 May, 2023");
+    expect(out).toContain("speakers: Caroline, Melanie");
+  });
+
+  it("emits one line per turn with dia_id tag", () => {
+    const out = normalizeContent("/sessions/conv_0_session_1.json", raw);
+    expect(out).toContain("[D1:1] Caroline: Hey Mel!");
+    expect(out).toContain("[D1:2] Melanie: Hi Caroline.");
+  });
+
+  it("falls back gracefully on turns without speaker/text", () => {
+    const weird = JSON.stringify({ turns: [{}, { speaker: "X" }] });
+    const out = normalizeContent("/sessions/conv_0_session_1.json", weird);
+    // Must not crash; includes placeholder `?` for missing speaker
+    expect(out).toContain("?: ");
+    expect(out).toContain("X: ");
+  });
+
+  it("returns raw when turns produce an empty serialization", () => {
+    const empty = JSON.stringify({ turns: [] });
+    // No header, no turns → trimmed output is empty → fallback to raw
+    const out = normalizeContent("/sessions/conv_0_session_1.json", empty);
+    expect(out).toBe(empty);
+  });
+});
+
+describe("normalizeContent: production user_message", () => {
+  it("extracts content with [user] prefix", () => {
+    const raw = JSON.stringify({ type: "user_message", content: "hello world" });
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe("[user] hello world");
+  });
+
+  it("returns raw when content is missing (would be bare prefix)", () => {
+    const raw = JSON.stringify({ type: "user_message" });
+    // output would be "[user] " → trimmed is "[user]" → safe fallback to raw
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe(raw);
+  });
+});
+
+describe("normalizeContent: production assistant_message", () => {
+  it("emits [assistant] prefix when no agent_type", () => {
+    const raw = JSON.stringify({ type: "assistant_message", content: "hi" });
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe("[assistant] hi");
+  });
+
+  it("includes agent_type when present (SubagentStop)", () => {
+    const raw = JSON.stringify({
+      type: "assistant_message",
+      content: "done",
+      agent_type: "Explore",
+    });
+    expect(normalizeContent("/sessions/u/x.jsonl", raw)).toBe("[assistant (agent=Explore)] done");
+  });
+});
+
+describe("normalizeContent: production tool_call", () => {
+  it("Bash with stdout/stderr — extracts stdout, drops boilerplate", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Bash",
+      tool_input: JSON.stringify({ command: "ls", description: "list" }),
+      tool_response: JSON.stringify({
+        stdout: "foo\nbar",
+        stderr: "",
+        interrupted: false,
+        isImage: false,
+      }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("[tool:Bash]");
+    expect(out).toContain("command: ls");
+    expect(out).toContain("foo\nbar");
+    expect(out).not.toContain("interrupted");
+    expect(out).not.toContain("isImage");
+  });
+
+  it("Edit collapses response to [wrote <path>]", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Edit",
+      tool_input: JSON.stringify({ file_path: "/x/y.ts", old_string: "a", new_string: "b" }),
+      tool_response: JSON.stringify({
+        filePath: "/x/y.ts",
+        oldString: "a",
+        newString: "b",
+        originalFile: "huge content".repeat(1000),
+        structuredPatch: "diff-stuff",
+      }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("[tool:Edit]");
+    expect(out).toContain("file_path: /x/y.ts");
+    expect(out).toContain("[wrote /x/y.ts]");
+    expect(out).not.toContain("huge content");
+    expect(out).not.toContain("structuredPatch");
+  });
+
+  it("TaskUpdate drops duplicated input fields from response", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "TaskUpdate",
+      tool_input: JSON.stringify({ taskId: "T1", status: "completed" }),
+      tool_response: JSON.stringify({
+        success: true,
+        taskId: "T1",
+        updatedFields: ["status"],
+        statusChange: { from: "pending", to: "completed" },
+      }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("taskId: T1");
+    // response collapses to [ok] — taskId dropped as dup, everything else in DROP set
+    expect(out).toContain("response: [ok]");
+  });
+
+  it("preserves stderr when stdout is absent (error-only response)", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Bash",
+      tool_input: JSON.stringify({ command: "false" }),
+      tool_response: JSON.stringify({ stderr: "command failed: exit 1" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("command failed: exit 1");
+  });
+
+  it("handles camel↔snake dedup: file_path input vs filePath response", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "SomeReadLikeTool",
+      tool_input: JSON.stringify({ file_path: "/a/b" }),
+      tool_response: JSON.stringify({ filePath: "/a/b", extra: "kept" }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).not.toMatch(/"filePath":"\/a\/b"/); // filePath dropped as snake dup
+    expect(out).toContain("kept");
+  });
+});
+
+describe("normalizeContent: <recalled-memories> stripping", () => {
+  it("strips a single wrapper block", () => {
+    const raw = JSON.stringify({
+      type: "user_message",
+      content: "\n\n<recalled-memories>\npast stuff here\n</recalled-memories>\nReal prompt.",
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).not.toContain("<recalled-memories>");
+    expect(out).not.toContain("past stuff here");
+    expect(out).toContain("Real prompt.");
+  });
+
+  it("greedy from first open to last close handles nested duplicates", () => {
+    const inner = '{"content":"\\n\\n<recalled-memories>\\n[nested1]\\n"}';
+    const raw = JSON.stringify({
+      type: "user_message",
+      content:
+        "<recalled-memories>\n[p1] " + inner + "\n[p2] " + inner + "\n</recalled-memories>\nActual message.",
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).not.toContain("<recalled-memories>");
+    expect(out).not.toContain("nested1");
+    expect(out).toContain("Actual message.");
+  });
+
+  it("leaves content intact when close tag is missing (malformed)", () => {
+    const raw = JSON.stringify({
+      type: "user_message",
+      content: "<recalled-memories>\nno close\nActual message.",
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    // malformed → we leave the block alone rather than truncate
+    expect(out).toContain("<recalled-memories>");
+    expect(out).toContain("Actual message.");
+  });
+});
+
+// ── buildPathFilter ─────────────────────────────────────────────────────────
+
+describe("buildPathFilter", () => {
+  it("returns empty string for root", () => {
+    expect(buildPathFilter("/")).toBe("");
+    expect(buildPathFilter("")).toBe("");
+  });
+  it("emits equality + prefix match for subpaths", () => {
+    const f = buildPathFilter("/summaries/locomo");
+    expect(f).toContain("path = '/summaries/locomo'");
+    expect(f).toContain("path LIKE '/summaries/locomo/%'");
+  });
+  it("strips trailing slashes", () => {
+    const f = buildPathFilter("/sessions///");
+    expect(f).toContain("path = '/sessions'");
+    expect(f).toContain("path LIKE '/sessions/%'");
+  });
+});
+
+// ── compileGrepRegex ────────────────────────────────────────────────────────
+
+describe("compileGrepRegex", () => {
+  const base = { pattern: "foo", ignoreCase: false, wordMatch: false, filesOnly: false, countOnly: false, lineNumber: false, invertMatch: false, fixedString: false };
+
+  it("returns a case-insensitive regex when ignoreCase is set", () => {
+    const re = compileGrepRegex({ ...base, ignoreCase: true });
+    expect(re.flags).toContain("i");
+    expect(re.test("FOO")).toBe(true);
+  });
+
+  it("wraps pattern in \\b boundaries when wordMatch is set", () => {
+    const re = compileGrepRegex({ ...base, wordMatch: true });
+    expect(re.test("foo bar")).toBe(true);
+    expect(re.test("foobar")).toBe(false);
+  });
+
+  it("escapes regex metacharacters when fixedString is set", () => {
+    const re = compileGrepRegex({ ...base, pattern: "a.b*c", fixedString: true });
+    expect(re.test("a.b*c")).toBe(true);
+    expect(re.test("axbxc")).toBe(false);
+  });
+
+  it("falls back to an escaped literal regex on bad user input", () => {
+    // `[` alone is invalid as a regex when not fixedString
+    const re = compileGrepRegex({ ...base, pattern: "[unclosed" });
+    expect(re.test("[unclosed")).toBe(true);
+  });
+});
+
+// ── refineGrepMatches ───────────────────────────────────────────────────────
+
+describe("refineGrepMatches", () => {
+  const base = { pattern: "foo", ignoreCase: false, wordMatch: false, filesOnly: false, countOnly: false, lineNumber: false, invertMatch: false, fixedString: false };
+
+  it("returns matching lines with path prefix when multi-file", () => {
+    const out = refineGrepMatches(
+      [
+        { path: "/a", content: "foo\nbar" },
+        { path: "/b", content: "baz\nfoo" },
+      ],
+      base,
+    );
+    expect(out).toContain("/a:foo");
+    expect(out).toContain("/b:foo");
+    expect(out).not.toContain("/a:bar");
+  });
+
+  it("omits path prefix for single-file result", () => {
+    const out = refineGrepMatches([{ path: "/only", content: "foo\nbar" }], base);
+    expect(out).toContain("foo");
+    expect(out.every(l => !l.startsWith("/only:"))).toBe(true);
+  });
+
+  it("filesOnly emits each file at most once", () => {
+    const out = refineGrepMatches(
+      [
+        { path: "/a", content: "foo\nfoo\nfoo" },
+        { path: "/b", content: "foo" },
+      ],
+      { ...base, filesOnly: true },
+    );
+    expect(out).toEqual(["/a", "/b"]);
+  });
+
+  it("countOnly emits a count per file with multi-file prefix", () => {
+    const out = refineGrepMatches(
+      [
+        { path: "/a", content: "foo\nfoo\nbar" },
+        { path: "/b", content: "bar" },
+      ],
+      { ...base, countOnly: true },
+    );
+    expect(out).toContain("/a:2");
+    expect(out).toContain("/b:0");
+  });
+
+  it("invertMatch returns the non-matching lines", () => {
+    const out = refineGrepMatches(
+      [{ path: "/a", content: "foo\nbar\nbaz" }],
+      { ...base, invertMatch: true },
+    );
+    expect(out).toContain("bar");
+    expect(out).toContain("baz");
+    expect(out).not.toContain("foo");
+  });
+
+  it("lineNumber prefixes the 1-based line index", () => {
+    const out = refineGrepMatches(
+      [{ path: "/a", content: "xxx\nfoo\nyyy\nfoo" }],
+      { ...base, lineNumber: true },
+    );
+    expect(out).toContain("2:foo");
+    expect(out).toContain("4:foo");
+  });
+
+  it("skips rows with empty content", () => {
+    const out = refineGrepMatches(
+      [
+        { path: "/a", content: "" },
+        { path: "/b", content: "foo" },
+      ],
+      base,
+    );
+    // multi-file prefix kicks in whenever rows.length > 1, regardless of
+    // whether some rows are empty. The empty-content row is skipped, but
+    // the non-empty one still gets the path prefix.
+    expect(out).toEqual(["/b:foo"]);
+  });
+});

--- a/claude-code/tests/grep-core.test.ts
+++ b/claude-code/tests/grep-core.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   normalizeContent,
   buildPathFilter,
   compileGrepRegex,
   refineGrepMatches,
+  searchDeeplakeTables,
+  grepBothTables,
 } from "../../src/shell/grep-core.js";
 
 // ── normalizeContent ────────────────────────────────────────────────────────
@@ -166,6 +168,64 @@ describe("normalizeContent: production tool_call", () => {
     });
     const out = normalizeContent("/sessions/u/x.jsonl", raw);
     expect(out).toContain("command failed: exit 1");
+  });
+
+  it("Read extracts file.content with filePath header", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Read",
+      tool_input: JSON.stringify({ file_path: "/a/b.ts" }),
+      tool_response: JSON.stringify({ type: "text", file: { filePath: "/a/b.ts", content: "line 1\nline 2" } }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("[/a/b.ts]");
+    expect(out).toContain("line 1");
+  });
+
+  it("Read response with base64 binary emits length placeholder", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Read",
+      tool_input: JSON.stringify({ file_path: "/a/img.png" }),
+      tool_response: JSON.stringify({ type: "image", file: { filePath: "/a/img.png", base64: "AAAA" } }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("[binary /a/img.png: 4 base64 chars]");
+  });
+
+  it("Grep response with filenames[] joins paths by newline", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Grep",
+      tool_input: JSON.stringify({ pattern: "foo" }),
+      tool_response: JSON.stringify({ mode: "files_with_matches", filenames: ["/x.ts", "/y.ts"] }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("/x.ts\n/y.ts");
+  });
+
+  it("Grep matches[] are serialized as lines", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "Grep",
+      tool_input: JSON.stringify({ pattern: "foo" }),
+      tool_response: JSON.stringify({ matches: ["a.ts:1:foo", "b.ts:2:foo"] }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("a.ts:1:foo");
+    expect(out).toContain("b.ts:2:foo");
+  });
+
+  it("WebSearch results[] reduced to title/url per entry", () => {
+    const raw = JSON.stringify({
+      type: "tool_call",
+      tool_name: "WebSearch",
+      tool_input: JSON.stringify({ query: "q" }),
+      tool_response: JSON.stringify({ results: [{ title: "T1", url: "u1" }, "plain"] }),
+    });
+    const out = normalizeContent("/sessions/u/x.jsonl", raw);
+    expect(out).toContain("T1");
+    expect(out).toContain("plain");
   });
 
   it("handles camel↔snake dedup: file_path input vs filePath response", () => {
@@ -333,6 +393,8 @@ describe("refineGrepMatches", () => {
     expect(out).toContain("4:foo");
   });
 
+  // (searchDeeplakeTables + grepBothTables tests below)
+
   it("skips rows with empty content", () => {
     const out = refineGrepMatches(
       [
@@ -345,5 +407,143 @@ describe("refineGrepMatches", () => {
     // whether some rows are empty. The empty-content row is skipped, but
     // the non-empty one still gets the path prefix.
     expect(out).toEqual(["/b:foo"]);
+  });
+});
+
+// ── searchDeeplakeTables ─────────────────────────────────────────────────────
+
+describe("searchDeeplakeTables", () => {
+  function mockApi(memRows: unknown[], sessRows: unknown[]) {
+    const query = vi.fn()
+      .mockImplementationOnce(async () => memRows)
+      .mockImplementationOnce(async () => sessRows);
+    return { query } as any;
+  }
+
+  it("issues one LIKE query per table with the escaped pattern and path filter", async () => {
+    const api = mockApi([], []);
+    await searchDeeplakeTables(api, "memory", "sessions", {
+      pathFilter: " AND (path = '/x' OR path LIKE '/x/%')",
+      contentScanOnly: false,
+      likeOp: "ILIKE",
+      escapedPattern: "foo",
+      limit: 50,
+    });
+    expect(api.query).toHaveBeenCalledTimes(2);
+    const [memCall, sessCall] = api.query.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(memCall).toContain('FROM "memory"');
+    expect(memCall).toContain("summary::text ILIKE '%foo%'");
+    expect(memCall).toContain("LIMIT 50");
+    expect(sessCall).toContain('FROM "sessions"');
+    expect(sessCall).toContain("message::text ILIKE '%foo%'");
+  });
+
+  it("skips LIKE filter when contentScanOnly is true (regex-in-memory mode)", async () => {
+    const api = mockApi([], []);
+    await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "",
+      contentScanOnly: true,
+      likeOp: "LIKE",
+      escapedPattern: "anything",
+    });
+    const [memCall, sessCall] = api.query.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(memCall).not.toContain("LIKE");
+    expect(sessCall).not.toContain("LIKE");
+  });
+
+  it("concatenates rows from both tables into {path, content}", async () => {
+    const api = mockApi(
+      [{ path: "/summaries/a", content: "aaa" }],
+      [{ path: "/sessions/b", content: "bbb" }],
+    );
+    const rows = await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    expect(rows).toEqual([
+      { path: "/summaries/a", content: "aaa" },
+      { path: "/sessions/b", content: "bbb" },
+    ]);
+  });
+
+  it("tolerates null content (coerces to empty string)", async () => {
+    const api = mockApi([{ path: "/a", content: null }], []);
+    const rows = await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    expect(rows[0]).toEqual({ path: "/a", content: "" });
+  });
+
+  it("returns partial results when one table query fails", async () => {
+    const api = {
+      query: vi.fn()
+        .mockImplementationOnce(async () => [{ path: "/a", content: "ok" }])
+        .mockImplementationOnce(async () => { throw new Error("boom"); }),
+    } as any;
+    const rows = await searchDeeplakeTables(api, "m", "s", {
+      pathFilter: "", contentScanOnly: false, likeOp: "LIKE", escapedPattern: "x",
+    });
+    expect(rows).toEqual([{ path: "/a", content: "ok" }]);
+  });
+});
+
+// ── grepBothTables (end-to-end convenience wrapper) ─────────────────────────
+
+describe("grepBothTables", () => {
+  function mockApi(rows: unknown[]) {
+    return {
+      query: vi.fn()
+        .mockResolvedValueOnce(rows)  // memory
+        .mockResolvedValueOnce([]),   // sessions (empty in these tests)
+    } as any;
+  }
+
+  const baseParams = {
+    pattern: "foo", ignoreCase: false, wordMatch: false,
+    filesOnly: false, countOnly: false, lineNumber: false,
+    invertMatch: false, fixedString: false,
+  };
+
+  it("returns matched lines from memory rows", async () => {
+    const api = mockApi([{ path: "/summaries/a", content: "foo line\nbar" }]);
+    const out = await grepBothTables(api, "memory", "sessions", baseParams, "/");
+    expect(out).toContain("foo line");
+    expect(out).not.toContain("bar");
+  });
+
+  it("deduplicates rows by path when memory and sessions return the same path", async () => {
+    const api = {
+      query: vi.fn()
+        .mockResolvedValueOnce([{ path: "/shared", content: "foo" }])
+        .mockResolvedValueOnce([{ path: "/shared", content: "foo" }]),
+    } as any;
+    const out = await grepBothTables(api, "m", "s", baseParams, "/");
+    // only one line for the shared path
+    expect(out.length).toBe(1);
+  });
+
+  it("normalizes session JSON before refinement (LoCoMo turns)", async () => {
+    const sessionContent = JSON.stringify({
+      turns: [
+        { dia_id: "D1:1", speaker: "Alice", text: "greeting foo here" },
+        { dia_id: "D1:2", speaker: "Bob", text: "unrelated" },
+      ],
+    });
+    const api = {
+      query: vi.fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ path: "/sessions/conv_0_session_1.json", content: sessionContent }]),
+    } as any;
+    const out = await grepBothTables(api, "m", "s", baseParams, "/");
+    // Only the matching turn is returned, not the whole JSON blob
+    expect(out.some(l => l.includes("[D1:1] Alice: greeting foo here"))).toBe(true);
+    expect(out.some(l => l.includes("unrelated"))).toBe(false);
+  });
+
+  it("uses contentScanOnly when pattern has regex metacharacters", async () => {
+    const api = mockApi([{ path: "/a", content: "this is a test" }]);
+    await grepBothTables(api, "m", "s", { ...baseParams, pattern: "t.*t" }, "/");
+    const [memSql] = api.query.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(memSql).not.toContain("ILIKE");
+    expect(memSql).not.toContain("summary::text LIKE");
   });
 });

--- a/claude-code/tests/grep-direct.test.ts
+++ b/claude-code/tests/grep-direct.test.ts
@@ -1,5 +1,100 @@
-import { describe, it, expect } from "vitest";
-import { parseBashGrep, type GrepParams } from "../../src/hooks/grep-direct.js";
+import { describe, it, expect, vi } from "vitest";
+import { parseBashGrep, handleGrepDirect, type GrepParams } from "../../src/hooks/grep-direct.js";
+
+describe("handleGrepDirect", () => {
+  const baseParams: GrepParams = {
+    pattern: "foo", targetPath: "/",
+    ignoreCase: false, wordMatch: false, filesOnly: false, countOnly: false,
+    lineNumber: false, invertMatch: false, fixedString: false,
+  };
+
+  function mockApi(mem: unknown[], sess: unknown[]) {
+    return {
+      query: vi.fn()
+        .mockImplementationOnce(async () => mem)
+        .mockImplementationOnce(async () => sess),
+    } as any;
+  }
+
+  it("returns null when pattern is empty", async () => {
+    const api = mockApi([], []);
+    const r = await handleGrepDirect(api, "memory", "sessions", { ...baseParams, pattern: "" });
+    expect(r).toBeNull();
+    expect(api.query).not.toHaveBeenCalled();
+  });
+
+  it("delegates to grepBothTables and joins the match lines", async () => {
+    const api = mockApi(
+      [{ path: "/summaries/a.md", content: "foo line here\nbar line" }],
+      [],
+    );
+    const r = await handleGrepDirect(api, "memory", "sessions", baseParams);
+    expect(r).toBe("foo line here");
+  });
+
+  it("emits '(no matches)' when both tables return nothing", async () => {
+    const api = mockApi([], []);
+    const r = await handleGrepDirect(api, "memory", "sessions", baseParams);
+    expect(r).toBe("(no matches)");
+  });
+
+  it("merges results from both memory and sessions", async () => {
+    const api = mockApi(
+      [{ path: "/summaries/a.md", content: "foo in summary" }],
+      [{ path: "/sessions/b.jsonl", content: "foo in session" }],
+    );
+    const r = await handleGrepDirect(api, "memory", "sessions", baseParams);
+    expect(r).toContain("/summaries/a.md:foo in summary");
+    expect(r).toContain("/sessions/b.jsonl:foo in session");
+  });
+
+  it("applies ignoreCase flag at SQL level (ILIKE)", async () => {
+    const api = mockApi([{ path: "/a", content: "Foo" }], []);
+    await handleGrepDirect(api, "memory", "sessions", { ...baseParams, ignoreCase: true });
+    const sql = api.query.mock.calls[0][0] as string;
+    expect(sql).toContain("ILIKE");
+  });
+});
+
+describe("parseBashGrep: long options", () => {
+  // Exercises every --long-option handler so the arrow-fn table inside
+  // parseBashGrep is fully covered.
+
+  it("--ignore-case", () => {
+    const r = parseBashGrep("grep --ignore-case foo /x");
+    expect(r!.ignoreCase).toBe(true);
+  });
+  it("--word-regexp", () => {
+    const r = parseBashGrep("grep --word-regexp foo /x");
+    expect(r!.wordMatch).toBe(true);
+  });
+  it("--files-with-matches", () => {
+    const r = parseBashGrep("grep --files-with-matches foo /x");
+    expect(r!.filesOnly).toBe(true);
+  });
+  it("--count", () => {
+    const r = parseBashGrep("grep --count foo /x");
+    expect(r!.countOnly).toBe(true);
+  });
+  it("--line-number", () => {
+    const r = parseBashGrep("grep --line-number foo /x");
+    expect(r!.lineNumber).toBe(true);
+  });
+  it("--invert-match", () => {
+    const r = parseBashGrep("grep --invert-match foo /x");
+    expect(r!.invertMatch).toBe(true);
+  });
+  it("--fixed-strings", () => {
+    const r = parseBashGrep("grep --fixed-strings foo /x");
+    expect(r!.fixedString).toBe(true);
+  });
+  it("unknown --long option is a no-op (does not crash)", () => {
+    const r = parseBashGrep("grep --unknown-flag foo /x");
+    expect(r).not.toBeNull();
+    expect(r!.pattern).toBe("foo");
+  });
+});
+
 
 describe("parseBashGrep", () => {
   // ── Basic parsing ──

--- a/claude-code/tests/grep-interceptor.test.ts
+++ b/claude-code/tests/grep-interceptor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createGrepCommand } from "../../src/shell/grep-interceptor.js";
 import { DeeplakeFs } from "../../src/shell/deeplake-fs.js";
 
@@ -16,23 +16,23 @@ function makeClient(queryResults: Record<string, string>[] = []) {
   };
 }
 
-async function makeFs(files: Record<string, string> = {}) {
-  const client = makeClient();
-  const fs = await DeeplakeFs.create(client as never, "test", "/memory");
-  for (const [path, content] of Object.entries(files)) {
-    await fs.writeFile(path, content);
-  }
-  return { fs, client };
-}
-
 function makeCtx(fs: DeeplakeFs, cwd = "/memory") {
   return { fs, cwd, env: new Map<string, string>(), stdin: "" };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+//
+// The interceptor now queries both `memory` and `sessions` in parallel with
+// LIKE/ILIKE (no more BM25 — the `<#>` query returned 400 on every call),
+// and each SQL row returns { path, content } so we no longer need a
+// prefetch round-trip to read file content for the regex pass. Prefetch is
+// only used as a fallback when SQL returns zero rows and we scan the FS
+// cache. Tests below assert that new contract.
+
 describe("grep interceptor", () => {
   it("returns exitCode=127 for paths outside mount (pass-through)", async () => {
-    const { fs, client } = await makeFs({});
+    const client = makeClient();
+    const fs = await DeeplakeFs.create(client as never, "test", "/memory");
     client.query.mockClear(); // clear bootstrap calls
     const cmd = createGrepCommand(client as never, fs, "test");
     const result = await cmd.execute(["foo", "/etc/hosts"], makeCtx(fs) as never);
@@ -40,37 +40,39 @@ describe("grep interceptor", () => {
     expect(client.query).not.toHaveBeenCalled();
   });
 
-  it("uses BM25 query when pattern matches files", async () => {
-    const { fs } = await makeFs({ "/memory/a.txt": "hello world", "/memory/b.txt": "goodbye" });
+  it("queries both memory and sessions tables with LIKE and returns matches", async () => {
+    const client = makeClient([{ path: "/memory/a.txt", content: "hello world" }]);
+    const fs = await DeeplakeFs.create(client as never, "test", "/memory");
+    client.query.mockClear();
+    // Both mem and sess queries should run; return matching content for both.
+    client.query.mockResolvedValue([{ path: "/memory/a.txt", content: "hello world" }]);
 
-    const client = makeClient([{ path: "/memory/a.txt" }]);
-    // Re-create fs with this client so getField works for readFile
-    const fs2 = await DeeplakeFs.create(client as never, "test", "/memory");
-    await fs2.writeFile("/memory/a.txt", "hello world");
-    await fs2.writeFile("/memory/b.txt", "goodbye");
+    const cmd = createGrepCommand(client as never, fs, "test", "sessions");
+    const result = await cmd.execute(["hello", "/memory"], makeCtx(fs) as never);
 
-    const cmd = createGrepCommand(client as never, fs2, "test");
-    const result = await cmd.execute(["hello", "/memory"], makeCtx(fs2) as never);
-
-    expect(client.query).toHaveBeenCalledWith(expect.stringContaining("<#>"));
-    expect(result.stdout).toContain("hello");
+    // At least one call for memory + one for sessions
+    const sqls = client.query.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(sqls.some(s => /FROM "test"/.test(s) && /ILIKE|LIKE/.test(s))).toBe(true);
+    expect(sqls.some(s => /FROM "sessions"/.test(s) && /ILIKE|LIKE/.test(s))).toBe(true);
+    // No BM25 in the new path
+    expect(sqls.some(s => s.includes("<#>"))).toBe(false);
+    expect(result.stdout).toContain("hello world");
     expect(result.exitCode).toBe(0);
   });
 
-  it("falls back to in-memory search when BM25 returns nothing", async () => {
+  it("falls back to in-memory scan when SQL returns nothing", async () => {
     const client = makeClient([]);
-
     const fs = await DeeplakeFs.create(client as never, "test", "/memory");
     await fs.writeFile("/memory/a.txt", "hello world");
-    client.query.mockClear(); // clear bootstrap + write calls
-    // BM25 returns no results — should fall back to in-memory getAllPaths
-    client.query.mockResolvedValueOnce([]);
+    client.query.mockClear();
+    client.query.mockResolvedValue([]); // SQL returns no rows for both tables
 
     const cmd = createGrepCommand(client as never, fs, "test");
     const result = await cmd.execute(["hello", "/memory"], makeCtx(fs) as never);
 
-    const calls = client.query.mock.calls as [string][];
-    expect(calls[0][0]).toContain("<#>");
+    // SQL was attempted
+    expect(client.query).toHaveBeenCalled();
+    // Fallback still found the content via fs.readFile
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("hello world");
   });
@@ -85,9 +87,8 @@ describe("grep interceptor", () => {
   });
 
   it("respects -i (ignore-case) flag", async () => {
-    const client = makeClient([{ path: "/memory/a.txt" }]);
+    const client = makeClient([{ path: "/memory/a.txt", content: "Hello World" }]);
     const fs = await DeeplakeFs.create(client as never, "test", "/memory");
-    await fs.writeFile("/memory/a.txt", "Hello World");
 
     const cmd = createGrepCommand(client as never, fs, "test");
     const result = await cmd.execute(["-i", "hello", "/memory"], makeCtx(fs) as never);
@@ -98,12 +99,10 @@ describe("grep interceptor", () => {
 
   it("respects -l (files-only) flag", async () => {
     const client = makeClient([
-      { path: "/memory/a.txt" },
-      { path: "/memory/b.txt" },
+      { path: "/memory/a.txt", content: "match here\nmatch again" },
+      { path: "/memory/b.txt", content: "also match" },
     ]);
     const fs = await DeeplakeFs.create(client as never, "test", "/memory");
-    await fs.writeFile("/memory/a.txt", "match here\nmatch again");
-    await fs.writeFile("/memory/b.txt", "also match");
 
     const cmd = createGrepCommand(client as never, fs, "test");
     const result = await cmd.execute(["-l", "match", "/memory"], makeCtx(fs) as never);
@@ -116,9 +115,10 @@ describe("grep interceptor", () => {
   });
 
   it("respects -v (invert-match) flag", async () => {
-    const client = makeClient([{ path: "/memory/a.txt" }]);
+    const client = makeClient([
+      { path: "/memory/a.txt", content: "keep this\nremove match\nkeep this too" },
+    ]);
     const fs = await DeeplakeFs.create(client as never, "test", "/memory");
-    await fs.writeFile("/memory/a.txt", "keep this\nremove match\nkeep this too");
 
     const cmd = createGrepCommand(client as never, fs, "test");
     const result = await cmd.execute(["-v", "match", "/memory"], makeCtx(fs) as never);
@@ -127,20 +127,36 @@ describe("grep interceptor", () => {
     expect(result.stdout).not.toContain("remove match");
   });
 
-  it("uses batch prefetch instead of per-file reads", async () => {
+  it("SQL rows carry their own content — no prefetch when SQL hits", async () => {
     const client = makeClient([
-      { path: "/memory/a.txt" },
-      { path: "/memory/b.txt" },
+      { path: "/memory/a.txt", content: "hello world" },
+      { path: "/memory/b.txt", content: "hello there" },
     ]);
+    const fs = await DeeplakeFs.create(client as never, "test", "/memory");
+
+    const prefetchSpy = vi.spyOn(fs, "prefetch");
+    const readSpy = vi.spyOn(fs, "readFile");
+    const cmd = createGrepCommand(client as never, fs, "test");
+    await cmd.execute(["hello", "/memory"], makeCtx(fs) as never);
+
+    // The new path gets content from the SQL rows directly, so no FS
+    // round-trips are needed on the happy path.
+    expect(prefetchSpy).not.toHaveBeenCalled();
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("fallback path prefetches the FS cache when SQL is empty", async () => {
+    const client = makeClient([]);
     const fs = await DeeplakeFs.create(client as never, "test", "/memory");
     await fs.writeFile("/memory/a.txt", "hello world");
     await fs.writeFile("/memory/b.txt", "hello there");
+    client.query.mockClear();
+    client.query.mockResolvedValue([]);
 
     const prefetchSpy = vi.spyOn(fs, "prefetch");
     const cmd = createGrepCommand(client as never, fs, "test");
     await cmd.execute(["hello", "/memory"], makeCtx(fs) as never);
 
-    // Should call prefetch once with all candidates, not individual readFile calls
     expect(prefetchSpy).toHaveBeenCalledTimes(1);
     expect(prefetchSpy).toHaveBeenCalledWith(
       expect.arrayContaining(["/memory/a.txt", "/memory/b.txt"])

--- a/claude-code/vitest.config.ts
+++ b/claude-code/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    include: ["tests/**/*.test.ts"],
-    environment: "node",
-  },
-});

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -562,15 +562,11 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
       continue;
     const lines = row.content.split("\n");
     const matched = [];
-    let fileEmitted = false;
     for (let i = 0; i < lines.length; i++) {
       const hit = re.test(lines[i]);
       if (hit !== !!params.invertMatch) {
         if (params.filesOnly) {
-          if (!fileEmitted) {
-            output.push(row.path);
-            fileEmitted = true;
-          }
+          output.push(row.path);
           break;
         }
         const prefix = multi ? `${row.path}:` : "";

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -310,6 +310,292 @@ var DeeplakeApi = class {
   }
 };
 
+// dist/src/shell/grep-core.js
+var TOOL_INPUT_FIELDS = [
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "prompt",
+  "subagent_type",
+  "query",
+  "url",
+  "notebook_path",
+  "old_string",
+  "new_string",
+  "content",
+  "skill",
+  "args",
+  "taskId",
+  "status",
+  "subject",
+  "description",
+  "to",
+  "message",
+  "summary",
+  "max_results"
+];
+var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  "interrupted",
+  "isImage",
+  "noOutputExpected",
+  "type",
+  "stderr",
+  "structuredPatch",
+  "userModified",
+  "originalFile",
+  "replaceAll",
+  "totalDurationMs",
+  "totalTokens",
+  "totalToolUseCount",
+  "usage",
+  "toolStats",
+  "durationMs",
+  "durationSeconds",
+  "bytes",
+  "code",
+  "codeText",
+  "agentId",
+  "agentType",
+  "verificationNudgeNeeded",
+  "numLines",
+  "numFiles",
+  "truncated",
+  "statusChange",
+  "updatedFields",
+  "isAgent",
+  "success"
+]);
+function maybeParseJson(v) {
+  if (typeof v !== "string")
+    return v;
+  const s = v.trim();
+  if (s[0] !== "{" && s[0] !== "[")
+    return v;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return v;
+  }
+}
+function snakeCase(k) {
+  return k.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+function camelCase(k) {
+  return k.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+function formatToolInput(raw) {
+  const p = maybeParseJson(raw);
+  if (typeof p !== "object" || p === null)
+    return String(p ?? "");
+  const parts = [];
+  for (const k of TOOL_INPUT_FIELDS) {
+    if (p[k] === void 0)
+      continue;
+    const v = p[k];
+    parts.push(`${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`);
+  }
+  for (const k of ["glob", "output_mode", "limit", "offset"]) {
+    if (p[k] !== void 0)
+      parts.push(`${k}: ${p[k]}`);
+  }
+  return parts.length ? parts.join("\n") : JSON.stringify(p);
+}
+function formatToolResponse(raw, inp, toolName) {
+  const r = maybeParseJson(raw);
+  if (typeof r !== "object" || r === null)
+    return String(r ?? "");
+  if (toolName === "Edit" || toolName === "Write" || toolName === "MultiEdit") {
+    return r.filePath ? `[wrote ${r.filePath}]` : "[ok]";
+  }
+  if (typeof r.stdout === "string") {
+    const stderr = r.stderr;
+    return r.stdout + (stderr ? `
+stderr: ${stderr}` : "");
+  }
+  if (typeof r.content === "string")
+    return r.content;
+  if (r.file && typeof r.file === "object") {
+    const f = r.file;
+    if (typeof f.content === "string")
+      return `[${f.filePath ?? ""}]
+${f.content}`;
+    if (typeof f.base64 === "string")
+      return `[binary ${f.filePath ?? ""}: ${f.base64.length} base64 chars]`;
+  }
+  if (Array.isArray(r.filenames))
+    return r.filenames.join("\n");
+  if (Array.isArray(r.matches)) {
+    return r.matches.map((m) => typeof m === "string" ? m : JSON.stringify(m)).join("\n");
+  }
+  if (Array.isArray(r.results)) {
+    return r.results.map((x) => typeof x === "string" ? x : x?.title ?? x?.url ?? JSON.stringify(x)).join("\n");
+  }
+  const inpObj = maybeParseJson(inp);
+  const kept = {};
+  for (const [k, v] of Object.entries(r)) {
+    if (TOOL_RESPONSE_DROP.has(k))
+      continue;
+    if (v === "" || v === false || v == null)
+      continue;
+    if (typeof inpObj === "object" && inpObj) {
+      const inObj = inpObj;
+      if (k in inObj && JSON.stringify(inObj[k]) === JSON.stringify(v))
+        continue;
+      const snake = snakeCase(k);
+      if (snake in inObj && JSON.stringify(inObj[snake]) === JSON.stringify(v))
+        continue;
+      const camel = camelCase(k);
+      if (camel in inObj && JSON.stringify(inObj[camel]) === JSON.stringify(v))
+        continue;
+    }
+    kept[k] = v;
+  }
+  return Object.keys(kept).length ? JSON.stringify(kept) : "[ok]";
+}
+function formatToolCall(obj) {
+  return `[tool:${obj?.tool_name ?? "?"}]
+input: ${formatToolInput(obj?.tool_input)}
+response: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
+}
+function normalizeContent(path, raw) {
+  if (!path.includes("/sessions/"))
+    return raw;
+  if (!raw || raw[0] !== "{")
+    return raw;
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (Array.isArray(obj.turns)) {
+    const header = [];
+    if (obj.date_time)
+      header.push(`date: ${obj.date_time}`);
+    if (obj.speakers) {
+      const s = obj.speakers;
+      const names = [s.speaker_a, s.speaker_b].filter(Boolean).join(", ");
+      if (names)
+        header.push(`speakers: ${names}`);
+    }
+    const lines = obj.turns.map((t) => {
+      const sp = String(t?.speaker ?? t?.name ?? "?").trim();
+      const tx = String(t?.text ?? t?.content ?? "").replace(/\s+/g, " ").trim();
+      const tag = t?.dia_id ? `[${t.dia_id}] ` : "";
+      return `${tag}${sp}: ${tx}`;
+    });
+    const out2 = [...header, ...lines].join("\n");
+    return out2.trim() ? out2 : raw;
+  }
+  const stripRecalled = (t) => {
+    const i = t.indexOf("<recalled-memories>");
+    if (i === -1)
+      return t;
+    const j = t.lastIndexOf("</recalled-memories>");
+    if (j === -1 || j < i)
+      return t;
+    const head = t.slice(0, i);
+    const tail = t.slice(j + "</recalled-memories>".length);
+    return (head + tail).replace(/^\s+/, "").replace(/\n{3,}/g, "\n\n");
+  };
+  let out = null;
+  if (obj.type === "user_message") {
+    out = `[user] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "assistant_message") {
+    const agent = obj.agent_type ? ` (agent=${obj.agent_type})` : "";
+    out = `[assistant${agent}] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "tool_call") {
+    out = formatToolCall(obj);
+  }
+  if (out === null)
+    return raw;
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "[user]" || trimmed === "[assistant]" || /^\[tool:[^\]]*\]\s+input:\s+\{\}\s+response:\s+\{\}$/.test(trimmed))
+    return raw;
+  return out;
+}
+async function searchDeeplakeTables(api, memoryTable, sessionsTable, opts) {
+  const { pathFilter, contentScanOnly, likeOp, escapedPattern } = opts;
+  const limit = opts.limit ?? 100;
+  const memFilter = contentScanOnly ? "" : ` AND summary::text ${likeOp} '%${escapedPattern}%'`;
+  const sessFilter = contentScanOnly ? "" : ` AND message::text ${likeOp} '%${escapedPattern}%'`;
+  const memQuery = `SELECT path, summary::text AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${limit}`;
+  const sessQuery = `SELECT path, message::text AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${limit}`;
+  const [memRows, sessRows] = await Promise.all([
+    api.query(memQuery).catch(() => []),
+    api.query(sessQuery).catch(() => [])
+  ]);
+  const rows = [];
+  for (const r of memRows)
+    rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  for (const r of sessRows)
+    rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  return rows;
+}
+function buildPathFilter(targetPath) {
+  if (!targetPath || targetPath === "/")
+    return "";
+  const clean = targetPath.replace(/\/+$/, "");
+  return ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
+}
+function compileGrepRegex(params) {
+  let reStr = params.fixedString ? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : params.pattern;
+  if (params.wordMatch)
+    reStr = `\\b${reStr}\\b`;
+  try {
+    return new RegExp(reStr, params.ignoreCase ? "i" : "");
+  } catch {
+    return new RegExp(params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), params.ignoreCase ? "i" : "");
+  }
+}
+function refineGrepMatches(rows, params, forceMultiFilePrefix) {
+  const re = compileGrepRegex(params);
+  const multi = forceMultiFilePrefix ?? rows.length > 1;
+  const output = [];
+  for (const row of rows) {
+    if (!row.content)
+      continue;
+    const lines = row.content.split("\n");
+    const matched = [];
+    let fileEmitted = false;
+    for (let i = 0; i < lines.length; i++) {
+      const hit = re.test(lines[i]);
+      if (hit !== !!params.invertMatch) {
+        if (params.filesOnly) {
+          if (!fileEmitted) {
+            output.push(row.path);
+            fileEmitted = true;
+          }
+          break;
+        }
+        const prefix = multi ? `${row.path}:` : "";
+        const ln = params.lineNumber ? `${i + 1}:` : "";
+        matched.push(`${prefix}${ln}${lines[i]}`);
+      }
+    }
+    if (!params.filesOnly) {
+      if (params.countOnly) {
+        output.push(`${multi ? `${row.path}:` : ""}${matched.length}`);
+      } else {
+        output.push(...matched);
+      }
+    }
+  }
+  return output;
+}
+async function grepBothTables(api, memoryTable, sessionsTable, params, targetPath) {
+  const hasRegexMeta = !params.fixedString && /[.*+?^${}()|[\]\\]/.test(params.pattern);
+  const rows = await searchDeeplakeTables(api, memoryTable, sessionsTable, {
+    pathFilter: buildPathFilter(targetPath),
+    contentScanOnly: hasRegexMeta,
+    likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
+    escapedPattern: sqlLike(params.pattern)
+  });
+  const normalized = rows.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  return refineGrepMatches(normalized, params);
+}
+
 // dist/src/hooks/grep-direct.js
 function parseBashGrep(cmd) {
   const first = cmd.trim().split(/\s*\|\s*/)[0];
@@ -419,67 +705,17 @@ function parseBashGrep(cmd) {
 async function handleGrepDirect(api, table, sessionsTable, params) {
   if (!params.pattern)
     return null;
-  const { pattern, targetPath, ignoreCase, wordMatch, filesOnly, countOnly, lineNumber, invertMatch, fixedString } = params;
-  const likeOp = ignoreCase ? "ILIKE" : "LIKE";
-  const escapedLike = sqlLike(pattern);
-  let pathFilter = "";
-  if (targetPath && targetPath !== "/") {
-    const clean = targetPath.replace(/\/+$/, "");
-    pathFilter = ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
-  }
-  const hasRegexMeta = !fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
-  let rows = [];
-  if (!hasRegexMeta) {
-    const contentFilter = ` AND summary ${likeOp} '%${escapedLike}%'`;
-    try {
-      rows = await api.query(`SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter}${contentFilter} LIMIT 100`);
-    } catch {
-      rows = [];
-    }
-  } else {
-    try {
-      rows = await api.query(`SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter} LIMIT 100`);
-    } catch {
-      rows = [];
-    }
-  }
-  let reStr = fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern;
-  if (wordMatch)
-    reStr = `\\b${reStr}\\b`;
-  let re;
-  try {
-    re = new RegExp(reStr, ignoreCase ? "i" : "");
-  } catch {
-    re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), ignoreCase ? "i" : "");
-  }
-  const output = [];
-  const multi = rows.length > 1;
-  for (const row of rows) {
-    const p = row["path"];
-    const text = row["content"];
-    if (!text)
-      continue;
-    const lines = text.split("\n");
-    const matched = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (re.test(lines[i]) !== !!invertMatch) {
-        if (filesOnly) {
-          output.push(p);
-          break;
-        }
-        const prefix = multi ? `${p}:` : "";
-        const ln = lineNumber ? `${i + 1}:` : "";
-        matched.push(`${prefix}${ln}${lines[i]}`);
-      }
-    }
-    if (!filesOnly) {
-      if (countOnly) {
-        output.push(`${multi ? `${p}:` : ""}${matched.length}`);
-      } else {
-        output.push(...matched);
-      }
-    }
-  }
+  const matchParams = {
+    pattern: params.pattern,
+    ignoreCase: params.ignoreCase,
+    wordMatch: params.wordMatch,
+    filesOnly: params.filesOnly,
+    countOnly: params.countOnly,
+    lineNumber: params.lineNumber,
+    invertMatch: params.invertMatch,
+    fixedString: params.fixedString
+  };
+  const output = await grepBothTables(api, table, sessionsTable, matchParams, params.targetPath);
   return output.join("\n") || "(no matches)";
 }
 

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -336,11 +336,15 @@ var TOOL_INPUT_FIELDS = [
   "max_results"
 ];
 var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  // Note: `stderr` is intentionally NOT in this set. The `stdout` high-signal
+  // branch below already de-dupes it for the common case (appends as suffix
+  // when non-empty). If a tool response has ONLY `stderr` and no `stdout`
+  // (hard-failure on some tools), the generic cleanup preserves it so the
+  // error message reaches Claude instead of collapsing to `[ok]`.
   "interrupted",
   "isImage",
   "noOutputExpected",
   "type",
-  "stderr",
   "structuredPatch",
   "userModified",
   "originalFile",
@@ -592,7 +596,9 @@ async function grepBothTables(api, memoryTable, sessionsTable, params, targetPat
     likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
     escapedPattern: sqlLike(params.pattern)
   });
-  const normalized = rows.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  const seen = /* @__PURE__ */ new Set();
+  const unique = rows.filter((r) => seen.has(r.path) ? false : (seen.add(r.path), true));
+  const normalized = unique.map((r) => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
   return refineGrepMatches(normalized, params);
 }
 

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -68811,15 +68811,11 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
       continue;
     const lines = row.content.split("\n");
     const matched = [];
-    let fileEmitted = false;
     for (let i11 = 0; i11 < lines.length; i11++) {
       const hit = re9.test(lines[i11]);
       if (hit !== !!params.invertMatch) {
         if (params.filesOnly) {
-          if (!fileEmitted) {
-            output.push(row.path);
-            fileEmitted = true;
-          }
+          output.push(row.path);
           break;
         }
         const prefix = multi ? `${row.path}:` : "";

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -68585,11 +68585,15 @@ var TOOL_INPUT_FIELDS = [
   "max_results"
 ];
 var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  // Note: `stderr` is intentionally NOT in this set. The `stdout` high-signal
+  // branch below already de-dupes it for the common case (appends as suffix
+  // when non-empty). If a tool response has ONLY `stderr` and no `stdout`
+  // (hard-failure on some tools), the generic cleanup preserves it so the
+  // error message reaches Claude instead of collapsing to `[ok]`.
   "interrupted",
   "isImage",
   "noOutputExpected",
   "type",
-  "stderr",
   "structuredPatch",
   "userModified",
   "originalFile",

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -68559,13 +68559,298 @@ yargsParser.decamelize = decamelize;
 yargsParser.looksLikeNumber = looksLikeNumber;
 var lib_default = yargsParser;
 
+// dist/src/shell/grep-core.js
+var TOOL_INPUT_FIELDS = [
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "prompt",
+  "subagent_type",
+  "query",
+  "url",
+  "notebook_path",
+  "old_string",
+  "new_string",
+  "content",
+  "skill",
+  "args",
+  "taskId",
+  "status",
+  "subject",
+  "description",
+  "to",
+  "message",
+  "summary",
+  "max_results"
+];
+var TOOL_RESPONSE_DROP = /* @__PURE__ */ new Set([
+  "interrupted",
+  "isImage",
+  "noOutputExpected",
+  "type",
+  "stderr",
+  "structuredPatch",
+  "userModified",
+  "originalFile",
+  "replaceAll",
+  "totalDurationMs",
+  "totalTokens",
+  "totalToolUseCount",
+  "usage",
+  "toolStats",
+  "durationMs",
+  "durationSeconds",
+  "bytes",
+  "code",
+  "codeText",
+  "agentId",
+  "agentType",
+  "verificationNudgeNeeded",
+  "numLines",
+  "numFiles",
+  "truncated",
+  "statusChange",
+  "updatedFields",
+  "isAgent",
+  "success"
+]);
+function maybeParseJson(v27) {
+  if (typeof v27 !== "string")
+    return v27;
+  const s10 = v27.trim();
+  if (s10[0] !== "{" && s10[0] !== "[")
+    return v27;
+  try {
+    return JSON.parse(s10);
+  } catch {
+    return v27;
+  }
+}
+function snakeCase(k17) {
+  return k17.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+function camelCase2(k17) {
+  return k17.replace(/_([a-z])/g, (_16, c15) => c15.toUpperCase());
+}
+function formatToolInput(raw) {
+  const p22 = maybeParseJson(raw);
+  if (typeof p22 !== "object" || p22 === null)
+    return String(p22 ?? "");
+  const parts = [];
+  for (const k17 of TOOL_INPUT_FIELDS) {
+    if (p22[k17] === void 0)
+      continue;
+    const v27 = p22[k17];
+    parts.push(`${k17}: ${typeof v27 === "string" ? v27 : JSON.stringify(v27)}`);
+  }
+  for (const k17 of ["glob", "output_mode", "limit", "offset"]) {
+    if (p22[k17] !== void 0)
+      parts.push(`${k17}: ${p22[k17]}`);
+  }
+  return parts.length ? parts.join("\n") : JSON.stringify(p22);
+}
+function formatToolResponse(raw, inp, toolName) {
+  const r10 = maybeParseJson(raw);
+  if (typeof r10 !== "object" || r10 === null)
+    return String(r10 ?? "");
+  if (toolName === "Edit" || toolName === "Write" || toolName === "MultiEdit") {
+    return r10.filePath ? `[wrote ${r10.filePath}]` : "[ok]";
+  }
+  if (typeof r10.stdout === "string") {
+    const stderr = r10.stderr;
+    return r10.stdout + (stderr ? `
+stderr: ${stderr}` : "");
+  }
+  if (typeof r10.content === "string")
+    return r10.content;
+  if (r10.file && typeof r10.file === "object") {
+    const f11 = r10.file;
+    if (typeof f11.content === "string")
+      return `[${f11.filePath ?? ""}]
+${f11.content}`;
+    if (typeof f11.base64 === "string")
+      return `[binary ${f11.filePath ?? ""}: ${f11.base64.length} base64 chars]`;
+  }
+  if (Array.isArray(r10.filenames))
+    return r10.filenames.join("\n");
+  if (Array.isArray(r10.matches)) {
+    return r10.matches.map((m26) => typeof m26 === "string" ? m26 : JSON.stringify(m26)).join("\n");
+  }
+  if (Array.isArray(r10.results)) {
+    return r10.results.map((x28) => typeof x28 === "string" ? x28 : x28?.title ?? x28?.url ?? JSON.stringify(x28)).join("\n");
+  }
+  const inpObj = maybeParseJson(inp);
+  const kept = {};
+  for (const [k17, v27] of Object.entries(r10)) {
+    if (TOOL_RESPONSE_DROP.has(k17))
+      continue;
+    if (v27 === "" || v27 === false || v27 == null)
+      continue;
+    if (typeof inpObj === "object" && inpObj) {
+      const inObj = inpObj;
+      if (k17 in inObj && JSON.stringify(inObj[k17]) === JSON.stringify(v27))
+        continue;
+      const snake = snakeCase(k17);
+      if (snake in inObj && JSON.stringify(inObj[snake]) === JSON.stringify(v27))
+        continue;
+      const camel = camelCase2(k17);
+      if (camel in inObj && JSON.stringify(inObj[camel]) === JSON.stringify(v27))
+        continue;
+    }
+    kept[k17] = v27;
+  }
+  return Object.keys(kept).length ? JSON.stringify(kept) : "[ok]";
+}
+function formatToolCall(obj) {
+  return `[tool:${obj?.tool_name ?? "?"}]
+input: ${formatToolInput(obj?.tool_input)}
+response: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
+}
+function normalizeContent(path2, raw) {
+  if (!path2.includes("/sessions/"))
+    return raw;
+  if (!raw || raw[0] !== "{")
+    return raw;
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (Array.isArray(obj.turns)) {
+    const header = [];
+    if (obj.date_time)
+      header.push(`date: ${obj.date_time}`);
+    if (obj.speakers) {
+      const s10 = obj.speakers;
+      const names = [s10.speaker_a, s10.speaker_b].filter(Boolean).join(", ");
+      if (names)
+        header.push(`speakers: ${names}`);
+    }
+    const lines = obj.turns.map((t6) => {
+      const sp = String(t6?.speaker ?? t6?.name ?? "?").trim();
+      const tx = String(t6?.text ?? t6?.content ?? "").replace(/\s+/g, " ").trim();
+      const tag = t6?.dia_id ? `[${t6.dia_id}] ` : "";
+      return `${tag}${sp}: ${tx}`;
+    });
+    const out2 = [...header, ...lines].join("\n");
+    return out2.trim() ? out2 : raw;
+  }
+  const stripRecalled = (t6) => {
+    const i11 = t6.indexOf("<recalled-memories>");
+    if (i11 === -1)
+      return t6;
+    const j14 = t6.lastIndexOf("</recalled-memories>");
+    if (j14 === -1 || j14 < i11)
+      return t6;
+    const head = t6.slice(0, i11);
+    const tail = t6.slice(j14 + "</recalled-memories>".length);
+    return (head + tail).replace(/^\s+/, "").replace(/\n{3,}/g, "\n\n");
+  };
+  let out = null;
+  if (obj.type === "user_message") {
+    out = `[user] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "assistant_message") {
+    const agent = obj.agent_type ? ` (agent=${obj.agent_type})` : "";
+    out = `[assistant${agent}] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "tool_call") {
+    out = formatToolCall(obj);
+  }
+  if (out === null)
+    return raw;
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "[user]" || trimmed === "[assistant]" || /^\[tool:[^\]]*\]\s+input:\s+\{\}\s+response:\s+\{\}$/.test(trimmed))
+    return raw;
+  return out;
+}
+async function searchDeeplakeTables(api, memoryTable, sessionsTable, opts) {
+  const { pathFilter, contentScanOnly, likeOp, escapedPattern } = opts;
+  const limit = opts.limit ?? 100;
+  const memFilter = contentScanOnly ? "" : ` AND summary::text ${likeOp} '%${escapedPattern}%'`;
+  const sessFilter = contentScanOnly ? "" : ` AND message::text ${likeOp} '%${escapedPattern}%'`;
+  const memQuery = `SELECT path, summary::text AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${limit}`;
+  const sessQuery = `SELECT path, message::text AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${limit}`;
+  const [memRows, sessRows] = await Promise.all([
+    api.query(memQuery).catch(() => []),
+    api.query(sessQuery).catch(() => [])
+  ]);
+  const rows = [];
+  for (const r10 of memRows)
+    rows.push({ path: String(r10.path), content: String(r10.content ?? "") });
+  for (const r10 of sessRows)
+    rows.push({ path: String(r10.path), content: String(r10.content ?? "") });
+  return rows;
+}
+function buildPathFilter(targetPath) {
+  if (!targetPath || targetPath === "/")
+    return "";
+  const clean = targetPath.replace(/\/+$/, "");
+  return ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
+}
+function compileGrepRegex(params) {
+  let reStr = params.fixedString ? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : params.pattern;
+  if (params.wordMatch)
+    reStr = `\\b${reStr}\\b`;
+  try {
+    return new RegExp(reStr, params.ignoreCase ? "i" : "");
+  } catch {
+    return new RegExp(params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), params.ignoreCase ? "i" : "");
+  }
+}
+function refineGrepMatches(rows, params, forceMultiFilePrefix) {
+  const re9 = compileGrepRegex(params);
+  const multi = forceMultiFilePrefix ?? rows.length > 1;
+  const output = [];
+  for (const row of rows) {
+    if (!row.content)
+      continue;
+    const lines = row.content.split("\n");
+    const matched = [];
+    let fileEmitted = false;
+    for (let i11 = 0; i11 < lines.length; i11++) {
+      const hit = re9.test(lines[i11]);
+      if (hit !== !!params.invertMatch) {
+        if (params.filesOnly) {
+          if (!fileEmitted) {
+            output.push(row.path);
+            fileEmitted = true;
+          }
+          break;
+        }
+        const prefix = multi ? `${row.path}:` : "";
+        const ln3 = params.lineNumber ? `${i11 + 1}:` : "";
+        matched.push(`${prefix}${ln3}${lines[i11]}`);
+      }
+    }
+    if (!params.filesOnly) {
+      if (params.countOnly) {
+        output.push(`${multi ? `${row.path}:` : ""}${matched.length}`);
+      } else {
+        output.push(...matched);
+      }
+    }
+  }
+  return output;
+}
+
 // dist/src/shell/grep-interceptor.js
 var MAX_FALLBACK_CANDIDATES = 500;
 function createGrepCommand(client, fs3, table, sessionsTable) {
   return Yi2("grep", async (args, ctx) => {
     const parsed = lib_default(args, {
-      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "fixed-strings", "recursive", "ignore-case"],
-      alias: { r: "recursive", R: "recursive", F: "fixed-strings", i: "ignore-case", n: "line-number" }
+      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "w", "fixed-strings", "recursive", "ignore-case", "word-regexp"],
+      alias: {
+        r: "recursive",
+        R: "recursive",
+        F: "fixed-strings",
+        i: "ignore-case",
+        n: "line-number",
+        w: "word-regexp",
+        l: "files-with-matches",
+        c: "count",
+        v: "invert-match"
+      }
     });
     const positional = parsed._;
     if (positional.length === 0) {
@@ -68579,79 +68864,52 @@ function createGrepCommand(client, fs3, table, sessionsTable) {
     const mount = fs3.mountPoint;
     const mountPrefix = mount === "/" ? "/" : mount + "/";
     const allUnderMount = targets.every((t6) => t6 === mount || t6.startsWith(mountPrefix));
-    if (!allUnderMount) {
+    if (!allUnderMount)
       return { stdout: "", stderr: "", exitCode: 127 };
-    }
-    let candidates = [];
+    const matchParams = {
+      pattern,
+      fixedString: Boolean(parsed.F || parsed["fixed-strings"]),
+      ignoreCase: Boolean(parsed.i || parsed["ignore-case"]),
+      wordMatch: Boolean(parsed.w || parsed["word-regexp"]),
+      lineNumber: Boolean(parsed.n || parsed["line-number"]),
+      invertMatch: Boolean(parsed.v || parsed["invert-match"]),
+      filesOnly: Boolean(parsed.l || parsed["files-with-matches"]),
+      countOnly: Boolean(parsed.c || parsed["count"])
+    };
+    const likeOp = matchParams.ignoreCase ? "ILIKE" : "LIKE";
+    const hasRegexMeta = !matchParams.fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
+    const escapedPattern = sqlLike(pattern);
+    let rows = [];
     try {
-      const queries = [
-        client.query(`SELECT path FROM "${table}" WHERE summary <#> '${sqlStr(pattern)}' LIMIT 50`)
-      ];
-      if (sessionsTable) {
-        queries.push(client.query(`SELECT path FROM "${sessionsTable}" WHERE message::text LIKE '%${sqlLike(pattern)}%' LIMIT 10`));
-      }
-      const results = await Promise.race([
-        Promise.all(queries),
+      const perTarget = await Promise.race([
+        Promise.all(targets.map((t6) => searchDeeplakeTables(client, table, sessionsTable ?? "sessions", {
+          pathFilter: buildPathFilter(t6),
+          contentScanOnly: hasRegexMeta,
+          likeOp,
+          escapedPattern,
+          limit: 100
+        }))),
         new Promise((_16, reject) => setTimeout(() => reject(new Error("timeout")), 3e3))
       ]);
-      for (const rows of results) {
-        candidates.push(...rows.map((r10) => r10["path"]).filter(Boolean));
-      }
+      for (const batch of perTarget)
+        rows.push(...batch);
     } catch {
-    }
-    const withinTargets = (p22) => targets.some((t6) => t6 === "/" || p22 === t6 || p22.startsWith(t6 + "/"));
-    if (candidates.length === 0) {
-      candidates = fs3.getAllPaths().filter((p22) => !p22.endsWith("/") && withinTargets(p22));
-      if (candidates.length > MAX_FALLBACK_CANDIDATES) {
-        candidates = candidates.slice(0, MAX_FALLBACK_CANDIDATES);
-      }
-    } else {
-      candidates = candidates.filter((c15) => withinTargets(c15));
+      rows = [];
     }
     const seen = /* @__PURE__ */ new Set();
-    candidates = candidates.filter((c15) => {
-      if (seen.has(c15))
-        return false;
-      seen.add(c15);
-      return true;
-    });
-    await fs3.prefetch(candidates);
-    const fixedString = parsed.F || parsed["fixed-strings"];
-    const ignoreCase = parsed.i || parsed["ignore-case"];
-    const showLine = parsed.n || parsed["line-number"];
-    const invertMatch = parsed.v;
-    const filesOnly = parsed.l;
-    const countOnly = parsed.c;
-    const re9 = new RegExp(fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern, ignoreCase ? "i" : "");
-    const output = [];
-    const multipleFiles = candidates.length > 1;
-    for (const fp of candidates) {
-      const content = await fs3.readFile(fp).catch(() => null);
-      if (content === null)
-        continue;
-      const lines = content.split("\n");
-      const matchedLines = [];
-      for (let i11 = 0; i11 < lines.length; i11++) {
-        const matched = re9.test(lines[i11]);
-        if (matched !== invertMatch) {
-          if (filesOnly) {
-            output.push(fp);
-            break;
-          }
-          const prefix = multipleFiles ? `${fp}:` : "";
-          const lineNo = showLine ? `${i11 + 1}:` : "";
-          matchedLines.push(`${prefix}${lineNo}${lines[i11]}`);
-        }
-      }
-      if (!filesOnly) {
-        if (countOnly) {
-          const prefix = multipleFiles ? `${fp}:` : "";
-          output.push(`${prefix}${matchedLines.length}`);
-        } else {
-          output.push(...matchedLines);
-        }
+    rows = rows.filter((r10) => seen.has(r10.path) ? false : (seen.add(r10.path), true));
+    if (rows.length === 0) {
+      const withinTargets = (p22) => targets.some((t6) => t6 === "/" || p22 === t6 || p22.startsWith(t6 + "/"));
+      const candidates = fs3.getAllPaths().filter((p22) => !p22.endsWith("/") && withinTargets(p22)).slice(0, MAX_FALLBACK_CANDIDATES);
+      await fs3.prefetch(candidates);
+      for (const fp of candidates) {
+        const content = await fs3.readFile(fp).catch(() => null);
+        if (content !== null)
+          rows.push({ path: fp, content });
       }
     }
+    const normalized = rows.map((r10) => ({ path: r10.path, content: normalizeContent(r10.path, r10.content) }));
+    const output = refineGrepMatches(normalized, matchParams);
     return {
       stdout: output.length > 0 ? output.join("\n") + "\n" : "",
       stderr: "",

--- a/src/hooks/grep-direct.ts
+++ b/src/hooks/grep-direct.ts
@@ -1,10 +1,12 @@
 /**
- * Shared grep handler — single SQL query + in-memory regex refinement.
- * Used by both Claude Code and Codex pre-tool-use hooks.
+ * Fast-path grep handler invoked from the pre-tool-use hook. Parses a Bash
+ * grep/egrep/fgrep command (or accepts pre-parsed Grep-tool params) and
+ * delegates the actual search to the shared core in ../shell/grep-core.ts,
+ * which handles dual-table SQL + session-JSON normalization + regex refinement.
  */
 
 import type { DeeplakeApi } from "../deeplake-api.js";
-import { sqlStr, sqlLike } from "../utils/sql.js";
+import { grepBothTables, type GrepMatchParams } from "../shell/grep-core.js";
 
 export interface GrepParams {
   pattern: string;
@@ -89,7 +91,7 @@ export function parseBashGrep(cmd: string): GrepParams | null {
   };
 }
 
-/** Run grep via single SQL query + in-memory regex refinement. */
+/** Run grep via the shared dual-table core. Returns formatted grep output. */
 export async function handleGrepDirect(
   api: DeeplakeApi,
   table: string,
@@ -98,85 +100,17 @@ export async function handleGrepDirect(
 ): Promise<string | null> {
   if (!params.pattern) return null;
 
-  const { pattern, targetPath, ignoreCase, wordMatch, filesOnly, countOnly,
-          lineNumber, invertMatch, fixedString } = params;
+  const matchParams: GrepMatchParams = {
+    pattern: params.pattern,
+    ignoreCase: params.ignoreCase,
+    wordMatch: params.wordMatch,
+    filesOnly: params.filesOnly,
+    countOnly: params.countOnly,
+    lineNumber: params.lineNumber,
+    invertMatch: params.invertMatch,
+    fixedString: params.fixedString,
+  };
 
-  const likeOp = ignoreCase ? "ILIKE" : "LIKE";
-  const escapedLike = sqlLike(pattern);
-
-  // ── path filter ──
-  let pathFilter = "";
-  if (targetPath && targetPath !== "/") {
-    const clean = targetPath.replace(/\/+$/, "");
-    pathFilter = ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
-  }
-
-  // For regex patterns, can't use BM25 or LIKE — fetch all files under path
-  const hasRegexMeta = !fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
-
-  // Search only the memory/summaries table — sessions contain raw JSONB
-  // (prompts, tool calls) which is slow to scan and produces noisy results.
-  // Summaries already contain all useful content from sessions.
-  //
-  // Strategy: BM25 first (ranked, fast with index), LIKE fallback if BM25 fails.
-  let rows: Record<string, unknown>[] = [];
-
-  if (!hasRegexMeta) {
-    // BM25 ranked search disabled — CREATE INDEX causes oid errors on fresh tables.
-    // See bm25-oid-bug.sh. Using LIKE until Deeplake fixes the oid invalidation.
-    // When re-enabling, uncomment the BM25 block and make LIKE the fallback.
-    const contentFilter = ` AND summary ${likeOp} '%${escapedLike}%'`;
-    try {
-      rows = await api.query(
-        `SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter}${contentFilter} LIMIT 100`,
-      );
-    } catch { rows = []; }
-  } else {
-    // Regex pattern — fetch all files under path, filter in-memory
-    try {
-      rows = await api.query(
-        `SELECT path, summary AS content FROM "${table}" WHERE 1=1${pathFilter} LIMIT 100`,
-      );
-    } catch { rows = []; }
-  }
-
-  // ── regex refinement ──
-  let reStr = fixedString
-    ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    : pattern;
-  if (wordMatch) reStr = `\\b${reStr}\\b`;
-  let re: RegExp;
-  try { re = new RegExp(reStr, ignoreCase ? "i" : ""); }
-  catch { re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), ignoreCase ? "i" : ""); }
-
-  const output: string[] = [];
-  const multi = rows.length > 1;
-
-  for (const row of rows) {
-    const p = row["path"] as string;
-    const text = row["content"] as string;
-    if (!text) continue;
-
-    const lines = text.split("\n");
-    const matched: string[] = [];
-
-    for (let i = 0; i < lines.length; i++) {
-      if (re.test(lines[i]) !== !!invertMatch) {
-        if (filesOnly) { output.push(p); break; }
-        const prefix = multi ? `${p}:` : "";
-        const ln = lineNumber ? `${i + 1}:` : "";
-        matched.push(`${prefix}${ln}${lines[i]}`);
-      }
-    }
-
-    if (!filesOnly) {
-      if (countOnly) {
-        output.push(`${multi ? `${p}:` : ""}${matched.length}`);
-      } else {
-        output.push(...matched);
-      }
-    }
-  }
-
+  const output = await grepBothTables(api, table, sessionsTable, matchParams, params.targetPath);
   return output.join("\n") || "(no matches)";
 }

--- a/src/shell/grep-core.ts
+++ b/src/shell/grep-core.ts
@@ -298,15 +298,11 @@ export function refineGrepMatches(
     if (!row.content) continue;
     const lines = row.content.split("\n");
     const matched: string[] = [];
-    let fileEmitted = false;
 
     for (let i = 0; i < lines.length; i++) {
       const hit = re.test(lines[i]);
       if (hit !== !!params.invertMatch) {
-        if (params.filesOnly) {
-          if (!fileEmitted) { output.push(row.path); fileEmitted = true; }
-          break;
-        }
+        if (params.filesOnly) { output.push(row.path); break; }
         const prefix = multi ? `${row.path}:` : "";
         const ln = params.lineNumber ? `${i + 1}:` : "";
         matched.push(`${prefix}${ln}${lines[i]}`);

--- a/src/shell/grep-core.ts
+++ b/src/shell/grep-core.ts
@@ -1,0 +1,340 @@
+/**
+ * Shared grep core for the plugin. Used by:
+ *   - src/hooks/grep-direct.ts  (fast-path from pre-tool-use)
+ *   - src/shell/grep-interceptor.ts  (slow-path inside deeplake-shell)
+ *
+ * Responsibilities:
+ *   1. searchDeeplakeTables: run parallel LIKE/ILIKE queries against both the
+ *      memory table (summaries, column `summary`) AND the sessions table
+ *      (raw dialogue, column `message` JSONB), returning {path, content}.
+ *   2. normalizeSessionContent: when a row comes from a session path, turn the
+ *      single-line JSON blob into multi-line "Speaker: text" so the standard
+ *      line-wise regex refinement surfaces only matching turns, not the whole
+ *      5 KB blob.
+ *   3. refineGrepMatches: line-by-line regex match with the usual grep flags.
+ */
+
+import type { DeeplakeApi } from "../deeplake-api.js";
+import { sqlStr, sqlLike } from "../utils/sql.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface GrepMatchParams {
+  pattern: string;
+  ignoreCase: boolean;
+  wordMatch: boolean;
+  filesOnly: boolean;
+  countOnly: boolean;
+  lineNumber: boolean;
+  invertMatch: boolean;
+  fixedString: boolean;
+}
+
+export interface ContentRow {
+  path: string;
+  content: string;
+}
+
+export interface SearchOptions {
+  /** SQL path filter to apply to BOTH queries, e.g. ` AND (path = '/x' OR path LIKE '/x/%')`. Empty string = no filter. */
+  pathFilter: string;
+  /** true → fetch all rows under pathFilter (caller will regex in-memory). false → filter server-side by LIKE/ILIKE. */
+  contentScanOnly: boolean;
+  /** "LIKE" | "ILIKE" — case matters. */
+  likeOp: "LIKE" | "ILIKE";
+  /** LIKE-escaped pattern (via sqlLike). */
+  escapedPattern: string;
+  /** Per-table row cap. */
+  limit?: number;
+}
+
+// ── Content normalization ───────────────────────────────────────────────────
+
+/**
+ * If the row is a session JSON blob, serialize it as multi-line
+ * "Speaker: text" so the standard grep refinement surfaces only matching turns.
+ * Falls back to the raw content if parsing fails or the path is not a session.
+ */
+// ── Tool-call extractor ─────────────────────────────────────────────────────
+// Extracts only signal-bearing fields from `tool_input` / `tool_response`,
+// dropping wrapper noise (booleans, type tags, empty strings) and fields
+// duplicated between input and response. DB bytes are untouched; this is a
+// read-time view. Covers every (agent, tool_name) shape observed in the
+// production workspace.
+
+const TOOL_INPUT_FIELDS = [
+  "command", "file_path", "path", "pattern", "prompt", "subagent_type",
+  "query", "url", "notebook_path", "old_string", "new_string", "content",
+  "skill", "args", "taskId", "status", "subject", "description",
+  "to", "message", "summary", "max_results",
+] as const;
+
+const TOOL_RESPONSE_DROP = new Set([
+  "interrupted", "isImage", "noOutputExpected", "type", "stderr",
+  "structuredPatch", "userModified", "originalFile", "replaceAll",
+  "totalDurationMs", "totalTokens", "totalToolUseCount", "usage", "toolStats",
+  "durationMs", "durationSeconds", "bytes", "code", "codeText",
+  "agentId", "agentType",
+  "verificationNudgeNeeded", "numLines", "numFiles", "truncated",
+  "statusChange", "updatedFields", "isAgent", "success",
+]);
+
+function maybeParseJson(v: unknown): any {
+  if (typeof v !== "string") return v;
+  const s = v.trim();
+  if (s[0] !== "{" && s[0] !== "[") return v;
+  try { return JSON.parse(s); } catch { return v; }
+}
+
+function snakeCase(k: string): string { return k.replace(/([A-Z])/g, "_$1").toLowerCase(); }
+function camelCase(k: string): string { return k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()); }
+
+function formatToolInput(raw: unknown): string {
+  const p = maybeParseJson(raw);
+  if (typeof p !== "object" || p === null) return String(p ?? "");
+  const parts: string[] = [];
+  for (const k of TOOL_INPUT_FIELDS) {
+    if ((p as any)[k] === undefined) continue;
+    const v = (p as any)[k];
+    parts.push(`${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`);
+  }
+  // minor modifiers
+  for (const k of ["glob", "output_mode", "limit", "offset"] as const) {
+    if ((p as any)[k] !== undefined) parts.push(`${k}: ${(p as any)[k]}`);
+  }
+  return parts.length ? parts.join("\n") : JSON.stringify(p);
+}
+
+function formatToolResponse(raw: unknown, inp: unknown, toolName: string | undefined): string {
+  const r = maybeParseJson(raw);
+  if (typeof r !== "object" || r === null) return String(r ?? "");
+  // Side-effect tools — their response is pure metadata; confirm and move on.
+  if (toolName === "Edit" || toolName === "Write" || toolName === "MultiEdit") {
+    return (r as any).filePath ? `[wrote ${(r as any).filePath}]` : "[ok]";
+  }
+  // High-signal fields — return the useful payload directly.
+  if (typeof (r as any).stdout === "string") {
+    const stderr = (r as any).stderr;
+    return (r as any).stdout + (stderr ? `\nstderr: ${stderr}` : "");
+  }
+  if (typeof (r as any).content === "string") return (r as any).content;
+  if ((r as any).file && typeof (r as any).file === "object") {
+    const f = (r as any).file;
+    if (typeof f.content === "string") return `[${f.filePath ?? ""}]\n${f.content}`;
+    if (typeof f.base64 === "string") return `[binary ${f.filePath ?? ""}: ${f.base64.length} base64 chars]`;
+  }
+  if (Array.isArray((r as any).filenames)) return (r as any).filenames.join("\n");
+  if (Array.isArray((r as any).matches)) {
+    return (r as any).matches.map((m: unknown) => typeof m === "string" ? m : JSON.stringify(m)).join("\n");
+  }
+  if (Array.isArray((r as any).results)) {
+    return (r as any).results.map((x: any) => typeof x === "string" ? x : (x?.title ?? x?.url ?? JSON.stringify(x))).join("\n");
+  }
+  // Generic cleanup for less common tools: drop known-noisy keys + values
+  // duplicated from input (including snake↔camel variants).
+  const inpObj = maybeParseJson(inp);
+  const kept: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(r as any)) {
+    if (TOOL_RESPONSE_DROP.has(k)) continue;
+    if (v === "" || v === false || v == null) continue;
+    if (typeof inpObj === "object" && inpObj) {
+      const inObj = inpObj as Record<string, unknown>;
+      if (k in inObj && JSON.stringify(inObj[k]) === JSON.stringify(v)) continue;
+      const snake = snakeCase(k);
+      if (snake in inObj && JSON.stringify(inObj[snake]) === JSON.stringify(v)) continue;
+      const camel = camelCase(k);
+      if (camel in inObj && JSON.stringify(inObj[camel]) === JSON.stringify(v)) continue;
+    }
+    kept[k] = v;
+  }
+  return Object.keys(kept).length ? JSON.stringify(kept) : "[ok]";
+}
+
+function formatToolCall(obj: any): string {
+  return `[tool:${obj?.tool_name ?? "?"}]\ninput: ${formatToolInput(obj?.tool_input)}\nresponse: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
+}
+
+export function normalizeContent(path: string, raw: string): string {
+  // Any unknown shape falls through to `raw` below. This function never
+  // returns null/empty — if the result would be trivially empty (e.g.
+  // "[user] " with no content), we fall back to `raw` so grep still has
+  // something to scan.
+  if (!path.includes("/sessions/")) return raw;
+  if (!raw || raw[0] !== "{") return raw;
+  let obj: any;
+  try { obj = JSON.parse(raw); } catch { return raw; }
+
+  // ── LoCoMo benchmark shape: { turns: [...] } ─────────────────────────────
+  if (Array.isArray(obj.turns)) {
+    const header: string[] = [];
+    if (obj.date_time) header.push(`date: ${obj.date_time}`);
+    if (obj.speakers) {
+      const s = obj.speakers;
+      const names = [s.speaker_a, s.speaker_b].filter(Boolean).join(", ");
+      if (names) header.push(`speakers: ${names}`);
+    }
+    const lines = obj.turns.map((t: any) => {
+      const sp = String(t?.speaker ?? t?.name ?? "?").trim();
+      const tx = String(t?.text ?? t?.content ?? "").replace(/\s+/g, " ").trim();
+      const tag = t?.dia_id ? `[${t.dia_id}] ` : "";
+      return `${tag}${sp}: ${tx}`;
+    });
+    const out = [...header, ...lines].join("\n");
+    return out.trim() ? out : raw;
+  }
+
+  // ── Production shape: single hook-event row (capture.ts output) ─────────
+  //
+  // `<recalled-memories>` blocks are injected by OpenClaw as extra context
+  // before user prompts. They contain serialized JSON of past events which
+  // already live as their own rows in the sessions table — keeping them
+  // duplicates every hit and drowns the actual prompt. Greedy strip from
+  // first open to last close handles nested tags (past events that
+  // themselves had a recalled-memories wrapper).
+  const stripRecalled = (t: string): string => {
+    const i = t.indexOf("<recalled-memories>");
+    if (i === -1) return t;
+    const j = t.lastIndexOf("</recalled-memories>");
+    if (j === -1 || j < i) return t; // malformed — leave intact
+    const head = t.slice(0, i);
+    const tail = t.slice(j + "</recalled-memories>".length);
+    return (head + tail).replace(/^\s+/, "").replace(/\n{3,}/g, "\n\n");
+  };
+
+  let out: string | null = null;
+  if (obj.type === "user_message") {
+    out = `[user] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "assistant_message") {
+    const agent = obj.agent_type ? ` (agent=${obj.agent_type})` : "";
+    out = `[assistant${agent}] ${stripRecalled(String(obj.content ?? ""))}`;
+  } else if (obj.type === "tool_call") {
+    out = formatToolCall(obj);
+  }
+
+  // Safe fallback for any unknown shape or trivially empty result.
+  if (out === null) return raw;
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === "[user]" || trimmed === "[assistant]" || /^\[tool:[^\]]*\]\s+input:\s+\{\}\s+response:\s+\{\}$/.test(trimmed)) return raw;
+  return out;
+}
+
+// ── SQL search (both tables in parallel) ────────────────────────────────────
+
+/**
+ * Dual-table LIKE/ILIKE search. Casts `summary` (TEXT) and `message` (JSONB)
+ * to ::text so the same predicate works across both. Both queries run in
+ * parallel; if one fails, the other's rows are still returned.
+ */
+export async function searchDeeplakeTables(
+  api: DeeplakeApi,
+  memoryTable: string,
+  sessionsTable: string,
+  opts: SearchOptions,
+): Promise<ContentRow[]> {
+  const { pathFilter, contentScanOnly, likeOp, escapedPattern } = opts;
+  const limit = opts.limit ?? 100;
+
+  const memFilter = contentScanOnly ? "" : ` AND summary::text ${likeOp} '%${escapedPattern}%'`;
+  const sessFilter = contentScanOnly ? "" : ` AND message::text ${likeOp} '%${escapedPattern}%'`;
+
+  const memQuery = `SELECT path, summary::text AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${limit}`;
+  const sessQuery = `SELECT path, message::text AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${limit}`;
+
+  const [memRows, sessRows] = await Promise.all([
+    api.query(memQuery).catch(() => []),
+    api.query(sessQuery).catch(() => []),
+  ]);
+
+  const rows: ContentRow[] = [];
+  for (const r of memRows) rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  for (const r of sessRows) rows.push({ path: String(r.path), content: String(r.content ?? "") });
+  return rows;
+}
+
+/** Build a LIKE pathFilter clause for a `path` column. Returns "" if targetPath is root or empty. */
+export function buildPathFilter(targetPath: string): string {
+  if (!targetPath || targetPath === "/") return "";
+  const clean = targetPath.replace(/\/+$/, "");
+  return ` AND (path = '${sqlStr(clean)}' OR path LIKE '${sqlLike(clean)}/%')`;
+}
+
+// ── Regex refinement (line-by-line grep) ────────────────────────────────────
+
+/** Compile the grep regex from params, with a safe fallback on bad user regex. */
+export function compileGrepRegex(params: GrepMatchParams): RegExp {
+  let reStr = params.fixedString
+    ? params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    : params.pattern;
+  if (params.wordMatch) reStr = `\\b${reStr}\\b`;
+  try {
+    return new RegExp(reStr, params.ignoreCase ? "i" : "");
+  } catch {
+    return new RegExp(
+      params.pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+      params.ignoreCase ? "i" : "",
+    );
+  }
+}
+
+/**
+ * Line-by-line grep refinement over already-fetched rows. Caller is expected
+ * to have normalized `content` (e.g. via normalizeContent) before calling.
+ */
+export function refineGrepMatches(
+  rows: ContentRow[],
+  params: GrepMatchParams,
+  forceMultiFilePrefix?: boolean,
+): string[] {
+  const re = compileGrepRegex(params);
+  const multi = forceMultiFilePrefix ?? rows.length > 1;
+  const output: string[] = [];
+
+  for (const row of rows) {
+    if (!row.content) continue;
+    const lines = row.content.split("\n");
+    const matched: string[] = [];
+    let fileEmitted = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const hit = re.test(lines[i]);
+      if (hit !== !!params.invertMatch) {
+        if (params.filesOnly) {
+          if (!fileEmitted) { output.push(row.path); fileEmitted = true; }
+          break;
+        }
+        const prefix = multi ? `${row.path}:` : "";
+        const ln = params.lineNumber ? `${i + 1}:` : "";
+        matched.push(`${prefix}${ln}${lines[i]}`);
+      }
+    }
+
+    if (!params.filesOnly) {
+      if (params.countOnly) {
+        output.push(`${multi ? `${row.path}:` : ""}${matched.length}`);
+      } else {
+        output.push(...matched);
+      }
+    }
+  }
+
+  return output;
+}
+
+/** Convenience: search both tables, normalize session JSON, then refine. */
+export async function grepBothTables(
+  api: DeeplakeApi,
+  memoryTable: string,
+  sessionsTable: string,
+  params: GrepMatchParams,
+  targetPath: string,
+): Promise<string[]> {
+  const hasRegexMeta = !params.fixedString && /[.*+?^${}()|[\]\\]/.test(params.pattern);
+  const rows = await searchDeeplakeTables(api, memoryTable, sessionsTable, {
+    pathFilter: buildPathFilter(targetPath),
+    contentScanOnly: hasRegexMeta,
+    likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
+    escapedPattern: sqlLike(params.pattern),
+  });
+  const normalized = rows.map(r => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  return refineGrepMatches(normalized, params);
+}

--- a/src/shell/grep-core.ts
+++ b/src/shell/grep-core.ts
@@ -70,7 +70,12 @@ const TOOL_INPUT_FIELDS = [
 ] as const;
 
 const TOOL_RESPONSE_DROP = new Set([
-  "interrupted", "isImage", "noOutputExpected", "type", "stderr",
+  // Note: `stderr` is intentionally NOT in this set. The `stdout` high-signal
+  // branch below already de-dupes it for the common case (appends as suffix
+  // when non-empty). If a tool response has ONLY `stderr` and no `stdout`
+  // (hard-failure on some tools), the generic cleanup preserves it so the
+  // error message reaches Claude instead of collapsing to `[ok]`.
+  "interrupted", "isImage", "noOutputExpected", "type",
   "structuredPatch", "userModified", "originalFile", "replaceAll",
   "totalDurationMs", "totalTokens", "totalToolUseCount", "usage", "toolStats",
   "durationMs", "durationSeconds", "bytes", "code", "codeText",
@@ -335,6 +340,13 @@ export async function grepBothTables(
     likeOp: params.ignoreCase ? "ILIKE" : "LIKE",
     escapedPattern: sqlLike(params.pattern),
   });
-  const normalized = rows.map(r => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+  // Defensive path dedup — memory and sessions tables use disjoint path
+  // prefixes in every schema we ship (/summaries/… vs /sessions/…), so the
+  // overlap is theoretical, but we dedupe to match grep-interceptor.ts and
+  // guarantee each path is emitted once even if a future schema change
+  // introduces overlap.
+  const seen = new Set<string>();
+  const unique = rows.filter(r => seen.has(r.path) ? false : (seen.add(r.path), true));
+  const normalized = unique.map(r => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
   return refineGrepMatches(normalized, params);
 }

--- a/src/shell/grep-interceptor.ts
+++ b/src/shell/grep-interceptor.ts
@@ -3,20 +3,27 @@ import { defineCommand } from "just-bash";
 import yargsParser from "yargs-parser";
 import type { DeeplakeFs } from "./deeplake-fs.js";
 
-import { sqlStr as esc, sqlLike } from "../utils/sql.js";
+import {
+  searchDeeplakeTables,
+  buildPathFilter,
+  normalizeContent,
+  refineGrepMatches,
+  type GrepMatchParams,
+  type ContentRow,
+} from "./grep-core.js";
+import { sqlLike } from "../utils/sql.js";
 
 const MAX_FALLBACK_CANDIDATES = 500;
 
 /**
- * Custom grep command for just-bash that replaces the built-in when the target
- * paths are under the Deeplake mount. Two-phase strategy:
- *   1. Coarse BM25 filter via Deeplake SQL → candidate paths
- *   2. Prefetch candidates into the in-memory content cache
- *   3. Fine-grained regex match line-by-line (in-memory, no further network I/O)
+ * grep implementation for the deeplake-shell (virtual bash). Two paths:
+ *   1. SQL-first: dual-table LIKE/ILIKE search via grep-core, with session
+ *      JSON normalized to per-turn lines for sane output.
+ *   2. Fallback: if SQL returns nothing (or races past a 3s timeout), scan
+ *      the in-memory FS cache using the same regex refinement.
  *
- * Falls back to ILIKE if BM25 index is unavailable.
- * Falls through (returns exitCode=127) for paths outside the mount so
- * just-bash can route to its own built-in grep.
+ * Falls through (exitCode=127) for paths outside the mount so just-bash can
+ * use its own built-in grep.
  */
 export function createGrepCommand(
   client: DeeplakeApi,
@@ -26,8 +33,13 @@ export function createGrepCommand(
 ) {
   return defineCommand("grep", async (args, ctx) => {
     const parsed = yargsParser(args, {
-      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "fixed-strings", "recursive", "ignore-case"],
-      alias: { r: "recursive", R: "recursive", F: "fixed-strings", i: "ignore-case", n: "line-number" },
+      boolean: ["r", "R", "l", "i", "n", "v", "c", "F", "w", "fixed-strings", "recursive", "ignore-case", "word-regexp"],
+      alias: {
+        r: "recursive", R: "recursive",
+        F: "fixed-strings", i: "ignore-case",
+        n: "line-number", w: "word-regexp",
+        l: "files-with-matches", c: "count", v: "invert-match",
+      },
     });
 
     const positional = parsed._ as string[];
@@ -38,112 +50,75 @@ export function createGrepCommand(
     const pattern = String(positional[0]);
     const targetArgs = positional.slice(1);
 
-    // Resolve all target paths against cwd
     const targets = targetArgs.length > 0
       ? targetArgs.map(t => ctx.fs.resolvePath(ctx.cwd, String(t))).filter(Boolean)
       : [ctx.cwd];
     if (targets.length === 0) return { stdout: "", stderr: "", exitCode: 1 };
 
     const mount = fs.mountPoint;
-
-    // Only intercept if all targets are under our mount point
     const mountPrefix = mount === "/" ? "/" : mount + "/";
     const allUnderMount = targets.every(t => t === mount || t.startsWith(mountPrefix));
-    if (!allUnderMount) {
-      // Signal to caller that this command doesn't handle it
-      return { stdout: "", stderr: "", exitCode: 127 };
-    }
+    if (!allUnderMount) return { stdout: "", stderr: "", exitCode: 127 };
 
-    // ── Phase 1: coarse filter — BM25 on summaries + LIKE on sessions ─────
-    let candidates: string[] = [];
+    const matchParams: GrepMatchParams = {
+      pattern,
+      fixedString: Boolean(parsed.F || parsed["fixed-strings"]),
+      ignoreCase: Boolean(parsed.i || parsed["ignore-case"]),
+      wordMatch: Boolean(parsed.w || parsed["word-regexp"]),
+      lineNumber: Boolean(parsed.n || parsed["line-number"]),
+      invertMatch: Boolean(parsed.v || parsed["invert-match"]),
+      filesOnly: Boolean(parsed.l || parsed["files-with-matches"]),
+      countOnly: Boolean(parsed.c || parsed["count"]),
+    };
 
+    const likeOp = matchParams.ignoreCase ? "ILIKE" : "LIKE";
+    const hasRegexMeta = !matchParams.fixedString && /[.*+?^${}()|[\]\\]/.test(pattern);
+    const escapedPattern = sqlLike(pattern);
+
+    // Targets can be multiple; we run one SQL round per distinct target so the
+    // per-table pathFilter can prune server-side. In practice targets is 1-2
+    // entries, so the cost is negligible and still faster than the old shell.
+    let rows: ContentRow[] = [];
     try {
-      const queries: Promise<Record<string, unknown>[]>[] = [
-        client.query(`SELECT path FROM "${table}" WHERE summary <#> '${esc(pattern)}' LIMIT 50`),
-      ];
-      if (sessionsTable) {
-        queries.push(
-          client.query(`SELECT path FROM "${sessionsTable}" WHERE message::text LIKE '%${sqlLike(pattern)}%' LIMIT 10`)
-        );
-      }
-      const results = await Promise.race([
-        Promise.all(queries),
+      const perTarget = await Promise.race([
+        Promise.all(targets.map(t =>
+          searchDeeplakeTables(client, table, sessionsTable ?? "sessions", {
+            pathFilter: buildPathFilter(t),
+            contentScanOnly: hasRegexMeta,
+            likeOp,
+            escapedPattern,
+            limit: 100,
+          })
+        )),
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 3000)),
       ]);
-      for (const rows of results) {
-        candidates.push(...rows.map(r => r["path"] as string).filter(Boolean));
-      }
+      for (const batch of perTarget) rows.push(...batch);
     } catch {
-      // BM25/LIKE not available or timed out — fall back to in-memory
+      rows = []; // fall through to in-memory fallback
     }
 
-    // Narrow candidates to those under the requested targets
-    const withinTargets = (p: string) =>
-      targets.some(t => t === "/" || p === t || p.startsWith(t + "/"));
-
-    if (candidates.length === 0) {
-      // No BM25 results or no index — only scan files under requested targets.
-      candidates = fs.getAllPaths().filter(p => !p.endsWith("/") && withinTargets(p));
-      if (candidates.length > MAX_FALLBACK_CANDIDATES) {
-        candidates = candidates.slice(0, MAX_FALLBACK_CANDIDATES);
-      }
-    } else {
-      candidates = candidates.filter(c => withinTargets(c));
-    }
-
-    // Preserve order and remove duplicates to avoid repeated reads.
+    // Dedup by path (multiple targets may overlap)
     const seen = new Set<string>();
-    candidates = candidates.filter((c) => {
-      if (seen.has(c)) return false;
-      seen.add(c);
-      return true;
-    });
+    rows = rows.filter(r => seen.has(r.path) ? false : (seen.add(r.path), true));
 
-    // ── Phase 2: prefetch into content cache (single batch query) ───────────
-    await fs.prefetch(candidates);
-
-    // ── Phase 3: fine-grained in-memory match ────────────────────────────────
-    const fixedString = parsed.F || parsed["fixed-strings"];
-    const ignoreCase  = parsed.i || parsed["ignore-case"];
-    const showLine    = parsed.n || parsed["line-number"];
-    const invertMatch = parsed.v;
-    const filesOnly   = parsed.l;
-    const countOnly   = parsed.c;
-
-    const re = new RegExp(
-      fixedString ? pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : pattern,
-      ignoreCase ? "i" : "",
-    );
-
-    const output: string[] = [];
-    const multipleFiles = candidates.length > 1;
-
-    for (const fp of candidates) {
-      const content = await fs.readFile(fp).catch(() => null);
-      if (content === null) continue;
-
-      const lines = content.split("\n");
-      const matchedLines: string[] = [];
-
-      for (let i = 0; i < lines.length; i++) {
-        const matched = re.test(lines[i]);
-        if (matched !== invertMatch) {
-          if (filesOnly) { output.push(fp); break; }
-          const prefix = multipleFiles ? `${fp}:` : "";
-          const lineNo = showLine ? `${i + 1}:` : "";
-          matchedLines.push(`${prefix}${lineNo}${lines[i]}`);
-        }
-      }
-
-      if (!filesOnly) {
-        if (countOnly) {
-          const prefix = multipleFiles ? `${fp}:` : "";
-          output.push(`${prefix}${matchedLines.length}`);
-        } else {
-          output.push(...matchedLines);
-        }
+    // Fallback: if SQL returned nothing, scan the FS cache. Limits exposure
+    // on huge mounts; previously this ran whenever BM25 errored.
+    if (rows.length === 0) {
+      const withinTargets = (p: string) =>
+        targets.some(t => t === "/" || p === t || p.startsWith(t + "/"));
+      const candidates = fs.getAllPaths()
+        .filter(p => !p.endsWith("/") && withinTargets(p))
+        .slice(0, MAX_FALLBACK_CANDIDATES);
+      await fs.prefetch(candidates);
+      for (const fp of candidates) {
+        const content = await fs.readFile(fp).catch(() => null);
+        if (content !== null) rows.push({ path: fp, content });
       }
     }
+
+    // Normalize session JSON blobs to per-turn lines before the regex pass.
+    const normalized = rows.map(r => ({ path: r.path, content: normalizeContent(r.path, r.content) }));
+    const output = refineGrepMatches(normalized, matchParams);
 
     return {
       stdout: output.length > 0 ? output.join("\n") + "\n" : "",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,11 @@ export default defineConfig({
     environment: "node",
     coverage: {
       provider: "v8",
-      reporter: ["text", "text-summary", "json-summary", "html"],
+      // `json` is needed by davelosert/vitest-coverage-report-action@v2 to
+      // render per-file / per-line coverage in its PR comment (alongside the
+      // aggregated json-summary). Without it the action emits a warning
+      // about a missing coverage-final.json and falls back to the summary.
+      reporter: ["text", "text-summary", "json", "json-summary", "html"],
       reportsDirectory: "coverage",
       include: ["src/**/*.ts"],
       exclude: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig } from "vitest/config";
+
+// Root vitest config. `npm test` runs `vitest run` from the repo root, so
+// this is the file that actually gets picked up. The one in claude-code/
+// is a historical leftover and is not used by the root test script.
+//
+// Coverage thresholds are enforced per-file on the files touched by each
+// PR. New files/PRs should add their paths to the `thresholds` block so
+// the CI check grows over time instead of collapsing to a global average
+// that hides regressions in new code.
+
+export default defineConfig({
+  test: {
+    include: [
+      "claude-code/tests/**/*.test.ts",
+      "codex/tests/**/*.test.ts",
+    ],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "json-summary", "html"],
+      reportsDirectory: "coverage",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.d.ts",
+        "src/**/*.js",
+        "src/**/*.js.map",
+      ],
+      // Per-file thresholds. Each PR that ships new files should append
+      // its paths here with 80 / 80 / 80 / 80, so we prevent regressions
+      // on the new code without having to first bring the whole
+      // (~500-file) codebase up to 80%.
+      thresholds: {
+        // PR #60 — fix/grep-dual-table-and-normalize
+        "src/shell/grep-core.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/shell/grep-interceptor.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/hooks/grep-direct.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,24 +36,28 @@ export default defineConfig({
       // on the new code without having to first bring the whole
       // (~500-file) codebase up to 80%.
       thresholds: {
-        // PR #60 — fix/grep-dual-table-and-normalize
+        // PR #60 — fix/grep-dual-table-and-normalize.
+        // Raised to 90 to surface the red path in the PR coverage comment
+        // for metrics that sit between 80 and 90 (e.g. grep-core branches
+        // at 83%). The actual long-term bar we want to hold is 80; revisit
+        // once the PR has landed.
         "src/shell/grep-core.ts": {
-          statements: 80,
-          branches: 80,
-          functions: 80,
-          lines: 80,
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
         },
         "src/shell/grep-interceptor.ts": {
-          statements: 80,
-          branches: 80,
-          functions: 80,
-          lines: 80,
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
         },
         "src/hooks/grep-direct.ts": {
-          statements: 80,
-          branches: 80,
-          functions: 80,
-          lines: 80,
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
         },
       },
     },


### PR DESCRIPTION
## Summary

Three independent bugs in the plugin grep interceptor, fixed together because they share a natural refactor into a new `src/shell/grep-core.ts` module.

**1. Fast-path grep ignored the sessions table.**
`handleGrepDirect` in `src/hooks/grep-direct.ts` received `sessionsTable` as an argument but only ever queried the memory (summaries) table. Literal quotes, titles, proper nouns that live in the raw dialogue but are paraphrased out of summaries were invisible to the hook. On a LoCoMo benchmark subset (45 questions where v2/v3 scored 0% and the baseline scored 100%), adding sessions lookup recovered **51%** of answers. Now we hit both tables in parallel (`summary::text` on memory, `message::text` on sessions) and merge results.

**2. Session JSON blobs leaked into grep output whole.**
A LoCoMo session is stored as a single JSONB row whose serialized `{turns:[...]}` has zero newlines — ~5700 chars on one line. When grep matched any token, the line-refinement step returned the entire blob. A production event row (capture.ts output) has the same problem at smaller scale: 200–3000 char of JSON wrapping around a small `content` field. The new `normalizeContent` function, run before the regex pass, transforms each shape into line-per-unit text:

- LoCoMo: `{turns:[...]}` → `date: ...\nspeakers: ...\n[dia_id] Speaker: text\n...` per turn
- Production `user_message` → `[user] <content>` (with `<recalled-memories>` blocks stripped — they duplicate rows that already exist standalone)
- Production `assistant_message` → `[assistant (agent=<subagent_type>)?] <content>`
- Production `tool_call` → `[tool:<name>]\ninput: <actionable fields>\nresponse: <extracted content>` — tool-aware field extraction drops wrapper noise and response fields duplicated from input (via camel ↔ snake mapping), with side-effect tools (`Edit`/`Write`/`MultiEdit`) collapsing to `[wrote <path>]`.
- Unknown shapes and parse failures always fall back to raw — `normalizeContent` never returns null/empty.

**3. Shell-path grep had a query that returned 400 on every call.**
`src/shell/grep-interceptor.ts` (used by the `deeplake-shell` virtual bash and by every Bash command the hook cannot fast-path) ran `SELECT path FROM "<table>" WHERE summary <#> '<pattern>' LIMIT 50` as its coarse BM25 filter. The `<#>` operator returns a float, not a boolean, so the server answered `400 Data type mismatch: argument of WHERE must be type boolean, not type real` every time. A try/catch swallowed the error and fell back to scanning the FS cache — functionally correct but slow and noisy. Removed. The interceptor now uses the same LIKE/ILIKE path as the fast-path.

## Read-only change

`capture.ts`, the session-start hook, and the wiki worker are untouched. Every byte `capture.ts` used to write still lands in `sessions.message` / `memory.summary`. Normalization is a read-time view; the raw content is always reachable via direct SQL if anyone needs it.

## Measured impact — production (activeloop/hivemind, 3 000 random rows)

Byte reduction of the text Claude sees from `sessions.message`:

| Tool / event | rows | raw | after | saved |
|---|---:|---:|---:|---:|
| Bash | 772 | 2 338 KB | 1 599 KB | 31.6 % |
| Read | 500 | 2 176 KB | 1 678 KB | 22.9 % |
| Grep | 207 | 460 KB | 313 KB | 32.0 % |
| Agent | 25 | 318 KB | 245 KB | 22.9 % |
| Write | 25 | 204 KB | 84 KB | 58.6 % |
| TaskUpdate | 64 | 53 KB | 4 KB | 91.9 % |
| ToolSearch | 19 | 14 KB | 2 KB | 87.3 % |
| user_message | 88 | 77 KB | 20 KB | 73.9 % |
| assistant_message | 87 | 90 KB | 54 KB | 39.7 % |
| **Overall** | **3 000** | **10.1 MB** | **4.7 MB** | **53.1 %** |

## Measured impact — LoCoMo benchmark (Gemini-judged, clean tables)

| Subset | baseline | v2 second (0.6.23 stock) | v3 (sync bug) | this PR |
|---|---:|---:|---:|---:|
| strict-45 (plugin-hard, baseline-easy) | 100 % | 0 % | 0 % | **51 %** |
| 100-mix (45 strict + 55 random) | 74.5 % | 28.5 % | 20.5 % | **47.5 %** |
| 250-full | 67.8 % | 46.2 % | 35.0 % | run pending on clean tables |

## File layout

- `src/shell/grep-core.ts` [new, ~340 lines] — `searchDeeplakeTables`, `normalizeContent`, `formatToolCall` + `formatToolInput` + `formatToolResponse`, `compileGrepRegex`, `refineGrepMatches`, `grepBothTables`, `buildPathFilter`. Plus exported types (`GrepMatchParams`, `ContentRow`, `SearchOptions`).
- `src/hooks/grep-direct.ts` [-67 lines] — thin wrapper over `grepBothTables`. `parseBashGrep` kept in place.
- `src/shell/grep-interceptor.ts` [-24 lines, heavy rewrite] — uses `searchDeeplakeTables`, keeps the in-memory cache fallback via `fs.prefetch` + `fs.readFile`.
- Rebuilt bundles: `claude-code/bundle/{pre-tool-use.js,shell/deeplake-shell.js}`, `codex/bundle/{pre-tool-use.js,shell/deeplake-shell.js}`. Deterministic output from `npm run build`.

## Commits

1. `feat(grep): add shared grep-core with dual-table search + normalization`
2. `refactor(grep): fast-path grep delegates to shared grep-core`
3. `fix(shell grep): drop broken BM25 query, route through shared core`
4. `build: regenerate bundles for dual-table grep + normalize`

## Test plan

- [ ] `npm run ci` (typecheck + vitest)
- [ ] `claude-code/tests/grep-direct.test.ts` and `claude-code/tests/grep-interceptor.test.ts` pass without edits
- [ ] Manual: `HIVEMIND_DEBUG=1 claude -p "Use Grep with pattern=Brave on memory path"` — log shows two `query start` lines (one per table)
- [ ] Manual: Grep on a LoCoMo session path returns per-turn lines, not a raw JSON blob
- [ ] Manual: Grep on a production session path returns `[user]`, `[assistant]`, `[tool:...]` lines, not raw JSON
- [ ] Re-run the LoCoMo full 250 benchmark on clean tables and confirm v4's 39.4 % regresses upward toward v2's 46.2 % or better.

## Non-goals

- No changes to capture / ingest / wiki worker.
- No changes to the LoCoMo data or `scripts/v2/ingest-plugin.ts`.
- No SQL schema changes.
- Production sessions still return one row per hook event; aggregating all N rows of a session at Read time (so Claude sees a full conversation rather than the first event) is a follow-up in a separate PR.
