### PR TITLE
feat(cli): add `hivemind update` command (centralized npm-based upgrade for all agents)

### DIFF
--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4627,6 +4627,152 @@ if (process.argv[1] && process.argv[1].endsWith("auth-login.js")) {
   });
 }
 
+// dist/src/cli/update.js
+import { execFileSync as execFileSync4 } from "node:child_process";
+import { existsSync as existsSync12, readFileSync as readFileSync10, realpathSync } from "node:fs";
+import { dirname as dirname3, sep } from "node:path";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
+
+// dist/src/utils/version-check.js
+import { readFileSync as readFileSync9 } from "node:fs";
+import { dirname as dirname2, join as join15 } from "node:path";
+function isNewer(latest, current) {
+  const parse = (v) => v.split(".").map(Number);
+  const [la, lb, lc] = parse(latest);
+  const [ca, cb, cc] = parse(current);
+  return la > ca || la === ca && lb > cb || la === ca && lb === cb && lc > cc;
+}
+
+// dist/src/cli/update.js
+var NPM_REGISTRY_URL = "https://registry.npmjs.org/@deeplake/hivemind/latest";
+var PKG_NAME = "@deeplake/hivemind";
+function detectInstallKind(argv1) {
+  const realArgv1 = (() => {
+    try {
+      return realpathSync(argv1 ?? process.argv[1] ?? fileURLToPath2(import.meta.url));
+    } catch {
+      return argv1 ?? process.argv[1] ?? fileURLToPath2(import.meta.url);
+    }
+  })();
+  let dir = dirname3(realArgv1);
+  let installDir = null;
+  for (let i = 0; i < 10; i++) {
+    const pkgPath = `${dir}${sep}package.json`;
+    try {
+      const pkg = JSON.parse(readFileSync10(pkgPath, "utf-8"));
+      if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
+        installDir = dir;
+        break;
+      }
+    } catch {
+    }
+    const parent = dirname3(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
+  installDir ??= dirname3(realArgv1);
+  let gitDir = installDir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync12(`${gitDir}${sep}.git`)) {
+      return { kind: "local-dev", installDir };
+    }
+    const parent = dirname3(gitDir);
+    if (parent === gitDir)
+      break;
+    gitDir = parent;
+  }
+  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
+    return { kind: "npx", installDir };
+  }
+  if (realArgv1.includes(`node_modules${sep}@deeplake${sep}hivemind`) || realArgv1.includes(`node_modules${sep}hivemind`)) {
+    return { kind: "npm-global", installDir };
+  }
+  return { kind: "unknown", installDir };
+}
+async function getLatestNpmVersion(timeoutMs = 5e3) {
+  try {
+    const res = await fetch(NPM_REGISTRY_URL, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok)
+      return null;
+    const meta = await res.json();
+    return meta.version ?? null;
+  } catch {
+    return null;
+  }
+}
+var defaultSpawn = (cmd, args) => {
+  execFileSync4(cmd, args, { stdio: "inherit" });
+};
+async function runUpdate(opts = {}) {
+  const current = opts.currentVersionOverride ?? getVersion();
+  const latest = opts.latestVersionOverride !== void 0 ? opts.latestVersionOverride : await getLatestNpmVersion();
+  if (!latest) {
+    warn(`Could not reach npm registry to check for updates.`);
+    warn(`Current version: ${current}`);
+    return 1;
+  }
+  if (!isNewer(latest, current)) {
+    log(`hivemind ${current} is up to date (npm latest: ${latest}).`);
+    return 0;
+  }
+  log(`Update available: ${current} \u2192 ${latest}`);
+  if (opts.dryRun) {
+    log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
+    log(`(dry-run) Would re-run: hivemind install --skip-auth`);
+    return 0;
+  }
+  const detected = opts.installKindOverride ?? detectInstallKind();
+  const spawn = opts.spawn ?? defaultSpawn;
+  switch (detected.kind) {
+    case "npm-global": {
+      log(`Upgrading via npm\u2026`);
+      try {
+        spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
+      } catch (e) {
+        warn(`npm install failed: ${e.message}`);
+        warn(`Try running it manually: npm install -g ${PKG_NAME}@latest`);
+        return 1;
+      }
+      log(``);
+      log(`Refreshing agent bundles\u2026`);
+      try {
+        spawn("hivemind", ["install", "--skip-auth"]);
+      } catch (e) {
+        warn(`Agent refresh failed: ${e.message}`);
+        warn(`Run manually: hivemind install`);
+        return 1;
+      }
+      log(``);
+      log(`Updated to ${latest}.`);
+      return 0;
+    }
+    case "npx": {
+      log(`You ran hivemind via npx, which does not have a persistent global install.`);
+      log(`To use the new version, re-run with the explicit version pin:`);
+      log(``);
+      log(`  npx ${PKG_NAME}@${latest} install`);
+      log(``);
+      log(`Or install globally so future updates are one command:`);
+      log(``);
+      log(`  npm install -g ${PKG_NAME}@latest`);
+      return 0;
+    }
+    case "local-dev": {
+      warn(`hivemind is running from a local development checkout (${detected.installDir}).`);
+      warn(`Update via your dev workflow (git pull + npm install + npm run build),`);
+      warn(`not via 'hivemind update'.`);
+      return 1;
+    }
+    case "unknown":
+    default: {
+      warn(`Could not determine how hivemind was installed (path: ${detected.installDir}).`);
+      warn(`Update manually: npm install -g ${PKG_NAME}@latest`);
+      return 1;
+    }
+  }
+}
+
 // dist/src/cli/index.js
 var AUTH_SUBCOMMANDS = /* @__PURE__ */ new Set([
   "whoami",
@@ -4662,6 +4808,9 @@ Usage:
 
   hivemind login            Run device-flow login (open browser).
   hivemind status           Show which assistants are wired up.
+  hivemind update [--dry-run]
+      Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
+      every detected agent bundle. Single command for all agents.
 
 Semantic search (embeddings):
   hivemind embeddings install                Download @huggingface/transformers
@@ -4818,6 +4967,10 @@ async function main() {
   if (cmd === "status") {
     runStatus();
     return;
+  }
+  if (cmd === "update") {
+    const code = await runUpdate({ dryRun: hasFlag(args.slice(1), "--dry-run") });
+    process.exit(code);
   }
   if (cmd === "embeddings") {
     const sub = args[1];

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -177,6 +177,7 @@ function pluginAlreadyInstalled() {
     return false;
   return r.stdout.includes(PLUGIN_KEY);
 }
+var PLUGIN_SCOPES = ["user", "project", "local", "managed"];
 function installClaude() {
   requireClaudeCli();
   if (!marketplaceAlreadyAdded()) {
@@ -190,9 +191,15 @@ function installClaude() {
     if (!inst.ok) {
       throw new Error(`Failed to install hivemind plugin: ${inst.stderr.slice(0, 200)}`);
     }
+    log(`  Claude Code    installed via marketplace ${MARKETPLACE_SOURCE}`);
+  } else {
+    runClaude(["plugin", "marketplace", "update", MARKETPLACE_NAME]);
+    for (const scope of PLUGIN_SCOPES) {
+      runClaude(["plugin", "update", PLUGIN_KEY, "--scope", scope]);
+    }
+    log(`  Claude Code    refreshed via marketplace ${MARKETPLACE_SOURCE}`);
   }
   runClaude(["plugin", "enable", PLUGIN_KEY]);
-  log(`  Claude Code    installed via marketplace ${MARKETPLACE_SOURCE}`);
 }
 function uninstallClaude() {
   try {

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4672,6 +4672,12 @@ function detectInstallKind(argv1) {
     dir = parent;
   }
   installDir ??= dirname3(realArgv1);
+  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
+    return { kind: "npx", installDir };
+  }
+  if (realArgv1.includes(`${sep}node_modules${sep}@deeplake${sep}hivemind`) || realArgv1.includes(`${sep}node_modules${sep}hivemind`)) {
+    return { kind: "npm-global", installDir };
+  }
   let gitDir = installDir;
   for (let i = 0; i < 6; i++) {
     if (existsSync12(`${gitDir}${sep}.git`)) {
@@ -4681,12 +4687,6 @@ function detectInstallKind(argv1) {
     if (parent === gitDir)
       break;
     gitDir = parent;
-  }
-  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
-    return { kind: "npx", installDir };
-  }
-  if (realArgv1.includes(`node_modules${sep}@deeplake${sep}hivemind`) || realArgv1.includes(`node_modules${sep}hivemind`)) {
-    return { kind: "npm-global", installDir };
   }
   return { kind: "unknown", installDir };
 }
@@ -4717,15 +4717,15 @@ async function runUpdate(opts = {}) {
     return 0;
   }
   log(`Update available: ${current} \u2192 ${latest}`);
-  if (opts.dryRun) {
-    log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
-    log(`(dry-run) Would re-run: hivemind install --skip-auth`);
-    return 0;
-  }
   const detected = opts.installKindOverride ?? detectInstallKind();
   const spawn = opts.spawn ?? defaultSpawn;
   switch (detected.kind) {
     case "npm-global": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
+        log(`(dry-run) Would re-run: hivemind install --skip-auth`);
+        return 0;
+      }
       log(`Upgrading via npm\u2026`);
       try {
         spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
@@ -4748,6 +4748,10 @@ async function runUpdate(opts = {}) {
       return 0;
     }
     case "npx": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would print npx-pin instructions (no persistent install to upgrade).`);
+        return 0;
+      }
       log(`You ran hivemind via npx, which does not have a persistent global install.`);
       log(`To use the new version, re-run with the explicit version pin:`);
       log(``);
@@ -4759,6 +4763,10 @@ async function runUpdate(opts = {}) {
       return 0;
     }
     case "local-dev": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would refuse: running from a local dev checkout (${detected.installDir}).`);
+        return 0;
+      }
       warn(`hivemind is running from a local development checkout (${detected.installDir}).`);
       warn(`Update via your dev workflow (git pull + npm install + npm run build),`);
       warn(`not via 'hivemind update'.`);
@@ -4766,6 +4774,10 @@ async function runUpdate(opts = {}) {
     }
     case "unknown":
     default: {
+      if (opts.dryRun) {
+        log(`(dry-run) Would refuse: install kind unknown (${detected.installDir}).`);
+        return 0;
+      }
       warn(`Could not determine how hivemind was installed (path: ${detected.installDir}).`);
       warn(`Update manually: npm install -g ${PKG_NAME}@latest`);
       return 1;

--- a/claude-code/tests/cli-index.test.ts
+++ b/claude-code/tests/cli-index.test.ts
@@ -28,6 +28,7 @@ const runAuthCommandMock = vi.fn();
 const detectPlatformsMock = vi.fn();
 const allPlatformIdsMock = vi.fn();
 const getVersionMock = vi.fn();
+const runUpdateMock = vi.fn();
 const stdoutMock = vi.fn();
 const stderrMock = vi.fn();
 const exitSpy = vi.fn();
@@ -79,6 +80,9 @@ vi.mock("../../src/cli/util.js", async (importOriginal) => {
 vi.mock("../../src/cli/version.js", () => ({
   getVersion: (...a: unknown[]) => getVersionMock(...a),
 }));
+vi.mock("../../src/cli/update.js", () => ({
+  runUpdate: (...a: unknown[]) => runUpdateMock(...a),
+}));
 
 const originalArgv = process.argv;
 
@@ -91,6 +95,7 @@ beforeEach(() => {
   detectPlatformsMock.mockReset().mockReturnValue([]);
   allPlatformIdsMock.mockReset().mockReturnValue(["claude", "codex", "claw", "cursor", "hermes", "pi"]);
   getVersionMock.mockReset().mockReturnValue("1.2.3");
+  runUpdateMock.mockReset().mockResolvedValue(0);
   stdoutMock.mockReset();
   stderrMock.mockReset();
   exitSpy.mockReset();
@@ -293,6 +298,29 @@ describe("per-platform shorthand: hivemind <platform> install|uninstall", () => 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(stderrText()).toContain("Usage: hivemind claude install");
     expect(stderrText()).toContain("uninstall");
+  });
+});
+
+describe("hivemind update", () => {
+  it("'update' calls runUpdate({ dryRun: false }) once and exits with its return code", async () => {
+    runUpdateMock.mockResolvedValueOnce(0);
+    await runCli(["update"]);
+    expect(runUpdateMock).toHaveBeenCalledTimes(1);
+    expect(runUpdateMock.mock.calls[0][0]).toEqual({ dryRun: false });
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("'update --dry-run' passes dryRun: true", async () => {
+    runUpdateMock.mockResolvedValueOnce(0);
+    await runCli(["update", "--dry-run"]);
+    expect(runUpdateMock).toHaveBeenCalledTimes(1);
+    expect(runUpdateMock.mock.calls[0][0]).toEqual({ dryRun: true });
+  });
+
+  it("propagates a non-zero return code from runUpdate", async () => {
+    runUpdateMock.mockResolvedValueOnce(1);
+    await runCli(["update"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
 

--- a/claude-code/tests/cli-index.test.ts
+++ b/claude-code/tests/cli-index.test.ts
@@ -83,6 +83,14 @@ vi.mock("../../src/cli/version.js", () => ({
 vi.mock("../../src/cli/update.js", () => ({
   runUpdate: (...a: unknown[]) => runUpdateMock(...a),
 }));
+const enableEmbeddingsMock = vi.fn();
+const disableEmbeddingsMock = vi.fn();
+const statusEmbeddingsMock = vi.fn();
+vi.mock("../../src/cli/embeddings.js", () => ({
+  enableEmbeddings: (...a: unknown[]) => enableEmbeddingsMock(...a),
+  disableEmbeddings: (...a: unknown[]) => disableEmbeddingsMock(...a),
+  statusEmbeddings: (...a: unknown[]) => statusEmbeddingsMock(...a),
+}));
 
 const originalArgv = process.argv;
 
@@ -96,6 +104,9 @@ beforeEach(() => {
   allPlatformIdsMock.mockReset().mockReturnValue(["claude", "codex", "claw", "cursor", "hermes", "pi"]);
   getVersionMock.mockReset().mockReturnValue("1.2.3");
   runUpdateMock.mockReset().mockResolvedValue(0);
+  enableEmbeddingsMock.mockReset();
+  disableEmbeddingsMock.mockReset();
+  statusEmbeddingsMock.mockReset();
   stdoutMock.mockReset();
   stderrMock.mockReset();
   exitSpy.mockReset();
@@ -321,6 +332,60 @@ describe("hivemind update", () => {
     runUpdateMock.mockResolvedValueOnce(1);
     await runCli(["update"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("hivemind embeddings", () => {
+  it.each([["install"], ["enable"]] as const)(
+    "'embeddings %s' calls enableEmbeddings exactly once",
+    async (sub) => {
+      await runCli(["embeddings", sub]);
+      expect(enableEmbeddingsMock).toHaveBeenCalledTimes(1);
+      expect(disableEmbeddingsMock).not.toHaveBeenCalled();
+      expect(statusEmbeddingsMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([["uninstall"], ["disable"]] as const)(
+    "'embeddings %s' calls disableEmbeddings({ prune: false }) by default",
+    async (sub) => {
+      await runCli(["embeddings", sub]);
+      expect(disableEmbeddingsMock).toHaveBeenCalledTimes(1);
+      expect(disableEmbeddingsMock.mock.calls[0][0]).toEqual({ prune: false });
+    },
+  );
+
+  it("'embeddings uninstall --prune' passes prune: true", async () => {
+    await runCli(["embeddings", "uninstall", "--prune"]);
+    expect(disableEmbeddingsMock).toHaveBeenCalledTimes(1);
+    expect(disableEmbeddingsMock.mock.calls[0][0]).toEqual({ prune: true });
+  });
+
+  it("'embeddings status' calls statusEmbeddings once", async () => {
+    await runCli(["embeddings", "status"]);
+    expect(statusEmbeddingsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("unknown 'embeddings' subcommand exits 1 with usage warning", async () => {
+    await runCli(["embeddings", "bogus"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrText()).toContain("Usage: hivemind embeddings");
+    expect(enableEmbeddingsMock).not.toHaveBeenCalled();
+    expect(disableEmbeddingsMock).not.toHaveBeenCalled();
+    expect(statusEmbeddingsMock).not.toHaveBeenCalled();
+  });
+
+  it("'install --with-embeddings' enables embeddings after the install loop", async () => {
+    detectPlatformsMock.mockReturnValue([{ id: "claude", markerDir: "/x/.claude" }]);
+    await runCli(["install", "--with-embeddings"]);
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(enableEmbeddingsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("'<platform> install --with-embeddings' enables embeddings after the per-agent install", async () => {
+    await runCli(["cursor", "install", "--with-embeddings"]);
+    expect(installs.installCursor).toHaveBeenCalledTimes(1);
+    expect(enableEmbeddingsMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/claude-code/tests/cli-install-claude.test.ts
+++ b/claude-code/tests/cli-install-claude.test.ts
@@ -139,14 +139,57 @@ describe("installClaude — happy path argv shape", () => {
     expect(argvList).toContain("plugin enable hivemind@hivemind");
   });
 
-  it("skips plugin install when 'plugin list' already includes 'hivemind@hivemind'", async () => {
+  it("skips 'plugin install' AND triggers 'plugin update' across all 4 scopes when already installed", async () => {
+    // When `plugin list` already shows the plugin, we no longer skip and
+    // do nothing. We refresh the marketplace cache and run
+    // `plugin update --scope X` for every scope so the user actually
+    // gets the new version. Without this, `hivemind update`'s call into
+    // installClaude() was a silent no-op for Claude.
     setupClaudeResponses({ pluginList: "hivemind@hivemind enabled" });
     const { installClaude } = await importFresh();
     installClaude();
 
     const argvList = calls().map(c => c.args.join(" "));
     expect(argvList).not.toContain("plugin install hivemind");
+    expect(argvList).toContain("plugin marketplace update hivemind");
+    // All four scopes must be exercised — `claude plugin update` is
+    // per-scope, and we don't know which one the user has the plugin
+    // activated under.
+    expect(argvList).toContain("plugin update hivemind@hivemind --scope user");
+    expect(argvList).toContain("plugin update hivemind@hivemind --scope project");
+    expect(argvList).toContain("plugin update hivemind@hivemind --scope local");
+    expect(argvList).toContain("plugin update hivemind@hivemind --scope managed");
+    // And enable still fires (idempotent).
     expect(argvList).toContain("plugin enable hivemind@hivemind");
+  });
+
+  it("on already-installed: runs marketplace update BEFORE plugin update (cache must be fresh)", async () => {
+    // Order matters — without `marketplace update` first, the `plugin
+    // update` calls would resolve against a stale catalog and could
+    // no-op even when a newer version is published.
+    setupClaudeResponses({ pluginList: "hivemind@hivemind enabled" });
+    const { installClaude } = await importFresh();
+    installClaude();
+
+    const argvList = calls().map(c => c.args.join(" "));
+    const refreshIdx = argvList.indexOf("plugin marketplace update hivemind");
+    const firstUpdateIdx = argvList.findIndex(a => a.startsWith("plugin update hivemind@hivemind --scope"));
+    expect(refreshIdx).toBeGreaterThanOrEqual(0);
+    expect(firstUpdateIdx).toBeGreaterThan(refreshIdx);
+  });
+
+  it("on cold install: does NOT run 'plugin update' (no upgrade needed when freshly installed)", async () => {
+    // Negative-pattern test (CLAUDE.md rule 8): a regression that ran
+    // `plugin update` even on a cold install would waste cycles and
+    // possibly misreport "refreshed" instead of "installed".
+    setupClaudeResponses({});
+    const { installClaude } = await importFresh();
+    installClaude();
+
+    const argvList = calls().map(c => c.args.join(" "));
+    expect(argvList.some(a => a.startsWith("plugin update hivemind@hivemind"))).toBe(false);
+    expect(argvList).not.toContain("plugin marketplace update hivemind");
+    expect(argvList).toContain("plugin install hivemind");
   });
 
   it("matches the marketplace name as a whole token, not a substring", async () => {

--- a/claude-code/tests/cli-update.test.ts
+++ b/claude-code/tests/cli-update.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Tests for src/cli/update.ts — the unified `hivemind update` command.
+ *
+ * The update flow has three branches we care about:
+ *   1. up-to-date          → log + exit 0
+ *   2. update available    → npm install -g + re-exec install
+ *   3. install kind != npm → user instructions, no spawn
+ *
+ * Tests use `latestVersionOverride`, `currentVersionOverride`, and
+ * `installKindOverride` to drive each branch deterministically without
+ * touching the network or fork()ing npm. The `spawn` injector lets us
+ * assert on COUNT and SHAPE of the commands we'd run (CLAUDE.md rule 6).
+ */
+
+import { runUpdate, detectInstallKind, getLatestNpmVersion } from "../../src/cli/update.js";
+
+let stdoutMock: ReturnType<typeof vi.fn>;
+let stderrMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  stdoutMock = vi.fn();
+  stderrMock = vi.fn();
+  vi.spyOn(process.stdout, "write").mockImplementation(((...a: unknown[]) => { stdoutMock(...a); return true; }) as any);
+  vi.spyOn(process.stderr, "write").mockImplementation(((...a: unknown[]) => { stderrMock(...a); return true; }) as any);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const stdoutText = () => stdoutMock.mock.calls.map(c => c[0]).join("");
+const stderrText = () => stderrMock.mock.calls.map(c => c[0]).join("");
+
+describe("runUpdate — branches", () => {
+  it("exits 0 with 'up to date' when latest equals current", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.2.3",
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("up to date");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("exits 0 with 'up to date' when current is ahead of registry", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.4",
+      latestVersionOverride: "1.2.3",
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("up to date");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 with a warning when registry can't be reached", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: null,
+      spawn,
+    });
+    expect(code).toBe(1);
+    expect(stderrText()).toContain("Could not reach npm registry");
+    expect(stderrText()).toContain("1.2.3");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("dry-run: prints 'Would run' and 'Would re-run' without spawning", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      dryRun: true,
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("Update available: 1.2.3 → 1.3.0");
+    expect(stdoutText()).toContain("(dry-run) Would run: npm install -g @deeplake/hivemind@latest");
+    expect(stdoutText()).toContain("(dry-run) Would re-run: hivemind install --skip-auth");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("npm-global: spawns 'npm install -g @latest' THEN 'hivemind install --skip-auth' (in that order, exactly once each)", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npm-global", installDir: "/usr/lib/node_modules/@deeplake/hivemind" },
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn.mock.calls[0]).toEqual(["npm", ["install", "-g", "@deeplake/hivemind@latest"]]);
+    expect(spawn.mock.calls[1]).toEqual(["hivemind", ["install", "--skip-auth"]]);
+    expect(stdoutText()).toContain("Updated to 1.3.0");
+  });
+
+  it("npm-global: returns 1 if `npm install` itself fails (does NOT attempt the refresh)", async () => {
+    const spawn = vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === "npm") throw new Error("ENOENT");
+    });
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npm-global", installDir: "/x" },
+      spawn,
+    });
+    expect(code).toBe(1);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(stderrText()).toContain("npm install failed: ENOENT");
+  });
+
+  it("npm-global: returns 1 if the post-install agent refresh fails", async () => {
+    const spawn = vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === "hivemind") throw new Error("missing platforms");
+    });
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npm-global", installDir: "/x" },
+      spawn,
+    });
+    expect(code).toBe(1);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(stderrText()).toContain("Agent refresh failed");
+  });
+
+  it("npx: prints versioned-pin instructions, returns 0, does NOT spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npx", installDir: "/home/u/.npm/_npx/abc/node_modules/@deeplake/hivemind" },
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("npx @deeplake/hivemind@1.3.0 install");
+    expect(stdoutText()).toContain("npm install -g @deeplake/hivemind@latest");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("local-dev: refuses with a clear message, returns 1, does NOT spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "local-dev", installDir: "/home/u/al-projects/hivemind" },
+      spawn,
+    });
+    expect(code).toBe(1);
+    expect(stderrText()).toContain("local development checkout");
+    expect(stderrText()).toContain("/home/u/al-projects/hivemind");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("unknown: refuses with manual-install fallback, returns 1, does NOT spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "unknown", installDir: "/strange/path" },
+      spawn,
+    });
+    expect(code).toBe(1);
+    expect(stderrText()).toContain("Could not determine how hivemind was installed");
+    expect(stderrText()).toContain("npm install -g @deeplake/hivemind@latest");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectInstallKind — heuristics", () => {
+  let TMP = "";
+  beforeEach(() => { TMP = mkdtempSync(join(tmpdir(), "hivemind-update-test-")); });
+  afterEach(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+  // Build a fake install layout that points argv[1] at a fake CLI binary
+  // and fake the surrounding directory tree. Each test exercises ONE
+  // heuristic in isolation so a regression in one branch can't be hidden by
+  // another (CLAUDE.md rule 7: cover both branches of conditional logic).
+  function fakeInstall(opts: {
+    pathSegments: string[];        // path under TMP, e.g. ["lib","node_modules","@deeplake","hivemind"]
+    pkgName?: string;              // package.json name field
+    addGitIn?: string[];           // create .git in this subpath of installDir
+  }): string {
+    const installDir = join(TMP, ...opts.pathSegments);
+    mkdirSync(installDir, { recursive: true });
+    if (opts.pkgName) {
+      writeFileSync(join(installDir, "package.json"), JSON.stringify({ name: opts.pkgName, version: "0.0.0" }));
+    }
+    if (opts.addGitIn) {
+      mkdirSync(join(installDir, ...opts.addGitIn, ".git"), { recursive: true });
+    }
+    const binDir = join(installDir, "bundle");
+    mkdirSync(binDir, { recursive: true });
+    const bin = join(binDir, "cli.js");
+    writeFileSync(bin, "// fake");
+    return bin;
+  }
+
+  it("identifies a local-dev checkout (.git present in a parent)", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["repo"],
+      pkgName: "@deeplake/hivemind",
+      addGitIn: [],
+    });
+    expect(detectInstallKind(argv1).kind).toBe("local-dev");
+  });
+
+  it("identifies an npm-global install (node_modules/@deeplake/hivemind, no .git)", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["lib", "node_modules", "@deeplake", "hivemind"],
+      pkgName: "@deeplake/hivemind",
+    });
+    const got = detectInstallKind(argv1);
+    expect(got.kind).toBe("npm-global");
+  });
+
+  it("identifies an npx install (path contains _npx, no .git)", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["_npx", "abc123", "node_modules", "@deeplake", "hivemind"],
+      pkgName: "@deeplake/hivemind",
+    });
+    const got = detectInstallKind(argv1);
+    expect(got.kind).toBe("npx");
+  });
+
+  it("returns 'unknown' when no marker matches", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["random", "place"],
+    });
+    expect(detectInstallKind(argv1).kind).toBe("unknown");
+  });
+});
+
+describe("getLatestNpmVersion", () => {
+  it("returns the version on a 200 response with a parseable body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
+    );
+    const got = await getLatestNpmVersion();
+    expect(got).toBe("9.9.9");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    fetchSpy.mockRestore();
+  });
+
+  it("returns null on non-200", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500 }),
+    );
+    expect(await getLatestNpmVersion()).toBeNull();
+    fetchSpy.mockRestore();
+  });
+
+  it("returns null on a network failure (caught, never throws)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await getLatestNpmVersion()).toBeNull();
+    fetchSpy.mockRestore();
+  });
+
+  it("returns null when the response is missing 'version'", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ name: "x" }), { status: 200 }),
+    );
+    expect(await getLatestNpmVersion()).toBeNull();
+    fetchSpy.mockRestore();
+  });
+});

--- a/claude-code/tests/cli-update.test.ts
+++ b/claude-code/tests/cli-update.test.ts
@@ -74,18 +74,66 @@ describe("runUpdate — branches", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it("dry-run: prints 'Would run' and 'Would re-run' without spawning", async () => {
+  it("dry-run, npm-global: prints 'Would run npm install -g' + 'Would re-run hivemind install', no spawn", async () => {
     const spawn = vi.fn();
     const code = await runUpdate({
       dryRun: true,
       currentVersionOverride: "1.2.3",
       latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npm-global", installDir: "/usr/lib/node_modules/@deeplake/hivemind" },
       spawn,
     });
     expect(code).toBe(0);
     expect(stdoutText()).toContain("Update available: 1.2.3 → 1.3.0");
     expect(stdoutText()).toContain("(dry-run) Would run: npm install -g @deeplake/hivemind@latest");
     expect(stdoutText()).toContain("(dry-run) Would re-run: hivemind install --skip-auth");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("dry-run, npx: prints 'Would print npx-pin instructions', no spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      dryRun: true,
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "npx", installDir: "/home/u/.npm/_npx/abc/node_modules/@deeplake/hivemind" },
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("(dry-run)");
+    expect(stdoutText()).toContain("npx-pin");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("dry-run, local-dev: prints 'Would refuse: running from a local dev checkout', no spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      dryRun: true,
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "local-dev", installDir: "/home/u/al-projects/hivemind" },
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("(dry-run) Would refuse");
+    expect(stdoutText()).toContain("local dev checkout");
+    expect(stdoutText()).toContain("/home/u/al-projects/hivemind");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("dry-run, unknown: prints 'Would refuse: install kind unknown', no spawn", async () => {
+    const spawn = vi.fn();
+    const code = await runUpdate({
+      dryRun: true,
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      installKindOverride: { kind: "unknown", installDir: "/strange/path" },
+      spawn,
+    });
+    expect(code).toBe(0);
+    expect(stdoutText()).toContain("(dry-run) Would refuse");
+    expect(stdoutText()).toContain("install kind unknown");
+    expect(stdoutText()).toContain("/strange/path");
     expect(spawn).not.toHaveBeenCalled();
   });
 
@@ -160,6 +208,49 @@ describe("runUpdate — branches", () => {
     expect(stderrText()).toContain("local development checkout");
     expect(stderrText()).toContain("/home/u/al-projects/hivemind");
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  // Drives the live-fetch fallback (ternary at `latestVersionOverride !==
+  // undefined ? ... : await getLatestNpmVersion()`) AND the
+  // `currentVersionOverride ?? getVersion()` fallback at the same time.
+  // Mocked at the fetch boundary to avoid network. Mocks fetch to return
+  // the SAME version as the running package.json so we land in
+  // "up to date" and don't dispatch into any spawn branch.
+  it("falls through to live getVersion + getLatestNpmVersion when both overrides are omitted", async () => {
+    // Read the actual installed version so the mock matches and we hit
+    // the "up to date" branch deterministically.
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const repoRoot = join(__dirname, "..", "..");
+    const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8"));
+    const version: string = pkg.version;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version }), { status: 200 }),
+    );
+    const code = await runUpdate({
+      // NO currentVersionOverride → exercises getVersion()
+      // NO latestVersionOverride → exercises getLatestNpmVersion()
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(stdoutText()).toContain("up to date");
+    fetchSpy.mockRestore();
+  });
+
+  // Drives the `installKindOverride ?? detectInstallKind()` fallback —
+  // omits installKindOverride so the real detection runs against this
+  // test process. The result is local-dev (we're inside a git checkout).
+  it("falls through to live detectInstallKind when installKindOverride is omitted", async () => {
+    const code = await runUpdate({
+      currentVersionOverride: "1.2.3",
+      latestVersionOverride: "1.3.0",
+      // NO installKindOverride → exercises detectInstallKind()
+    });
+    // detectInstallKind() in this test process lands in local-dev
+    // (the worktree has a .git linkage) → exit 1 + refuse.
+    expect(code).toBe(1);
+    expect(stderrText()).toMatch(/local development checkout|Could not determine/);
   });
 
   it("unknown: refuses with manual-install fallback, returns 1, does NOT spawn", async () => {
@@ -238,6 +329,105 @@ describe("detectInstallKind — heuristics", () => {
       pathSegments: ["random", "place"],
     });
     expect(detectInstallKind(argv1).kind).toBe("unknown");
+  });
+
+  // Regression: an npm-global install whose grandparent dir contains .git
+  // (e.g. nvm-installed-via-git → ~/.nvm/.git → ~/.nvm/versions/node/v24/lib/node_modules/@deeplake/hivemind)
+  // must NOT be classified as local-dev. The path-based npm-global match
+  // takes priority over the .git-reachable probe.
+  it("npm-global wins over local-dev when both heuristics would fire", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["versions", "node", "v24.12.0", "lib", "node_modules", "@deeplake", "hivemind"],
+      pkgName: "@deeplake/hivemind",
+    });
+    // Drop a .git that's reachable from a parent of installDir, to mimic
+    // the nvm-via-git layout.
+    mkdirSync(join(TMP, ".git"), { recursive: true });
+    expect(detectInstallKind(argv1).kind).toBe("npm-global");
+  });
+
+  // Same regression for npx — path-based check wins over .git probe.
+  it("npx wins over local-dev when both heuristics would fire", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["_npx", "abc123", "node_modules", "@deeplake", "hivemind"],
+      pkgName: "@deeplake/hivemind",
+    });
+    mkdirSync(join(TMP, ".git"), { recursive: true });
+    expect(detectInstallKind(argv1).kind).toBe("npx");
+  });
+
+  // Walk-up loop: the package.json walk caps at 10 levels. If the install
+  // is deeper than that, we still get *a* result (fall back to argv1's
+  // dirname as installDir) — just won't find package.json.
+  it("returns a result even when no package.json is reachable in 10 levels", () => {
+    const argv1 = fakeInstall({
+      pathSegments: ["random", "place"],
+    });
+    // Don't write any package.json — force the walk-up to exhaust.
+    const got = detectInstallKind(argv1);
+    expect(got.kind).toBe("unknown");
+    expect(got.installDir).toBeTruthy();
+  });
+
+  // realpathSync throws on a non-existent path → catch falls back to the
+  // raw argv1. Covers the catch branch in the realpath wrapper.
+  it("falls back to raw argv1 when realpath throws (path doesn't exist)", () => {
+    const fakePath = "/this/path/does/not/exist/_npx/x/node_modules/@deeplake/hivemind/bundle/cli.js";
+    const got = detectInstallKind(fakePath);
+    // Path-pattern checks still work against the raw string — should land
+    // in npx (the path contains `_npx`).
+    expect(got.kind).toBe("npx");
+  });
+
+  // Walks up to filesystem root without finding our package.json: covers
+  // the `parent === dir` break branch in the walk-up loop. We use the
+  // root path itself, so dir starts at "/" and break fires immediately.
+  it("walk-up handles the filesystem-root edge case", () => {
+    // dirname("/") is "/", so the loop's break-on-no-progress fires.
+    expect(() => detectInstallKind("/cli.js")).not.toThrow();
+  });
+});
+
+// Real defaultSpawn path: passing no `spawn` override exercises the real
+// execFileSync. We can't actually run npm in the test, but we can prove
+// the default impl gets reached on the failure path. CodeRabbit flagged
+// the absence of coverage for this fallback; this drives the line.
+describe("runUpdate — default spawn", () => {
+  it("invokes the default spawn (execFileSync) when no override is passed", async () => {
+    // npm-global path with a guaranteed-to-fail command via PATH override.
+    // We can't override the real spawn here, so we exercise the npm-global
+    // branch which calls into defaultSpawn → execFileSync('npm', ...).
+    // execFileSync will fail because PATH doesn't have a real npm in the
+    // test sandbox (or the install will succeed against a valid registry —
+    // either way the line is executed and counted).
+    //
+    // Skip if we're in CI where npm IS installed; the test would actually
+    // try to upgrade. Use a dry-run kind override that hits the npx branch
+    // to avoid that: npx branch never spawns, so default isn't reached.
+    //
+    // Better: exercise the dry-run for npm-global, which goes through the
+    // dry-run branch (no spawn). That doesn't hit defaultSpawn either.
+    //
+    // The simplest deterministic exercise of defaultSpawn: install kind
+    // override = npm-global, NO dry-run, and override spawn AS the default
+    // by NOT passing it. But then we'd actually fork npm install -g, which
+    // is destructive. So we mock out npm via PATH.
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/this/path/does/not/exist/anywhere";
+    try {
+      const code = await runUpdate({
+        currentVersionOverride: "1.2.3",
+        latestVersionOverride: "1.3.0",
+        installKindOverride: { kind: "npm-global", installDir: "/x" },
+        // NO spawn override — exercise defaultSpawn
+      });
+      // npm not on PATH → execFileSync throws ENOENT → npm-install branch
+      // returns 1.
+      expect(code).toBe(1);
+      expect(stderrText()).toContain("npm install failed");
+    } finally {
+      process.env.PATH = originalPath;
+    }
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { ensureLoggedIn, isLoggedIn, maybeShowOrgChoice } from "./auth.js";
 import { runAuthCommand } from "../commands/auth-login.js";
 import { detectPlatforms, allPlatformIds, log, warn, type PlatformId } from "./util.js";
 import { getVersion } from "./version.js";
+import { runUpdate } from "./update.js";
 
 const AUTH_SUBCOMMANDS = new Set([
   "whoami",
@@ -45,6 +46,9 @@ Usage:
 
   hivemind login            Run device-flow login (open browser).
   hivemind status           Show which assistants are wired up.
+  hivemind update [--dry-run]
+      Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
+      every detected agent bundle. Single command for all agents.
 
 Semantic search (embeddings):
   hivemind embeddings install                Download @huggingface/transformers
@@ -193,6 +197,10 @@ async function main(): Promise<void> {
 
   if (cmd === "login") { await ensureLoggedIn(); return; }
   if (cmd === "status") { runStatus(); return; }
+  if (cmd === "update") {
+    const code = await runUpdate({ dryRun: hasFlag(args.slice(1), "--dry-run") });
+    process.exit(code);
+  }
 
   if (cmd === "embeddings") {
     const sub = args[1];

--- a/src/cli/install-claude.ts
+++ b/src/cli/install-claude.ts
@@ -65,6 +65,13 @@ function pluginAlreadyInstalled(): boolean {
   return r.stdout.includes(PLUGIN_KEY);
 }
 
+// Claude Code's plugin model is multi-scope: a plugin can be enabled at
+// any of `user` / `project` / `local` / `managed` scope, and each scope
+// has its own activation. `claude plugin update` is per-scope, so an
+// upgrade has to fan out across all four; the scopes the user hasn't
+// activated will simply error out, which is fine.
+const PLUGIN_SCOPES = ["user", "project", "local", "managed"] as const;
+
 export function installClaude(): void {
   requireClaudeCli();
 
@@ -78,18 +85,34 @@ export function installClaude(): void {
   }
 
   if (!pluginAlreadyInstalled()) {
+    // First-time install path: just install. The marketplace fetch is
+    // implicit in `claude plugin install`.
     const inst = runClaude(["plugin", "install", "hivemind"]);
     if (!inst.ok) {
       throw new Error(
         `Failed to install hivemind plugin: ${inst.stderr.slice(0, 200)}`,
       );
     }
+    log(`  Claude Code    installed via marketplace ${MARKETPLACE_SOURCE}`);
+  } else {
+    // Already-installed path: refresh the marketplace cache so
+    // `plugin update` sees the newest version, then update across every
+    // scope. Without the explicit `marketplace update` first, ClawHub
+    // would serve a stale catalog and `plugin update` would no-op even
+    // when a newer version is published. Mirrors the legacy
+    // session-start logic in src/hooks/session-start.ts but routes it
+    // through the centralized `hivemind update` command — this is what
+    // makes `hivemind update` actually upgrade Claude (the install-only
+    // path was idempotent and silently skipped the upgrade).
+    runClaude(["plugin", "marketplace", "update", MARKETPLACE_NAME]);
+    for (const scope of PLUGIN_SCOPES) {
+      runClaude(["plugin", "update", PLUGIN_KEY, "--scope", scope]);
+    }
+    log(`  Claude Code    refreshed via marketplace ${MARKETPLACE_SOURCE}`);
   }
 
   // enable is idempotent in claude CLI — safe to run unconditionally
   runClaude(["plugin", "enable", PLUGIN_KEY]);
-
-  log(`  Claude Code    installed via marketplace ${MARKETPLACE_SOURCE}`);
 }
 
 export function uninstallClaude(): void {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,229 @@
+/**
+ * `hivemind update` — manual upgrade flow.
+ *
+ * Single source of truth for upgrades is the npm package
+ * `@deeplake/hivemind`. Per-agent autoupdate paths (Claude marketplace,
+ * Codex git-clone) are legacy: they remain in src/hooks/* until the next
+ * major, but new behavior centralizes here.
+ *
+ * Three-step flow when a newer version is on npm:
+ *   1. Upgrade the CLI itself  (`npm install -g @deeplake/hivemind@latest`)
+ *   2. Re-exec the just-installed binary to refresh agent bundles
+ *      (so we use the NEW pkgRoot()/bundle paths, not stale in-memory ones)
+ *   3. Print a summary
+ *
+ * The re-exec matters: after `npm install -g @latest` rewrites the install
+ * directory, our running process still holds in-memory references to old
+ * files. Calling runSingleInstall() in this process would either copy old
+ * bundles or hit ENOENT for files that were unlinked-and-replaced. Spawning
+ * the new binary side-steps both.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getVersion } from "./version.js";
+import { log, warn } from "./util.js";
+import { isNewer } from "../utils/version-check.js";
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/@deeplake/hivemind/latest";
+const PKG_NAME = "@deeplake/hivemind";
+
+export type InstallKind =
+  | "npm-global"   // npm install -g @deeplake/hivemind — owns its own prefix dir
+  | "npx"          // ran via `npx @deeplake/hivemind` — cached in ~/.npm/_npx
+  | "local-dev"    // git checkout / npm link — has a .git nearby
+  | "unknown";     // can't tell — refuse to upgrade automatically
+
+export interface DetectedInstall {
+  kind: InstallKind;
+  /** The directory of the installed package (resolved through symlinks). */
+  installDir: string;
+}
+
+/**
+ * Detect how the running CLI was installed by walking up from
+ * the binary's real path.
+ *
+ * Heuristics, ordered:
+ *   - Path contains `/_npx/` or `/.npx/` segment → "npx"
+ *   - Path contains `node_modules/@deeplake/hivemind` AND a `.git` dir is
+ *     reachable from a parent → "local-dev" (npm-link or sibling checkout)
+ *   - Path contains `node_modules/@deeplake/hivemind` → "npm-global"
+ *   - A package.json with our name AND a sibling .git dir → "local-dev"
+ *   - Otherwise → "unknown"
+ */
+export function detectInstallKind(argv1?: string): DetectedInstall {
+  const realArgv1 = (() => {
+    try { return realpathSync(argv1 ?? process.argv[1] ?? fileURLToPath(import.meta.url)); }
+    catch { return argv1 ?? process.argv[1] ?? fileURLToPath(import.meta.url); }
+  })();
+
+  // Walk up looking for our package.json.
+  let dir = dirname(realArgv1);
+  let installDir: string | null = null;
+  for (let i = 0; i < 10; i++) {
+    const pkgPath = `${dir}${sep}package.json`;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
+        installDir = dir;
+        break;
+      }
+    } catch { /* not here, keep walking */ }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  installDir ??= dirname(realArgv1);
+
+  // Local dev: .git is reachable from a parent of installDir.
+  let gitDir = installDir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(`${gitDir}${sep}.git`)) {
+      return { kind: "local-dev", installDir };
+    }
+    const parent = dirname(gitDir);
+    if (parent === gitDir) break;
+    gitDir = parent;
+  }
+
+  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
+    return { kind: "npx", installDir };
+  }
+
+  if (realArgv1.includes(`node_modules${sep}@deeplake${sep}hivemind`) ||
+      realArgv1.includes(`node_modules${sep}hivemind`)) {
+    return { kind: "npm-global", installDir };
+  }
+
+  return { kind: "unknown", installDir };
+}
+
+/**
+ * Fetch the latest version from the npm registry. Returns null on any
+ * failure — callers treat that as "skip update".
+ *
+ * Uses the npm registry directly (not GitHub raw) because npm is now the
+ * canonical channel: a git tag without a corresponding npm publish is not
+ * a release, so GitHub-raw can lie ahead of npm.
+ */
+export async function getLatestNpmVersion(timeoutMs = 5000): Promise<string | null> {
+  try {
+    const res = await fetch(NPM_REGISTRY_URL, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return null;
+    const meta = await res.json() as { version?: string };
+    return meta.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface UpdateOptions {
+  /** Skip the actual upgrade, just print what would happen. */
+  dryRun?: boolean;
+  /** Override the install-kind detection (tests). */
+  installKindOverride?: DetectedInstall;
+  /** Override the latest-version fetch (tests). */
+  latestVersionOverride?: string | null;
+  /** Override the running version (tests). */
+  currentVersionOverride?: string;
+  /** Inject the spawn impl (tests). Default: execSync with stdio inherit. */
+  spawn?: (cmd: string, args: string[]) => void;
+}
+
+const defaultSpawn = (cmd: string, args: string[]): void => {
+  execFileSync(cmd, args, { stdio: "inherit" });
+};
+
+/**
+ * Run the update flow. Returns the exit code the CLI should use.
+ *
+ * Exit codes:
+ *   0 — already up to date OR upgrade succeeded OR dry-run
+ *   1 — couldn't reach npm OR upgrade failed OR install kind unsupported
+ */
+export async function runUpdate(opts: UpdateOptions = {}): Promise<number> {
+  const current = opts.currentVersionOverride ?? getVersion();
+  const latest = opts.latestVersionOverride !== undefined
+    ? opts.latestVersionOverride
+    : await getLatestNpmVersion();
+
+  if (!latest) {
+    warn(`Could not reach npm registry to check for updates.`);
+    warn(`Current version: ${current}`);
+    return 1;
+  }
+
+  if (!isNewer(latest, current)) {
+    log(`hivemind ${current} is up to date (npm latest: ${latest}).`);
+    return 0;
+  }
+
+  log(`Update available: ${current} → ${latest}`);
+
+  if (opts.dryRun) {
+    log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
+    log(`(dry-run) Would re-run: hivemind install --skip-auth`);
+    return 0;
+  }
+
+  const detected = opts.installKindOverride ?? detectInstallKind();
+  const spawn = opts.spawn ?? defaultSpawn;
+
+  switch (detected.kind) {
+    case "npm-global": {
+      log(`Upgrading via npm…`);
+      try {
+        spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
+      } catch (e: any) {
+        warn(`npm install failed: ${e.message}`);
+        warn(`Try running it manually: npm install -g ${PKG_NAME}@latest`);
+        return 1;
+      }
+      log(``);
+      log(`Refreshing agent bundles…`);
+      try {
+        // Re-exec the NEW binary to use new pkgRoot()/bundle paths. The
+        // user's $PATH is preserved through stdio: "inherit", so this
+        // resolves to the freshly-installed `hivemind` regardless of how
+        // npm laid it out.
+        spawn("hivemind", ["install", "--skip-auth"]);
+      } catch (e: any) {
+        warn(`Agent refresh failed: ${e.message}`);
+        warn(`Run manually: hivemind install`);
+        return 1;
+      }
+      log(``);
+      log(`Updated to ${latest}.`);
+      return 0;
+    }
+
+    case "npx": {
+      log(`You ran hivemind via npx, which does not have a persistent global install.`);
+      log(`To use the new version, re-run with the explicit version pin:`);
+      log(``);
+      log(`  npx ${PKG_NAME}@${latest} install`);
+      log(``);
+      log(`Or install globally so future updates are one command:`);
+      log(``);
+      log(`  npm install -g ${PKG_NAME}@latest`);
+      return 0;
+    }
+
+    case "local-dev": {
+      warn(`hivemind is running from a local development checkout (${detected.installDir}).`);
+      warn(`Update via your dev workflow (git pull + npm install + npm run build),`);
+      warn(`not via 'hivemind update'.`);
+      return 1;
+    }
+
+    case "unknown":
+    default: {
+      warn(`Could not determine how hivemind was installed (path: ${detected.installDir}).`);
+      warn(`Update manually: npm install -g ${PKG_NAME}@latest`);
+      return 1;
+    }
+  }
+}

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -43,16 +43,23 @@ export interface DetectedInstall {
 }
 
 /**
- * Detect how the running CLI was installed by walking up from
- * the binary's real path.
+ * Detect how the running CLI was installed by walking up from the
+ * binary's real path.
  *
- * Heuristics, ordered:
- *   - Path contains `/_npx/` or `/.npx/` segment → "npx"
- *   - Path contains `node_modules/@deeplake/hivemind` AND a `.git` dir is
- *     reachable from a parent → "local-dev" (npm-link or sibling checkout)
- *   - Path contains `node_modules/@deeplake/hivemind` → "npm-global"
- *   - A package.json with our name AND a sibling .git dir → "local-dev"
- *   - Otherwise → "unknown"
+ * Heuristics, in priority order:
+ *   1. Path contains `/_npx/` or `/.npx/` segment             → "npx"
+ *   2. Path contains `node_modules/(@deeplake/)?hivemind`     → "npm-global"
+ *   3. A `.git` directory is reachable within 6 levels of the
+ *      install dir (only checked if #1 and #2 didn't fire)    → "local-dev"
+ *   4. Otherwise                                              → "unknown"
+ *
+ * Path-pattern checks (#1, #2) come BEFORE the .git probe (#3) so an
+ * npm-global install whose grandparent happens to be a git repo (dotfiles
+ * tree, nvm-installed-via-git, CI checkouts where the home dir is part of
+ * the workspace) doesn't get mis-flagged as `local-dev` and refused.
+ * Without this ordering, users with a typical `git clone` install of nvm
+ * had `~/.nvm/.git` reachable from `~/.nvm/.../node_modules/@deeplake/hivemind`
+ * and `hivemind update` would refuse with "this is a dev checkout."
  */
 export function detectInstallKind(argv1?: string): DetectedInstall {
   const realArgv1 = (() => {
@@ -60,7 +67,8 @@ export function detectInstallKind(argv1?: string): DetectedInstall {
     catch { return argv1 ?? process.argv[1] ?? fileURLToPath(import.meta.url); }
   })();
 
-  // Walk up looking for our package.json.
+  // Walk up looking for our package.json — gives us the install dir to
+  // report and to use as the .git-search root.
   let dir = dirname(realArgv1);
   let installDir: string | null = null;
   for (let i = 0; i < 10; i++) {
@@ -78,7 +86,24 @@ export function detectInstallKind(argv1?: string): DetectedInstall {
   }
   installDir ??= dirname(realArgv1);
 
-  // Local dev: .git is reachable from a parent of installDir.
+  // 1. npx-cached install (path-based — definitive).
+  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
+    return { kind: "npx", installDir };
+  }
+
+  // 2. node_modules layout (path-based — definitive). Catches both an npm
+  // global prefix (`/usr/.../lib/node_modules/@deeplake/hivemind`) and a
+  // project-local install (`<proj>/node_modules/@deeplake/hivemind`). Both
+  // upgrade safely via `npm install -g @latest` from the user's POV.
+  if (realArgv1.includes(`${sep}node_modules${sep}@deeplake${sep}hivemind`) ||
+      realArgv1.includes(`${sep}node_modules${sep}hivemind`)) {
+    return { kind: "npm-global", installDir };
+  }
+
+  // 3. .git-reachable fallback. Only reached when path-based checks above
+  // didn't fire — i.e. install dir is NOT under any node_modules tree.
+  // That's the strong signal for a true dev checkout (`npm link` from a
+  // git clone, or `tsx src/cli/index.ts` straight from the repo).
   let gitDir = installDir;
   for (let i = 0; i < 6; i++) {
     if (existsSync(`${gitDir}${sep}.git`)) {
@@ -87,15 +112,6 @@ export function detectInstallKind(argv1?: string): DetectedInstall {
     const parent = dirname(gitDir);
     if (parent === gitDir) break;
     gitDir = parent;
-  }
-
-  if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
-    return { kind: "npx", installDir };
-  }
-
-  if (realArgv1.includes(`node_modules${sep}@deeplake${sep}hivemind`) ||
-      realArgv1.includes(`node_modules${sep}hivemind`)) {
-    return { kind: "npm-global", installDir };
   }
 
   return { kind: "unknown", installDir };
@@ -163,17 +179,16 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<number> {
 
   log(`Update available: ${current} → ${latest}`);
 
-  if (opts.dryRun) {
-    log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
-    log(`(dry-run) Would re-run: hivemind install --skip-auth`);
-    return 0;
-  }
-
   const detected = opts.installKindOverride ?? detectInstallKind();
   const spawn = opts.spawn ?? defaultSpawn;
 
   switch (detected.kind) {
     case "npm-global": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would run: npm install -g ${PKG_NAME}@latest`);
+        log(`(dry-run) Would re-run: hivemind install --skip-auth`);
+        return 0;
+      }
       log(`Upgrading via npm…`);
       try {
         spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
@@ -201,6 +216,10 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<number> {
     }
 
     case "npx": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would print npx-pin instructions (no persistent install to upgrade).`);
+        return 0;
+      }
       log(`You ran hivemind via npx, which does not have a persistent global install.`);
       log(`To use the new version, re-run with the explicit version pin:`);
       log(``);
@@ -213,6 +232,10 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<number> {
     }
 
     case "local-dev": {
+      if (opts.dryRun) {
+        log(`(dry-run) Would refuse: running from a local dev checkout (${detected.installDir}).`);
+        return 0;
+      }
       warn(`hivemind is running from a local development checkout (${detected.installDir}).`);
       warn(`Update via your dev workflow (git pull + npm install + npm run build),`);
       warn(`not via 'hivemind update'.`);
@@ -221,6 +244,10 @@ export async function runUpdate(opts: UpdateOptions = {}): Promise<number> {
 
     case "unknown":
     default: {
+      if (opts.dryRun) {
+        log(`(dry-run) Would refuse: install kind unknown (${detected.installDir}).`);
+        return 0;
+      }
       warn(`Could not determine how hivemind was installed (path: ${detected.installDir}).`);
       warn(`Update manually: npm install -g ${PKG_NAME}@latest`);
       return 1;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -209,6 +209,7 @@ export default defineConfig({
         "src/cli/version.ts":           { statements: 80, branches: 80, functions: 80, lines: 80 },
         "src/cli/auth.ts":              { statements: 80, branches: 80, functions: 80, lines: 80 },
         "src/cli/index.ts":             { statements: 80, branches: 80, functions: 80, lines: 80 },
+        "src/cli/update.ts":            { statements: 80, branches: 80, functions: 80, lines: 80 },
         "src/cli/install-claude.ts":    { statements: 80, branches: 80, functions: 80, lines: 80 },
         "src/cli/install-codex.ts":     { statements: 80, branches: 80, functions: 80, lines: 80 },
         "src/cli/install-cursor.ts":    { statements: 80, branches: 80, functions: 80, lines: 80 },


### PR DESCRIPTION
## Summary

New `hivemind update` command that upgrades the CLI itself + refreshes every detected agent bundle in one go. Single entry point for all agents — replaces the divergent per-agent update paths (Claude marketplace `claude plugin update`, Codex git-clone tag flow) for users who installed via npm.

## How it works

1. Queries the npm registry (`registry.npmjs.org/@deeplake/hivemind/latest`)
2. If newer, detects install kind from `process.argv[1]`:
   - `npm-global` → `npm install -g @deeplake/hivemind@latest`, then re-exec `hivemind install --skip-auth` (the re-exec uses the *new* binary, avoiding the post-install inode-vs-memory mismatch)
   - `npx` → prints the versioned-pin command (no global install to upgrade in place)
   - `local-dev` (.git nearby) → refuses with "use git pull + npm run build"
   - `unknown` → falls back to "run npm install -g manually"

## Why centralize on npm

Per the architectural direction, npm is now the single update channel. Cursor / Hermes / pi / OpenClaw never had autoupdate (they only get a `.hivemind_version` stamp at install time); they pick it up for free here. Per-agent update paths in `src/hooks/session-start.ts` and `src/hooks/codex/session-start-setup.ts` remain in place for already-installed users — follow-up PR will route them through the same shared helper.

## Test plan

- [x] `npm test` — 1769 / 1769 pass (1747 prior + 22 new)
- [x] `npm run typecheck` clean
- [x] `npm run build` — bundles re-emitted, no drift
- [x] Smoke: `node bundle/cli.js update --dry-run` against repo (current === npm latest) prints `up to date`
- [x] Smoke: `runUpdate` with `currentVersionOverride: 0.0.1, latestVersionOverride: 9.9.9`, each install-kind override — output matches expected branch (dry-run, npx, local-dev, unknown)
- [x] `hivemind --help` lists the new command
- [ ] Real-world: not yet exercised against an actual published `@latest > current` situation; will test once we publish 0.7.5+

## Tests added

- `claude-code/tests/cli-update.test.ts` — 18 tests:
  - `runUpdate`: up-to-date / current-ahead / unreachable-registry / dry-run / npm-global success / npm-global failure (npm itself fails) / npm-global failure (refresh fails) / npx / local-dev / unknown
  - `detectInstallKind`: local-dev / npm-global / npx / unknown
  - `getLatestNpmVersion`: 200 / 500 / network failure / missing version field
- `claude-code/tests/cli-index.test.ts` — 3 new tests for the dispatch path: default args / `--dry-run` flag / exit-code propagation

## Follow-up (not in this PR)

- Route `creds.autoupdate`-gated session-start checks through the same shared helper. Removes the divergent Claude-marketplace and Codex-git-clone update paths — Cursor / Hermes / pi / OpenClaw inherit autoupdate for free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hivemind update [--dry-run]` command to check for and install the latest version of the CLI. The `--dry-run` flag lets you preview what would be upgraded without making changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->