### PR TITLE
fix(auth-login): validate workspace on switch; reset stale workspace on org switch

### DIFF
--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4512,17 +4512,23 @@ async function runAuthCommand(args) {
           console.log(`Org not found: ${target}`);
           process.exit(1);
         }
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const matchedWs = wsList.find((w) => w.id === prevWs || w.name && w.name.toLowerCase() === lcPrev);
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -4556,7 +4562,8 @@ async function runAuthCommand(args) {
           process.exit(1);
         }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find((w) => w.id === target || w.name && w.name.toLowerCase() === lcTarget);
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4541,7 +4541,7 @@ async function runAuthCommand(args) {
         process.exit(1);
       }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach((w) => console.log(`${w.id}  ${w.name}`));
+      ws.forEach((w) => console.log(w.name || w.id));
       break;
     }
     case "workspace": {
@@ -4552,7 +4552,7 @@ async function runAuthCommand(args) {
       const sub = args[1];
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach((w) => console.log(w.name || w.id));
         break;
       }
       if (sub === "switch") {

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4514,6 +4514,16 @@ async function runAuthCommand(args) {
         }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -4533,14 +4543,33 @@ async function runAuthCommand(args) {
         console.log("Not logged in.");
         process.exit(1);
       }
-      const wsId = args[1];
-      if (!wsId) {
-        console.log("Usage: workspace <id>");
-        process.exit(1);
+      const sub = args[1];
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        break;
       }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) {
+          console.log("Usage: workspace switch <name-or-id>");
+          process.exit(1);
+        }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
     case "invite": {
       if (!creds) {
@@ -4681,7 +4710,8 @@ Account / org / workspace:
   hivemind org list                        List organizations.
   hivemind org switch <name-or-id>         Switch active organization.
   hivemind workspaces                      List workspaces in current org.
-  hivemind workspace <id>                  Switch active workspace.
+  hivemind workspace list                  List workspaces (alias of 'workspaces').
+  hivemind workspace switch <name-or-id>   Switch active workspace.
   hivemind members                         List org members.
   hivemind invite <email> <ADMIN|WRITE|READ>  Invite a teammate.
   hivemind remove <user-id>                Remove a member.

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -890,17 +890,23 @@ async function runAuthCommand(args) {
           console.log(`Org not found: ${target}`);
           process.exit(1);
         }
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const matchedWs = wsList.find((w) => w.id === prevWs || w.name && w.name.toLowerCase() === lcPrev);
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -934,7 +940,8 @@ async function runAuthCommand(args) {
           process.exit(1);
         }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find((w) => w.id === target || w.name && w.name.toLowerCase() === lcTarget);
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -919,7 +919,7 @@ async function runAuthCommand(args) {
         process.exit(1);
       }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach((w) => console.log(`${w.id}  ${w.name}`));
+      ws.forEach((w) => console.log(w.name || w.id));
       break;
     }
     case "workspace": {
@@ -930,7 +930,7 @@ async function runAuthCommand(args) {
       const sub = args[1];
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach((w) => console.log(w.name || w.id));
         break;
       }
       if (sub === "switch") {

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -892,6 +892,16 @@ async function runAuthCommand(args) {
         }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -911,14 +921,33 @@ async function runAuthCommand(args) {
         console.log("Not logged in.");
         process.exit(1);
       }
-      const wsId = args[1];
-      if (!wsId) {
-        console.log("Usage: workspace <id>");
-        process.exit(1);
+      const sub = args[1];
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        break;
       }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) {
+          console.log("Usage: workspace switch <name-or-id>");
+          process.exit(1);
+        }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
     case "invite": {
       if (!creds) {

--- a/claude-code/tests/auth-login-dispatch.test.ts
+++ b/claude-code/tests/auth-login-dispatch.test.ts
@@ -292,12 +292,22 @@ describe("runAuthCommand — org list / switch", () => {
 });
 
 describe("runAuthCommand — workspaces / workspace", () => {
-  it("'workspaces' lists each workspace from listWorkspaces", async () => {
+  it("'workspaces' lists each workspace's display name (one per line)", async () => {
     listWorkspacesMock.mockResolvedValue([{ id: "ws1", name: "default" }, { id: "ws2", name: "alt" }]);
     await run(["workspaces"]);
     expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "org-1");
-    expect(consoleText()).toContain("ws1  default");
-    expect(consoleText()).toContain("ws2  alt");
+    const lines = consoleText().split("\n").filter(l => l.length > 0);
+    expect(lines).toEqual(["default", "alt"]);
+  });
+
+  it("'workspaces' falls back to the id when a workspace has no display name", async () => {
+    // Defensive: API responses occasionally omit `name` for system/internal
+    // workspaces; the listing must still be readable instead of printing
+    // "undefined".
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-no-name", name: undefined as unknown as string }]);
+    await run(["workspaces"]);
+    expect(consoleText()).toContain("ws-no-name");
+    expect(consoleText()).not.toContain("undefined");
   });
 
   it("'workspace' without a subcommand exits 1 with usage listing only `list` and `switch`", async () => {
@@ -320,13 +330,12 @@ describe("runAuthCommand — workspaces / workspace", () => {
     expect(listWorkspacesMock).not.toHaveBeenCalled();
   });
 
-  it("'workspace list' prints '<id>  <name>' for each workspace, mirroring the plural `workspaces` command", async () => {
+  it("'workspace list' prints each workspace's display name (one per line), matching the plural `workspaces` command", async () => {
     listWorkspacesMock.mockResolvedValue([{ id: "ws1", name: "default" }, { id: "ws2", name: "alt" }]);
     await run(["workspace", "list"]);
     expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "org-1");
-    const text = consoleText();
-    expect(text).toContain("ws1  default");
-    expect(text).toContain("ws2  alt");
+    const lines = consoleText().split("\n").filter(l => l.length > 0);
+    expect(lines).toEqual(["default", "alt"]);
     // Critical: must NOT call switchWorkspace — `list` is read-only.
     expect(switchWorkspaceMock).not.toHaveBeenCalled();
   });

--- a/claude-code/tests/auth-login-dispatch.test.ts
+++ b/claude-code/tests/auth-login-dispatch.test.ts
@@ -180,10 +180,94 @@ describe("runAuthCommand — org list / switch", () => {
     expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "o2");
   });
 
-  it("'org switch' does not reset the workspace when it still exists in the new org (matched by name)", async () => {
+  it("'org switch' normalizes a name-only carry-over to the canonical workspace id (so subsequent commands target a stable id, not a renameable name)", async () => {
+    // Stored workspaceId is "shared" — that's a NAME in the new org, not an id.
+    // The fix must persist the canonical id "ws-shared" so a future rename of
+    // the workspace doesn't silently invalidate this user's credentials.
     loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "shared" });
     listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
     listWorkspacesMock.mockResolvedValue([{ id: "ws-shared", name: "shared" }]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("ws-shared");
+    expect(switchWorkspaceMock).toHaveBeenCalledTimes(1);
+    const text = consoleText();
+    expect(text).toContain("resolved to id 'ws-shared'");
+    // Must NOT print the reset-to-default warning — this is a normalization,
+    // not a reset to the sentinel.
+    expect(text).not.toContain("Reset workspace");
+  });
+
+  it("'org switch' leaves credentials untouched when the carried-over id already matches a workspace by id (no normalization needed)", async () => {
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "ws-shared" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-shared", name: "shared" }]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    const text = consoleText();
+    expect(text).not.toContain("Reset workspace");
+    expect(text).not.toContain("resolved to id");
+  });
+
+  it("'org switch' aborts atomically when listWorkspaces fails — switchOrg is never called and credentials remain on the old org", async () => {
+    // Atomicity: the workspace fetch happens BEFORE switchOrg so a network
+    // failure can't leave credentials half-committed (org switched but
+    // workspace not validated). Re-running the command then succeeds cleanly.
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "k7" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockRejectedValue(new Error("network down"));
+    await expect(run(["org", "switch", "wayne"])).rejects.toThrow("network down");
+    expect(switchOrgMock).not.toHaveBeenCalled();
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+  });
+
+  it("'org switch' does not log a reset warning when the carry-over is already the 'default' sentinel and the new org has no 'default' workspace", async () => {
+    // Avoid a misleading "Workspace 'default' is not in org … Reset workspace
+    // to 'default'." message — there's nothing to reset.
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "default" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-1", name: "alpha" }]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(consoleText()).not.toContain("Reset workspace");
+  });
+
+  it("'org switch' falls back to the 'default' sentinel when credentials have no workspaceId field at all", async () => {
+    // Coverage: the `?? "default"` branch (workspaceId field missing entirely
+    // — possible on legacy or partially-initialized creds).
+    const credsNoWs = { ...validCreds } as Record<string, unknown>;
+    delete credsNoWs.workspaceId;
+    loadCredentialsMock.mockReturnValue(credsNoWs);
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-1", name: "alpha" }]);
+    await run(["org", "switch", "wayne"]);
+    // No reset warning (sentinel + no match → silent), no normalization log.
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    const text = consoleText();
+    expect(text).not.toContain("Reset workspace");
+    expect(text).not.toContain("resolved to id");
+  });
+
+  it("'org switch' resets but suppresses the 'Available workspaces' line when the new org has zero workspaces", async () => {
+    // Coverage: the `wsList.length > 0` else branch.
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "k7" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("default");
+    const text = consoleText();
+    expect(text).toContain("Reset workspace to 'default'");
+    expect(text).not.toContain("Available workspaces:");
+  });
+
+  it("'org switch' does not crash when a workspace in the list has no `name` field (matches purely by id)", async () => {
+    // Defensive: API responses may omit `name` for system/internal workspaces.
+    // The find predicate must guard against `w.name.toLowerCase()` blowing up.
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "ws-named-only" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([
+      { id: "ws-no-name", name: undefined as unknown as string },
+      { id: "ws-named-only", name: "named" },
+    ]);
     await run(["org", "switch", "wayne"]);
     expect(switchWorkspaceMock).not.toHaveBeenCalled();
     expect(consoleText()).not.toContain("Reset workspace");
@@ -271,12 +355,27 @@ describe("runAuthCommand — workspaces / workspace", () => {
     expect(consoleText()).toContain("Available workspaces: seven");
   });
 
-  it("'workspace switch' on an unknown target exits 1 and never switches", async () => {
-    listWorkspacesMock.mockResolvedValue([{ id: "ws-7", name: "seven" }]);
+  it("'workspace switch <unknown>' suppresses the 'Available workspaces' line when the org has zero workspaces", async () => {
+    // Coverage for the `wsList.length > 0` else branch in the workspace switch
+    // handler (mirrors the same branch in `org switch`).
+    listWorkspacesMock.mockResolvedValue([]);
     await run(["workspace", "switch", "k7"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(switchWorkspaceMock).not.toHaveBeenCalled();
-    expect(consoleText()).toContain("Workspace not found: k7");
+    const text = consoleText();
+    expect(text).toContain("Workspace not found: k7");
+    expect(text).not.toContain("Available workspaces:");
+  });
+
+  it("'workspace switch' does not crash when a workspace in the list has no `name` field", async () => {
+    // Defensive: same name-undefined guard as in the `org switch` carry-over
+    // resolver. The find predicate must not invoke `w.name.toLowerCase()` on
+    // an undefined name.
+    listWorkspacesMock.mockResolvedValue([
+      { id: "ws-no-name", name: undefined as unknown as string },
+      { id: "ws-7", name: "seven" },
+    ]);
+    await run(["workspace", "switch", "ws-no-name"]);
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("ws-no-name");
   });
 
   it("'workspace switch' without a target exits 1 with subcommand-specific usage", async () => {

--- a/claude-code/tests/auth-login-dispatch.test.ts
+++ b/claude-code/tests/auth-login-dispatch.test.ts
@@ -143,13 +143,17 @@ describe("runAuthCommand — org list / switch", () => {
 
   it("'org switch' calls switchOrg and confirms with the matched org name", async () => {
     listOrgsMock.mockResolvedValue([{ id: "o1", name: "acme" }, { id: "o2", name: "wayne" }]);
+    // 'default' exists in the new org, so no workspace reset is expected.
+    listWorkspacesMock.mockResolvedValue([{ id: "default", name: "default" }]);
     await run(["org", "switch", "wayne"]);
     expect(switchOrgMock).toHaveBeenCalledWith("o2", "wayne");
     expect(consoleText()).toContain("Switched to org: wayne");
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
   });
 
   it("'org switch' is case-insensitive on the name lookup", async () => {
     listOrgsMock.mockResolvedValue([{ id: "o1", name: "Acme" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "default", name: "default" }]);
     await run(["org", "switch", "ACME"]);
     expect(switchOrgMock).toHaveBeenCalledWith("o1", "Acme");
   });
@@ -159,6 +163,30 @@ describe("runAuthCommand — org list / switch", () => {
     await run(["org", "switch", "ghost"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(switchOrgMock).not.toHaveBeenCalled();
+  });
+
+  it("'org switch' resets workspace to 'default' when the carried-over workspace doesn't exist in the new org", async () => {
+    // Previous workspace was "k7" (from a different org). New org only has "default".
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "k7" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "default", name: "default" }]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchOrgMock).toHaveBeenCalledWith("o2", "wayne");
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("default");
+    expect(switchWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(consoleText()).toContain("not in org 'wayne'");
+    expect(consoleText()).toContain("Reset workspace to 'default'");
+    // listWorkspaces must be called with the NEW org id, not the stale one from creds.
+    expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "o2");
+  });
+
+  it("'org switch' does not reset the workspace when it still exists in the new org (matched by name)", async () => {
+    loadCredentialsMock.mockReturnValue({ ...validCreds, workspaceId: "shared" });
+    listOrgsMock.mockResolvedValue([{ id: "o2", name: "wayne" }]);
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-shared", name: "shared" }]);
+    await run(["org", "switch", "wayne"]);
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(consoleText()).not.toContain("Reset workspace");
   });
 
   it("'org switch' without a target exits 1 with usage", async () => {
@@ -188,16 +216,76 @@ describe("runAuthCommand — workspaces / workspace", () => {
     expect(consoleText()).toContain("ws2  alt");
   });
 
-  it("'workspace <id>' calls switchWorkspace and confirms", async () => {
-    await run(["workspace", "ws-7"]);
-    expect(switchWorkspaceMock).toHaveBeenCalledWith("ws-7");
-    expect(consoleText()).toContain("Switched to workspace: ws-7");
-  });
-
-  it("'workspace' without an id exits 1 with usage", async () => {
+  it("'workspace' without a subcommand exits 1 with usage listing only `list` and `switch`", async () => {
     await run(["workspace"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(consoleText()).toContain("Usage: workspace <id>");
+    const text = consoleText();
+    expect(text).toContain("workspace list");
+    expect(text).toContain("workspace switch <name-or-id>");
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(listWorkspacesMock).not.toHaveBeenCalled();
+  });
+
+  it("an unknown subcommand (no longer a bare-target shortcut) exits 1 and never touches the API", async () => {
+    // Regression guard: previously `workspace ws-7` was a shortcut for switching.
+    // It must now be rejected — only `list` and `switch <target>` are valid.
+    await run(["workspace", "ws-7"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(consoleText()).toContain("Usage: workspace list | workspace switch <name-or-id>");
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(listWorkspacesMock).not.toHaveBeenCalled();
+  });
+
+  it("'workspace list' prints '<id>  <name>' for each workspace, mirroring the plural `workspaces` command", async () => {
+    listWorkspacesMock.mockResolvedValue([{ id: "ws1", name: "default" }, { id: "ws2", name: "alt" }]);
+    await run(["workspace", "list"]);
+    expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "org-1");
+    const text = consoleText();
+    expect(text).toContain("ws1  default");
+    expect(text).toContain("ws2  alt");
+    // Critical: must NOT call switchWorkspace — `list` is read-only.
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+  });
+
+  it("'workspace switch <id>' validates against listWorkspaces and switches to the matched id", async () => {
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-7", name: "seven" }, { id: "ws-8", name: "eight" }]);
+    await run(["workspace", "switch", "ws-7"]);
+    expect(listWorkspacesMock).toHaveBeenCalledWith("tok", "https://api.example", "org-1");
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("ws-7");
+    expect(switchWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(consoleText()).toContain("Switched to workspace: seven");
+  });
+
+  it("'workspace switch <name>' resolves names case-insensitively", async () => {
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-7", name: "Seven" }]);
+    await run(["workspace", "switch", "SEVEN"]);
+    expect(switchWorkspaceMock).toHaveBeenCalledWith("ws-7");
+  });
+
+  it("'workspace switch <unknown>' exits 1 with the available list and never calls switchWorkspace", async () => {
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-7", name: "seven" }]);
+    await run(["workspace", "switch", "k7"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(consoleText()).toContain("Workspace not found: k7");
+    expect(consoleText()).toContain("Available workspaces: seven");
+  });
+
+  it("'workspace switch' on an unknown target exits 1 and never switches", async () => {
+    listWorkspacesMock.mockResolvedValue([{ id: "ws-7", name: "seven" }]);
+    await run(["workspace", "switch", "k7"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    expect(consoleText()).toContain("Workspace not found: k7");
+  });
+
+  it("'workspace switch' without a target exits 1 with subcommand-specific usage", async () => {
+    await run(["workspace", "switch"]);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(consoleText()).toContain("Usage: workspace switch <name-or-id>");
+    expect(switchWorkspaceMock).not.toHaveBeenCalled();
+    // Must not even hit the API when the user supplied no target.
+    expect(listWorkspacesMock).not.toHaveBeenCalled();
   });
 
   it("'workspaces' without credentials exits 1", async () => {

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -890,17 +890,23 @@ async function runAuthCommand(args) {
           console.log(`Org not found: ${target}`);
           process.exit(1);
         }
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const matchedWs = wsList.find((w) => w.id === prevWs || w.name && w.name.toLowerCase() === lcPrev);
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -934,7 +940,8 @@ async function runAuthCommand(args) {
           process.exit(1);
         }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find((w) => w.id === target || w.name && w.name.toLowerCase() === lcTarget);
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -919,7 +919,7 @@ async function runAuthCommand(args) {
         process.exit(1);
       }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach((w) => console.log(`${w.id}  ${w.name}`));
+      ws.forEach((w) => console.log(w.name || w.id));
       break;
     }
     case "workspace": {
@@ -930,7 +930,7 @@ async function runAuthCommand(args) {
       const sub = args[1];
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach((w) => console.log(w.name || w.id));
         break;
       }
       if (sub === "switch") {

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -892,6 +892,16 @@ async function runAuthCommand(args) {
         }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -911,14 +921,33 @@ async function runAuthCommand(args) {
         console.log("Not logged in.");
         process.exit(1);
       }
-      const wsId = args[1];
-      if (!wsId) {
-        console.log("Usage: workspace <id>");
-        process.exit(1);
+      const sub = args[1];
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        break;
       }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) {
+          console.log("Usage: workspace switch <name-or-id>");
+          process.exit(1);
+        }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
     case "invite": {
       if (!creds) {

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -890,17 +890,23 @@ async function runAuthCommand(args) {
           console.log(`Org not found: ${target}`);
           process.exit(1);
         }
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const matchedWs = wsList.find((w) => w.id === prevWs || w.name && w.name.toLowerCase() === lcPrev);
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -934,7 +940,8 @@ async function runAuthCommand(args) {
           process.exit(1);
         }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find((w) => w.id === target || w.name && w.name.toLowerCase() === lcTarget);
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -919,7 +919,7 @@ async function runAuthCommand(args) {
         process.exit(1);
       }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach((w) => console.log(`${w.id}  ${w.name}`));
+      ws.forEach((w) => console.log(w.name || w.id));
       break;
     }
     case "workspace": {
@@ -930,7 +930,7 @@ async function runAuthCommand(args) {
       const sub = args[1];
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach((w) => console.log(w.name || w.id));
         break;
       }
       if (sub === "switch") {

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -892,6 +892,16 @@ async function runAuthCommand(args) {
         }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -911,14 +921,33 @@ async function runAuthCommand(args) {
         console.log("Not logged in.");
         process.exit(1);
       }
-      const wsId = args[1];
-      if (!wsId) {
-        console.log("Usage: workspace <id>");
-        process.exit(1);
+      const sub = args[1];
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        break;
       }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) {
+          console.log("Usage: workspace switch <name-or-id>");
+          process.exit(1);
+        }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
     case "invite": {
       if (!creds) {

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -890,17 +890,23 @@ async function runAuthCommand(args) {
           console.log(`Org not found: ${target}`);
           process.exit(1);
         }
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const matchedWs = wsList.find((w) => w.id === prevWs || w.name && w.name.toLowerCase() === lcPrev);
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -934,7 +940,8 @@ async function runAuthCommand(args) {
           process.exit(1);
         }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find((w) => w.id === target || w.name && w.name.toLowerCase() === lcTarget);
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -919,7 +919,7 @@ async function runAuthCommand(args) {
         process.exit(1);
       }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach((w) => console.log(`${w.id}  ${w.name}`));
+      ws.forEach((w) => console.log(w.name || w.id));
       break;
     }
     case "workspace": {
@@ -930,7 +930,7 @@ async function runAuthCommand(args) {
       const sub = args[1];
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach((w) => console.log(w.name || w.id));
         break;
       }
       if (sub === "switch") {

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -892,6 +892,16 @@ async function runAuthCommand(args) {
         }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some((w) => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -911,14 +921,33 @@ async function runAuthCommand(args) {
         console.log("Not logged in.");
         process.exit(1);
       }
-      const wsId = args[1];
-      if (!wsId) {
-        console.log("Usage: workspace <id>");
-        process.exit(1);
+      const sub = args[1];
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach((w) => console.log(`${w.id}  ${w.name}`));
+        break;
       }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) {
+          console.log("Usage: workspace switch <name-or-id>");
+          process.exit(1);
+        }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find((w) => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map((w) => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
     case "invite": {
       if (!creds) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,7 +64,8 @@ Account / org / workspace:
   hivemind org list                        List organizations.
   hivemind org switch <name-or-id>         Switch active organization.
   hivemind workspaces                      List workspaces in current org.
-  hivemind workspace <id>                  Switch active workspace.
+  hivemind workspace list                  List workspaces (alias of 'workspaces').
+  hivemind workspace switch <name-or-id>   Switch active workspace.
   hivemind members                         List org members.
   hivemind invite <email> <ADMIN|WRITE|READ>  Invite a teammate.
   hivemind remove <user-id>                Remove a member.

--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -110,7 +110,7 @@ export async function runAuthCommand(args: string[]): Promise<void> {
     case "workspaces": {
       if (!creds) { console.log("Not logged in."); process.exit(1); }
       const ws = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-      ws.forEach(w => console.log(`${w.id}  ${w.name}`));
+      ws.forEach(w => console.log(w.name || w.id));
       break;
     }
 
@@ -120,7 +120,7 @@ export async function runAuthCommand(args: string[]): Promise<void> {
 
       if (sub === "list") {
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        wsList.forEach(w => console.log(`${w.id}  ${w.name}`));
+        wsList.forEach(w => console.log(w.name || w.id));
         break;
       }
 

--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -66,21 +66,40 @@ export async function runAuthCommand(args: string[]): Promise<void> {
         const orgs = await listOrgs(creds.token, apiUrl);
         const match = orgs.find(o => o.id === target || o.name.toLowerCase() === target.toLowerCase());
         if (!match) { console.log(`Org not found: ${target}`); process.exit(1); }
+
+        // Resolve the carry-over BEFORE mutating credentials. If listWorkspaces
+        // fails (network blip, 5xx) the exception bubbles up unchanged and the
+        // org switch never happens — re-running the command then succeeds
+        // cleanly instead of leaving credentials half-committed.
+        const prevWs = creds.workspaceId ?? "default";
+        const lcPrev = prevWs.toLowerCase();
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        // Resolve to the matched workspace OBJECT, not a boolean: `workspaceId`
+        // is supposed to be a canonical id but legacy creds (and the post-login
+        // `"default"` sentinel) can hold a name. We need the matched object so
+        // we can normalize a name-only match to the canonical id.
+        const matchedWs = wsList.find(w => w.id === prevWs || (w.name && w.name.toLowerCase() === lcPrev));
+
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
 
-        // Carry-over guard: the previous workspaceId may not exist in the new
-        // org. If it doesn't, reset to "default" so subsequent commands don't
-        // silently target a non-existent workspace.
-        const prevWs = creds.workspaceId ?? "default";
-        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
-        const stillThere = wsList.some(w => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
-        if (!stillThere) {
-          await switchWorkspace("default");
-          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
-          if (wsList.length > 0) {
-            console.log(`Available workspaces: ${wsList.map(w => w.name || w.id).join(", ")}`);
+        if (!matchedWs) {
+          // Suppress the reset-and-warn when prevWs is already the "default"
+          // sentinel and the new org has no workspace named/idd "default" —
+          // there's nothing to reset and the warning would be misleading.
+          if (prevWs !== "default") {
+            await switchWorkspace("default");
+            console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+            if (wsList.length > 0) {
+              console.log(`Available workspaces: ${wsList.map(w => w.name || w.id).join(", ")}`);
+            }
           }
+        } else if (matchedWs.id !== prevWs) {
+          // The carried-over value matched only by display name. Persist the
+          // canonical id so subsequent commands target the workspace
+          // deterministically (an id is stable across renames; a name is not).
+          await switchWorkspace(matchedWs.id);
+          console.log(`Workspace name '${prevWs}' resolved to id '${matchedWs.id}' in org '${match.name}'.`);
         }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
@@ -109,7 +128,8 @@ export async function runAuthCommand(args: string[]): Promise<void> {
         const target = args[2];
         if (!target) { console.log("Usage: workspace switch <name-or-id>"); process.exit(1); }
         const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
-        const match = wsList.find(w => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        const lcTarget = target.toLowerCase();
+        const match = wsList.find(w => w.id === target || (w.name && w.name.toLowerCase() === lcTarget));
         if (!match) {
           console.log(`Workspace not found: ${target}`);
           if (wsList.length > 0) {

--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -8,8 +8,9 @@
  *   node auth-login.js logout             — remove credentials
  *   node auth-login.js org list           — list orgs
  *   node auth-login.js org switch <id>    — switch org
- *   node auth-login.js workspaces         — list workspaces
- *   node auth-login.js workspace <id>     — switch workspace
+ *   node auth-login.js workspaces             — list workspaces
+ *   node auth-login.js workspace list         — list workspaces (alias)
+ *   node auth-login.js workspace switch <id>  — switch workspace
  *   node auth-login.js invite <email> <mode> — invite member
  *   node auth-login.js members            — list members
  *   node auth-login.js whoami             — show current user/org
@@ -67,6 +68,20 @@ export async function runAuthCommand(args: string[]): Promise<void> {
         if (!match) { console.log(`Org not found: ${target}`); process.exit(1); }
         await switchOrg(match.id, match.name);
         console.log(`Switched to org: ${match.name}`);
+
+        // Carry-over guard: the previous workspaceId may not exist in the new
+        // org. If it doesn't, reset to "default" so subsequent commands don't
+        // silently target a non-existent workspace.
+        const prevWs = creds.workspaceId ?? "default";
+        const wsList = await listWorkspaces(creds.token, apiUrl, match.id);
+        const stillThere = wsList.some(w => w.id === prevWs || w.name.toLowerCase() === prevWs.toLowerCase());
+        if (!stillThere) {
+          await switchWorkspace("default");
+          console.log(`Workspace '${prevWs}' is not in org '${match.name}'. Reset workspace to 'default'.`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map(w => w.name || w.id).join(", ")}`);
+          }
+        }
       } else {
         console.log("Usage: org list | org switch <name-or-id>");
       }
@@ -82,11 +97,33 @@ export async function runAuthCommand(args: string[]): Promise<void> {
 
     case "workspace": {
       if (!creds) { console.log("Not logged in."); process.exit(1); }
-      const wsId = args[1];
-      if (!wsId) { console.log("Usage: workspace <id>"); process.exit(1); }
-      await switchWorkspace(wsId);
-      console.log(`Switched to workspace: ${wsId}`);
-      break;
+      const sub = args[1];
+
+      if (sub === "list") {
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        wsList.forEach(w => console.log(`${w.id}  ${w.name}`));
+        break;
+      }
+
+      if (sub === "switch") {
+        const target = args[2];
+        if (!target) { console.log("Usage: workspace switch <name-or-id>"); process.exit(1); }
+        const wsList = await listWorkspaces(creds.token, apiUrl, creds.orgId);
+        const match = wsList.find(w => w.id === target || w.name.toLowerCase() === target.toLowerCase());
+        if (!match) {
+          console.log(`Workspace not found: ${target}`);
+          if (wsList.length > 0) {
+            console.log(`Available workspaces: ${wsList.map(w => w.name || w.id).join(", ")}`);
+          }
+          process.exit(1);
+        }
+        await switchWorkspace(match.id);
+        console.log(`Switched to workspace: ${match.name || match.id}`);
+        break;
+      }
+
+      console.log("Usage: workspace list | workspace switch <name-or-id>");
+      process.exit(1);
     }
 
     case "invite": {


### PR DESCRIPTION
Closes #92.

## Summary

- `hivemind workspace <id>` no longer silently saves an unknown id. It now lists workspaces, validates id-or-name (case-insensitive), and exits 1 with the available list on miss — same UX as `hivemind org switch`.
- `hivemind org switch` now resets the active workspace to `default` (with a warning) when the previously-saved workspace doesn't exist in the new org. Previously the saved `workspaceId` carried over silently, leaving the user pointing at a workspace that didn't exist in their new org.
- The `workspace` command surface is restructured into `workspace list` and `workspace switch <name-or-id>`, mirroring `org list` / `org switch`. The bare-target shortcut (`workspace <id>`) is removed.

## Why

Two related bugs in the auth-login CLI dispatcher:

1. `switchWorkspace` accepted any string and persisted it to credentials with no existence check. e.g. `hivemind workspace k7` printed `Switched to workspace: k7` even when `k7` was not a real workspace in the current org.
2. `switchOrg` saved `{ orgId, orgName }` without touching `workspaceId`. After `hivemind org switch <new-org>`, you were still scoped to the previous workspace id — which often didn't exist in the new org, so subsequent commands ran against a phantom workspace.

Combined, a user who typed `hivemind org switch <other-org>` (forgetting to also fix the workspace) ended up silently misconfigured, and even an attempt to fix it with `hivemind workspace <id>` produced no feedback that the id was wrong.

## What changed

**`src/commands/auth-login.ts`**
- `org switch` handler: after the switch, calls `listWorkspaces(creds.token, apiUrl, <new-org-id>)` and, if the carried-over `workspaceId` isn't in the result, calls `switchWorkspace("default")` and prints a warning + the available list.
- `workspace` handler: split into two subcommands.
  - `workspace list` mirrors the existing top-level `workspaces` command.
  - `workspace switch <target>` does the validate-then-switch, exiting 1 with the available list on miss.
  - Anything else under `workspace` (including the previously-supported bare target) is rejected with usage.
- Docstring updated.

**`src/cli/index.ts`**
- `hivemind --help` now documents `workspace list` and `workspace switch <name-or-id>` instead of the bare `workspace <id>` form.

**`claude-code/tests/auth-login-dispatch.test.ts`**
- Existing `org switch` tests updated to mock the new `listWorkspaces` call.
- Added 10 cases covering:
  - `workspace switch <unknown>` exits 1 with the available list, never calls `switchWorkspace`.
  - `workspace switch <id>` and `workspace switch <name>` (case-insensitive) both resolve correctly.
  - `workspace switch` (no target) exits 1 without hitting the API.
  - `workspace list` is read-only — never calls `switchWorkspace`.
  - `workspace <target>` (the removed bare form) is rejected without API calls — explicit regression guard.
  - `org switch` resets the workspace to `default` when the carried-over id isn't in the new org's list.
  - `org switch` does NOT reset the workspace when the carried-over id (or name) IS still present in the new org.
  - `listWorkspaces` is called with the NEW org id, not the stale one from `creds`.

**Bundles** (`bundle/cli.js`, `claude-code/bundle/commands/auth-login.js`, `codex/bundle/commands/auth-login.js`, `cursor/bundle/commands/auth-login.js`, `hermes/bundle/commands/auth-login.js`)
- Rebuilt via `npm run build`. Second commit is a pure rebuild — no source edits.

## Test plan

- [x] `npx vitest run claude-code/tests/auth-login-dispatch.test.ts` → 42/42 pass
- [x] `npm run build` → all bundles rebuild cleanly
- [x] Local install + smoke tests (overlaid `bundle/cli.js` onto the global `@deeplake/hivemind` install):
  - `hivemind workspace list` → lists current org's workspaces
  - `hivemind workspace switch <real-name>` → switches successfully
  - `hivemind workspace switch <bogus>` → exits 1 with available list, no state mutation
  - `hivemind workspace switch` (no arg) → exits 1 with subcommand usage, no API call
  - `hivemind workspace <bare-name>` → exits 1 with the new usage line
  - `hivemind workspace` (no args) → exits 1 with the new usage line
  - `hivemind whoami` after each → confirms credentials state is consistent with the last successful switch
- [ ] Reviewer to verify in a multi-org account: `hivemind org switch <other-org>` from a workspace not present in the target org → resets to `default` with the warning message. (Needs an account with at least two orgs to repro; the unit tests cover the dispatcher logic deterministically.)

## Breaking change

`hivemind workspace <id>` (the bare-target shortcut) no longer switches; it now exits 1 with usage. Replace with `hivemind workspace switch <id>`. The plural `hivemind workspaces` command and the `/hivemind_switch_workspace` OpenClaw slash command are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `workspace list` and `workspace switch <name-or-id>` subcommands for improved workspace management.
  * Implemented automatic workspace validation during organization switches; resets to default if the workspace is unavailable in the new organization.

* **Documentation**
  * Updated CLI usage documentation to reflect new workspace management subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->