### PR TITLE
codex: fix JSONB SQL escape so message column round-trips

### DIFF
--- a/claude-code/tests/codex-capture-hook.test.ts
+++ b/claude-code/tests/codex-capture-hook.test.ts
@@ -282,3 +282,53 @@ describe("codex capture hook — defensive fallbacks", () => {
     expect(queryMock).not.toHaveBeenCalled();
   });
 });
+
+describe("codex capture hook — JSONB SQL escape (regression)", () => {
+  // Regression for the codex Bash capture 400 — sqlStr() doubles backslashes,
+  // which corrupts the \" sequences produced by the inner JSON.stringify of
+  // tool_input / tool_response. The fix: only escape ' for the SQL literal,
+  // leave JSON-escape sequences alone.
+  const extractMessage = (sql: string): string => {
+    const m = sql.match(/'(\{[\s\S]+\})'::jsonb,/);
+    if (!m) throw new Error("no jsonb literal found in INSERT");
+    return m[1].replace(/''/g, "'");
+  };
+
+  it("produces parseable JSON when tool_input.command contains double quotes", async () => {
+    stdinMock.mockResolvedValue({
+      session_id: "sid-jsonb",
+      cwd: "/proj",
+      hook_event_name: "PostToolUse",
+      model: "gpt-5",
+      tool_name: "Bash",
+      tool_use_id: "tu-1",
+      tool_input: { command: 'echo "hi"' },
+      tool_response: { stdout: "hi\n" },
+    });
+    await runHook();
+    const sql = queryMock.mock.calls[0][0] as string;
+    const messageJson = extractMessage(sql);
+    const parsed = JSON.parse(messageJson);
+    expect(parsed.type).toBe("tool_call");
+    expect(parsed.tool_name).toBe("Bash");
+    // Inner stringified JSON survives round-trip
+    expect(JSON.parse(parsed.tool_input)).toEqual({ command: 'echo "hi"' });
+    expect(JSON.parse(parsed.tool_response)).toEqual({ stdout: "hi\n" });
+  });
+
+  it("produces parseable JSON when user prompt contains double quotes and apostrophes", async () => {
+    stdinMock.mockResolvedValue({
+      session_id: "sid-jsonb-2",
+      cwd: "/proj",
+      hook_event_name: "UserPromptSubmit",
+      model: "gpt-5",
+      prompt: `she said "it's fine"`,
+    });
+    await runHook();
+    const sql = queryMock.mock.calls[0][0] as string;
+    const messageJson = extractMessage(sql);
+    const parsed = JSON.parse(messageJson);
+    expect(parsed.type).toBe("user_message");
+    expect(parsed.content).toBe(`she said "it's fine"`);
+  });
+});

--- a/claude-code/tests/codex-stop-hook.test.ts
+++ b/claude-code/tests/codex-stop-hook.test.ts
@@ -277,3 +277,27 @@ describe("codex stop hook — fatal catch", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 });
+
+describe("codex stop hook — JSONB SQL escape (regression)", () => {
+  // Regression: sqlStr() over the JSON line doubled backslashes, which
+  // mangles \" sequences from JSON.stringify when the assistant message
+  // contains literal quotes. Now only ' is escaped for the SQL literal.
+  it("produces parseable JSON when the assistant message contains double quotes", async () => {
+    const path = join(tmpDir, "transcript.jsonl");
+    writeFileSync(path, JSON.stringify({
+      payload: { role: "assistant", content: 'she said "hello"' },
+    }));
+    stdinMock.mockResolvedValue({
+      session_id: "sid-1", cwd: "/x", hook_event_name: "Stop", model: "m",
+      transcript_path: path,
+    });
+    await runHook();
+    const sql = queryMock.mock.calls[0][0] as string;
+    const m = sql.match(/'(\{[\s\S]+\})'::jsonb,/);
+    expect(m).not.toBeNull();
+    const messageJson = m![1].replace(/''/g, "'");
+    const parsed = JSON.parse(messageJson);
+    expect(parsed.type).toBe("assistant_message");
+    expect(parsed.content).toBe('she said "hello"');
+  });
+});

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -703,7 +703,7 @@ async function main() {
   log3(`writing to ${sessionPath}`);
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
-  const jsonForSql = sqlStr(line);
+  const jsonForSql = line.replace(/'/g, "''");
   const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, agent, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, '${sqlStr(config.userName)}', ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(input.hook_event_name ?? "")}', 'codex', '${ts}', '${ts}')`;
   try {
     await api.query(insertSql);

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -634,7 +634,7 @@ async function main() {
       const sessionPath = buildSessionPath(config, sessionId);
       const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
       const filename = sessionPath.split("/").pop() ?? "";
-      const jsonForSql = sqlStr(line);
+      const jsonForSql = line.replace(/'/g, "''");
       const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, agent, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, '${sqlStr(config.userName)}', ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', 'Stop', 'codex', '${ts}', '${ts}')`;
       await api.query(insertSql);
       log3("stop event captured");

--- a/src/hooks/codex/capture.ts
+++ b/src/hooks/codex/capture.ts
@@ -98,7 +98,9 @@ async function main(): Promise<void> {
 
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
-  const jsonForSql = sqlStr(line);
+  // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.
+  // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.
+  const jsonForSql = line.replace(/'/g, "''");
 
   const insertSql =
     `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, agent, creation_date, last_update_date) ` +

--- a/src/hooks/codex/stop.ts
+++ b/src/hooks/codex/stop.ts
@@ -101,7 +101,9 @@ async function main(): Promise<void> {
       const sessionPath = buildSessionPath(config, sessionId);
       const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
       const filename = sessionPath.split("/").pop() ?? "";
-      const jsonForSql = sqlStr(line);
+      // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.
+      // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.
+      const jsonForSql = line.replace(/'/g, "''");
 
       const insertSql =
         `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, agent, creation_date, last_update_date) ` +


### PR DESCRIPTION
## Summary

Codex's `capture.ts` and `stop.ts` ran the JSON-encoded message line through `sqlStr()` before interpolating it into the SQL `'...'::jsonb` literal. `sqlStr()` doubles backslashes — correct for standard string columns under legacy Postgres escape syntax, but **wrong for jsonb under `standard_conforming_strings = on`** (modern default). The doubling corrupts the JSON-escape sequences, e.g. `\"` (from `JSON.stringify` of a string containing a `"`) becomes literal `\\"`, so jsonb parsing terminates the inner string early and Postgres returns:

```
400 INVALID_REQUEST: invalid input syntax for type json
```

## Reproduction

Bash tool capture in Codex with any quote-containing input fails outright. Stop captures with quote-containing assistant messages "succeed" but store mangled JSON (literal `\n` instead of newline, etc.).

Discovered while testing the unified npx installer (#75) end-to-end — every `PostToolUse(Bash)` event for codex returned 400, with the failing INSERT visible in the hook debug log.

## Fix

Apply the same pattern Claude Code's `src/hooks/capture.ts:114-116` already uses — only escape `'` for the SQL literal, leave JSON-escape sequences untouched:

```diff
- const jsonForSql = sqlStr(line);
+ // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.
+ // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.
+ const jsonForSql = line.replace(/'/g, "''");
```

Two files: `src/hooks/codex/capture.ts:101` and `src/hooks/codex/stop.ts:104`.

## Tests

Added regression tests asserting the JSON in the message column round-trips (extracted from the SQL, single-quote-undoubled, then `JSON.parse` succeeds and matches the original entry):

- `claude-code/tests/codex-capture-hook.test.ts` — quoted Bash command + tool_response, and a user prompt with both `"` and `'`
- `claude-code/tests/codex-stop-hook.test.ts` — assistant message containing `"`

If `sqlStr()` is reintroduced these tests fail at `JSON.parse`.

Full codex suite: 175 tests pass.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` for codex tests — 175 pass
- [x] Bundle rebuilt (`codex/bundle/capture.js`, `codex/bundle/stop.js` updated to match source)
- [ ] Live retest: re-run a codex session with HIVEMIND_DEBUG=1 — expect no `[codex-capture] fatal` lines, expect non-empty session jsonl after a Bash tool call
