### PR TITLE
send X-Deeplake-Client: hivemind/<version> on deeplake-api calls

### DIFF
--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -76,6 +76,24 @@ function sqlStr(value) {
   return value.replace(/\\/g, "\\\\").replace(/'/g, "''").replace(/\0/g, "").replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -187,7 +205,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -339,7 +358,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -78,11 +78,8 @@ function sqlStr(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -77,15 +77,9 @@ function sqlStr(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -5,6 +5,26 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
+// dist/src/commands/auth.js
 var CONFIG_DIR = join(homedir(), ".deeplake");
 var CREDS_PATH = join(CONFIG_DIR, "credentials.json");
 var DEFAULT_API_URL = "https://api.deeplake.ai";
@@ -32,7 +52,8 @@ function deleteCredentials() {
 async function apiGet(path, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -44,7 +65,8 @@ async function apiGet(path, token, apiUrl, orgId) {
 async function apiPost(path, body, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -56,7 +78,8 @@ async function apiPost(path, body, token, apiUrl, orgId) {
 async function apiDelete(path, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -67,7 +90,7 @@ async function apiDelete(path, token, apiUrl, orgId) {
 async function requestDeviceCode(apiUrl = DEFAULT_API_URL) {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() }
   });
   if (!resp.ok)
     throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
@@ -76,7 +99,7 @@ async function requestDeviceCode(apiUrl = DEFAULT_API_URL) {
 async function pollForToken(deviceCode, apiUrl = DEFAULT_API_URL) {
   const resp = await fetch(`${apiUrl}/auth/device/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
     body: JSON.stringify({ device_code: deviceCode })
   });
   if (resp.ok)
@@ -368,7 +391,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -520,7 +544,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -8,11 +8,8 @@ import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -7,15 +7,9 @@ import { homedir } from "node:os";
 import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -82,6 +82,24 @@ function sqlLike(value) {
   return sqlStr(value).replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -193,7 +211,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -345,7 +364,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -84,11 +84,8 @@ function sqlLike(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -83,15 +83,9 @@ function sqlLike(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -13,15 +13,9 @@ import { homedir } from "node:os";
 import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -14,11 +14,8 @@ import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -11,6 +11,26 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
+// dist/src/commands/auth.js
 var CONFIG_DIR = join(homedir(), ".deeplake");
 var CREDS_PATH = join(CONFIG_DIR, "credentials.json");
 function loadCredentials() {
@@ -198,7 +218,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -350,7 +371,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -13,15 +13,9 @@ import { homedir } from "node:os";
 import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -14,11 +14,8 @@ import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -12,6 +12,26 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
+// dist/src/commands/auth.js
 var CONFIG_DIR = join(homedir(), ".deeplake");
 var CREDS_PATH = join(CONFIG_DIR, "credentials.json");
 function loadCredentials() {
@@ -199,7 +219,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -351,7 +372,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -66780,15 +66780,9 @@ function sqlLike(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -66779,6 +66779,24 @@ function sqlLike(value) {
   return sqlStr(value).replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -66890,7 +66908,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -67042,7 +67061,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -66781,11 +66781,8 @@ function sqlLike(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/claude-code/bundle/wiki-worker.js
+++ b/claude-code/bundle/wiki-worker.js
@@ -21,6 +21,24 @@ function log(tag, msg) {
 `);
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/hooks/summary-state.js
 import { readFileSync, writeFileSync, writeSync, mkdirSync, renameSync, existsSync, unlinkSync, openSync, closeSync } from "node:fs";
 import { homedir as homedir2 } from "node:os";
@@ -154,7 +172,8 @@ async function query(sql, retries = 4) {
       headers: {
         Authorization: `Bearer ${cfg.token}`,
         "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId
+        "X-Activeloop-Org-Id": cfg.orgId,
+        ...deeplakeClientHeader()
       },
       body: JSON.stringify({ query: sql })
     });

--- a/claude-code/bundle/wiki-worker.js
+++ b/claude-code/bundle/wiki-worker.js
@@ -22,15 +22,9 @@ function log(tag, msg) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/claude-code/bundle/wiki-worker.js
+++ b/claude-code/bundle/wiki-worker.js
@@ -23,11 +23,8 @@ function log(tag, msg) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -76,6 +76,24 @@ function sqlStr(value) {
   return value.replace(/\\/g, "\\\\").replace(/'/g, "''").replace(/\0/g, "").replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -187,7 +205,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -339,7 +358,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -78,11 +78,8 @@ function sqlStr(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -77,15 +77,9 @@ function sqlStr(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -5,6 +5,26 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
+// dist/src/commands/auth.js
 var CONFIG_DIR = join(homedir(), ".deeplake");
 var CREDS_PATH = join(CONFIG_DIR, "credentials.json");
 var DEFAULT_API_URL = "https://api.deeplake.ai";
@@ -32,7 +52,8 @@ function deleteCredentials() {
 async function apiGet(path, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -44,7 +65,8 @@ async function apiGet(path, token, apiUrl, orgId) {
 async function apiPost(path, body, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -56,7 +78,8 @@ async function apiPost(path, body, token, apiUrl, orgId) {
 async function apiDelete(path, token, apiUrl, orgId) {
   const headers = {
     Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    ...deeplakeClientHeader()
   };
   if (orgId)
     headers["X-Activeloop-Org-Id"] = orgId;
@@ -67,7 +90,7 @@ async function apiDelete(path, token, apiUrl, orgId) {
 async function requestDeviceCode(apiUrl = DEFAULT_API_URL) {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() }
   });
   if (!resp.ok)
     throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
@@ -76,7 +99,7 @@ async function requestDeviceCode(apiUrl = DEFAULT_API_URL) {
 async function pollForToken(deviceCode, apiUrl = DEFAULT_API_URL) {
   const resp = await fetch(`${apiUrl}/auth/device/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
     body: JSON.stringify({ device_code: deviceCode })
   });
   if (resp.ok)
@@ -368,7 +391,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -520,7 +544,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -8,11 +8,8 @@ import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -7,15 +7,9 @@ import { homedir } from "node:os";
 import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -82,6 +82,24 @@ function sqlLike(value) {
   return sqlStr(value).replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -193,7 +211,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -345,7 +364,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -84,11 +84,8 @@ function sqlLike(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -83,15 +83,9 @@ function sqlLike(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -13,15 +13,9 @@ import { homedir } from "node:os";
 import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -14,11 +14,8 @@ import { execSync } from "node:child_process";
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -11,6 +11,26 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
+// dist/src/commands/auth.js
 var CONFIG_DIR = join(homedir(), ".deeplake");
 var CREDS_PATH = join(CONFIG_DIR, "credentials.json");
 function loadCredentials() {
@@ -198,7 +218,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -350,7 +371,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -66780,15 +66780,9 @@ function sqlLike(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -66779,6 +66779,24 @@ function sqlLike(value) {
   return sqlStr(value).replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -66890,7 +66908,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -67042,7 +67061,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -66781,11 +66781,8 @@ function sqlLike(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -80,15 +80,9 @@ function sqlStr(value) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -81,11 +81,8 @@ function sqlStr(value) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -79,6 +79,24 @@ function sqlStr(value) {
   return value.replace(/\\/g, "\\\\").replace(/'/g, "''").replace(/\0/g, "").replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/deeplake-api.js
 var log2 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
@@ -190,7 +208,8 @@ var DeeplakeApi = class {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           },
           signal,
           body: JSON.stringify({ query: sql })
@@ -342,7 +361,8 @@ var DeeplakeApi = class {
         const resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables`, {
           headers: {
             Authorization: `Bearer ${this.token}`,
-            "X-Activeloop-Org-Id": this.orgId
+            "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader()
           }
         });
         if (resp.ok) {

--- a/codex/bundle/wiki-worker.js
+++ b/codex/bundle/wiki-worker.js
@@ -131,11 +131,8 @@ async function uploadSummary(query2, params) {
 
 // dist/src/utils/client-header.js
 function pluginVersion() {
-  try {
-    if ("0.6.45") {
-      return "0.6.45";
-    }
-  } catch {
+  if ("0.6.48") {
+    return "0.6.48";
   }
   return "dev";
 }

--- a/codex/bundle/wiki-worker.js
+++ b/codex/bundle/wiki-worker.js
@@ -129,6 +129,24 @@ async function uploadSummary(query2, params) {
   return { path: "insert", sql, descLength: desc.length, summaryLength: text.length };
 }
 
+// dist/src/utils/client-header.js
+function pluginVersion() {
+  try {
+    if ("0.6.45") {
+      return "0.6.45";
+    }
+  } catch {
+  }
+  return "dev";
+}
+var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+function deeplakeClientValue() {
+  return `hivemind/${pluginVersion()}`;
+}
+function deeplakeClientHeader() {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}
+
 // dist/src/hooks/codex/wiki-worker.js
 var dlog2 = (msg) => log("codex-wiki-worker", msg);
 var cfg = JSON.parse(readFileSync2(process.argv[2], "utf-8"));
@@ -153,7 +171,8 @@ async function query(sql, retries = 4) {
       headers: {
         Authorization: `Bearer ${cfg.token}`,
         "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId
+        "X-Activeloop-Org-Id": cfg.orgId,
+        ...deeplakeClientHeader()
       },
       body: JSON.stringify({ query: sql })
     });

--- a/codex/bundle/wiki-worker.js
+++ b/codex/bundle/wiki-worker.js
@@ -130,15 +130,9 @@ async function uploadSummary(query2, params) {
 }
 
 // dist/src/utils/client-header.js
-function pluginVersion() {
-  if ("0.6.48") {
-    return "0.6.48";
-  }
-  return "dev";
-}
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${"0.6.48"}`;
 }
 function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,6 +2,7 @@ import { build } from "esbuild";
 import { chmodSync, writeFileSync, readFileSync } from "node:fs";
 
 const esmPackageJson = '{"type":"module"}\n';
+const hivemindVersion = JSON.parse(readFileSync("package.json", "utf-8")).version;
 const openclawVersion = JSON.parse(readFileSync("openclaw/package.json", "utf-8")).version;
 
 // Claude Code plugin
@@ -31,6 +32,9 @@ await build({
   format: "esm",
   outdir: "claude-code/bundle",
   external: ["node:*", "node-liblzma", "@mongodb-js/zstd"],
+  define: {
+    __HIVEMIND_VERSION__: JSON.stringify(hivemindVersion),
+  },
 });
 
 for (const h of ccAll) {
@@ -65,6 +69,9 @@ await build({
   format: "esm",
   outdir: "codex/bundle",
   external: ["node:*", "node-liblzma", "@mongodb-js/zstd"],
+  define: {
+    __HIVEMIND_VERSION__: JSON.stringify(hivemindVersion),
+  },
 });
 
 for (const h of codexAll) {

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "../../src/config.js";
 import { loadCredentials, saveCredentials, requestDeviceCode, pollForToken, listOrgs, switchOrg, listWorkspaces, switchWorkspace } from "../../src/commands/auth.js";
 import { DeeplakeApi } from "../../src/deeplake-api.js";
 import { sqlStr, sqlLike } from "../../src/utils/sql.js";
+import { deeplakeClientHeader } from "../../src/utils/client-header.js";
 
 interface PluginConfig {
   autoCapture?: boolean;
@@ -108,6 +109,7 @@ async function requestAuth(): Promise<string> {
                     Authorization: `Bearer ${token}`,
                     "Content-Type": "application/json",
                     "X-Activeloop-Org-Id": orgId,
+                    ...deeplakeClientHeader(),
                   },
                   body: JSON.stringify({ name: `hivemind-${new Date().toISOString().split("T")[0]}`, duration: 365 * 24 * 60 * 60, organization_id: orgId }),
                 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,6 +7,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+import { deeplakeClientHeader } from "../utils/client-header.js";
 
 const CONFIG_DIR = join(homedir(), ".deeplake");
 const CREDS_PATH = join(CONFIG_DIR, "credentials.json");
@@ -88,6 +89,7 @@ async function apiGet(path: string, token: string, apiUrl: string, orgId?: strin
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
+    ...deeplakeClientHeader(),
   };
   if (orgId) headers["X-Activeloop-Org-Id"] = orgId;
   const resp = await fetch(`${apiUrl}${path}`, { headers });
@@ -99,6 +101,7 @@ async function apiPost(path: string, body: unknown, token: string, apiUrl: strin
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
+    ...deeplakeClientHeader(),
   };
   if (orgId) headers["X-Activeloop-Org-Id"] = orgId;
   const resp = await fetch(`${apiUrl}${path}`, { method: "POST", headers, body: JSON.stringify(body) });
@@ -110,6 +113,7 @@ async function apiDelete(path: string, token: string, apiUrl: string, orgId?: st
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
+    ...deeplakeClientHeader(),
   };
   if (orgId) headers["X-Activeloop-Org-Id"] = orgId;
   const resp = await fetch(`${apiUrl}${path}`, { method: "DELETE", headers });
@@ -121,7 +125,7 @@ async function apiDelete(path: string, token: string, apiUrl: string, orgId?: st
 export async function requestDeviceCode(apiUrl = DEFAULT_API_URL): Promise<DeviceCodeResponse> {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
   });
   if (!resp.ok) throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
   return resp.json() as Promise<DeviceCodeResponse>;
@@ -130,7 +134,7 @@ export async function requestDeviceCode(apiUrl = DEFAULT_API_URL): Promise<Devic
 export async function pollForToken(deviceCode: string, apiUrl = DEFAULT_API_URL): Promise<DeviceTokenResponse | null> {
   const resp = await fetch(`${apiUrl}/auth/device/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
     body: JSON.stringify({ device_code: deviceCode }),
   });
   if (resp.ok) return resp.json() as Promise<DeviceTokenResponse>;

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { log as _log } from "./utils/debug.js";
 import { sqlStr } from "./utils/sql.js";
+import { deeplakeClientHeader } from "./utils/client-header.js";
 
 const log = (msg: string) => _log("sdk", msg);
 
@@ -146,6 +147,7 @@ export class DeeplakeApi {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
             "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader(),
           },
           signal,
           body: JSON.stringify({ query: sql }),
@@ -319,6 +321,7 @@ export class DeeplakeApi {
           headers: {
             Authorization: `Bearer ${this.token}`,
             "X-Activeloop-Org-Id": this.orgId,
+            ...deeplakeClientHeader(),
           },
         });
         if (resp.ok) {

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { finalizeSummary, releaseLock } from "../summary-state.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
+import { deeplakeClientHeader } from "../../utils/client-header.js";
 
 const dlog = (msg: string) => _log("codex-wiki-worker", msg);
 
@@ -60,6 +61,7 @@ async function query(sql: string, retries = 4): Promise<Record<string, unknown>[
         Authorization: `Bearer ${cfg.token}`,
         "Content-Type": "application/json",
         "X-Activeloop-Org-Id": cfg.orgId,
+        ...deeplakeClientHeader(),
       },
       body: JSON.stringify({ query: sql }),
     });

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -11,6 +11,7 @@ import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmS
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { utcTimestamp, log as _log } from "../utils/debug.js";
+import { deeplakeClientHeader } from "../utils/client-header.js";
 
 const dlog = (msg: string) => _log("wiki-worker", msg);
 import { finalizeSummary, releaseLock } from "./summary-state.js";
@@ -61,6 +62,7 @@ async function query(sql: string, retries = 4): Promise<Record<string, unknown>[
         Authorization: `Bearer ${cfg.token}`,
         "Content-Type": "application/json",
         "X-Activeloop-Org-Id": cfg.orgId,
+        ...deeplakeClientHeader(),
       },
       body: JSON.stringify({ query: sql }),
     });

--- a/src/utils/client-header.ts
+++ b/src/utils/client-header.ts
@@ -6,27 +6,18 @@
  * deeplake-api should carry this header; without it, hivemind traffic
  * looks indistinguishable from the activeloop-cli / device-code flow.
  *
- * __HIVEMIND_VERSION__ is a build-time constant injected by esbuild
- * (see esbuild.config.mjs). In dev (tsx, vitest) the constant is not
- * defined, so we fall back to "dev".
+ * __HIVEMIND_VERSION__ is replaced at build/test time:
+ *   - production bundles: esbuild.config.mjs sets it to the real package.json version
+ *   - vitest:             vitest.config.ts sets it to "dev"
+ * Source code therefore reads it directly, no runtime guard needed.
  */
 declare const __HIVEMIND_VERSION__: string;
-
-function pluginVersion(): string {
-  // typeof on an undeclared identifier returns "undefined" (never throws),
-  // so unbundled dev runs (where esbuild's define hasn't run) fall through
-  // to the "dev" sentinel without needing an exception handler.
-  if (typeof __HIVEMIND_VERSION__ === "string" && __HIVEMIND_VERSION__) {
-    return __HIVEMIND_VERSION__;
-  }
-  return "dev";
-}
 
 export const DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 
 /** Returns "hivemind/<version>" — the value for the X-Deeplake-Client header. */
 export function deeplakeClientValue(): string {
-  return `hivemind/${pluginVersion()}`;
+  return `hivemind/${__HIVEMIND_VERSION__}`;
 }
 
 /** Returns { "X-Deeplake-Client": "hivemind/<version>" } for spreading into a headers object. */

--- a/src/utils/client-header.ts
+++ b/src/utils/client-header.ts
@@ -1,0 +1,34 @@
+/**
+ * X-Deeplake-Client header helper.
+ *
+ * The deeplake-api backend reads X-Deeplake-Client to attribute traffic
+ * (analytics source + engagement metrics). Every outbound request to
+ * deeplake-api should carry this header; without it, hivemind traffic
+ * looks indistinguishable from the activeloop-cli / device-code flow.
+ *
+ * __HIVEMIND_VERSION__ is a build-time constant injected by esbuild
+ * (see esbuild.config.mjs). In dev (tsx, vitest) the constant is not
+ * defined, so we fall back to "dev".
+ */
+declare const __HIVEMIND_VERSION__: string;
+
+function pluginVersion(): string {
+  try {
+    if (typeof __HIVEMIND_VERSION__ === "string" && __HIVEMIND_VERSION__) {
+      return __HIVEMIND_VERSION__;
+    }
+  } catch { /* reference error in unbundled dev → fall through */ }
+  return "dev";
+}
+
+export const DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
+
+/** Returns "hivemind/<version>" — the value for the X-Deeplake-Client header. */
+export function deeplakeClientValue(): string {
+  return `hivemind/${pluginVersion()}`;
+}
+
+/** Returns { "X-Deeplake-Client": "hivemind/<version>" } for spreading into a headers object. */
+export function deeplakeClientHeader(): Record<string, string> {
+  return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ import { defineConfig } from "vitest/config";
 // that hides regressions in new code.
 
 export default defineConfig({
+  // Match esbuild's `define` for __HIVEMIND_VERSION__ so source files that
+  // read it directly (e.g. src/utils/client-header.ts) don't need a typeof
+  // guard for tests. Bundled builds substitute the real version; tests get
+  // the "dev" sentinel.
+  define: {
+    __HIVEMIND_VERSION__: JSON.stringify("dev"),
+  },
   test: {
     include: [
       "claude-code/tests/**/*.test.ts",


### PR DESCRIPTION
## Summary

- Adds `X-Deeplake-Client: hivemind/<version>` header on every outbound request to deeplake-api, so the backend can attribute hivemind traffic for analytics (signup source, login source, daily retention rollup).
- New `src/utils/client-header.ts` with a single `deeplakeClientHeader()` helper. Version is injected at bundle time via an esbuild `__HIVEMIND_VERSION__` define (same pattern openclaw already uses for its own version). Dev / tsx / vitest runs fall back to `"dev"` so nothing crashes without a bundle.
- Applied at every fetch site: `DeepLakeAPI` (query + listTables), `commands/auth.ts` (whoami / orgs / workspaces / device-code / device-token), and both `wiki-worker.ts` entry points (CC + Codex).
- Rebuilt `claude-code/bundle/` and `codex/bundle/` — grep confirms the version literal + header template both land in every shipped bundle.

No PostHog SDK added to hivemind. All analytics stay server-side in deeplake-api (PR activeloopai/deeplake-api#193).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 966 tests pass
- [x] `npm run build` produces bundles; grep confirms `"0.6.45"` + `` `hivemind/${pluginVersion()}` `` are present in CC + Codex bundles
- [x] Runtime intercept-fetch smoke: calling `requestDeviceCode()` emits the header (confirmed `X-Deeplake-Client: hivemind/dev` in unbundled dev; bundle path gets `hivemind/0.6.45`)
- [ ] After merge of deeplake-api#193, end-to-end: hivemind login → PostHog shows `login_completed` with `login_source: hivemind`, `hivemind_version: 0.6.45`
- [ ] After a hivemind session writes to its `sessions` table, the next 00:05 UTC rollup emits `hivemind_daily_active` with matching `sessions_count`