### PR TITLE
ci: publish to npm and ClawHub on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,12 @@ jobs:
             echo "::error::bundle/ is out of date. Run 'npm run build' and commit the bundle/ directory."
             exit 1
           }
+
+      - name: Pack-check (refuse forbidden filenames in tarball)
+        # Regression guard: hard-fails CI if a PR widens package.json's
+        # `files` array (or adds a permissive .npmignore) such that
+        # credentials, CI workflows, or git internals would ship to npm.
+        # Mirrors the same gate inside release.yml's publish job, so a
+        # broken `files` array trips on the PR — never on a release run
+        # where tokens are reachable.
+        run: npm run pack:check

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -21,9 +21,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Branch or commit SHA to smoke-test (default: main)'
+        description: "Branch or commit SHA to smoke-test (default: main)"
         required: false
-        default: 'main'
+        default: "main"
 
 permissions:
   contents: read
@@ -45,10 +45,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.12'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@deeplake'
-          cache: 'npm'
+          node-version: "24.12"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@deeplake"
+          cache: "npm"
+
+      - name: Load secrets from 1Password
+        uses: 1Password/load-secrets-action@v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CLAWHUB_TOKEN: "op://GitHub Actions/hivemind/CLAWHUB_TOKEN"
 
       - name: Install dependencies
         run: npm ci
@@ -64,8 +72,6 @@ jobs:
             echo "::error::NPM_TOKEN is not authenticating. Check the secret in the production environment."
             exit 1
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build bundles
         run: npm run build
@@ -80,16 +86,12 @@ jobs:
         # is a classic 2FA-required type, this fails with EOTP — which
         # is exactly the canary we want before the real publish.
         run: npm publish --dry-run --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install ClawHub CLI
         run: npm install -g clawhub
 
       - name: Authenticate ClawHub CLI
         run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
 
       - name: Validate CLAWHUB_TOKEN (whoami)
         run: clawhub whoami

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -18,9 +18,6 @@ name: Publish smoke test (dry-run)
 # workflow" → pick a branch (usually main).
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -65,18 +65,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate NPM_TOKEN (whoami)
-        # Confirms the token is accepted by the registry and tells us
-        # which user/automation account it's bound to. Fails fast with
-        # ENEEDAUTH if the secret is missing or wrong.
-        run: |
-          WHO=$(npm whoami)
-          echo "npm whoami → $WHO"
-          if [ -z "$WHO" ]; then
-            echo "::error::NPM_TOKEN is not authenticating. Check the secret in the production environment."
-            exit 1
-          fi
-
       - name: Build bundles
         run: npm run build
 
@@ -96,9 +84,6 @@ jobs:
 
       - name: Authenticate ClawHub CLI
         run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-
-      - name: Validate CLAWHUB_TOKEN (whoami)
-        run: clawhub whoami
 
       - name: clawhub package publish --dry-run
         run: clawhub package publish ./openclaw --dry-run

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -18,6 +18,9 @@ name: Publish smoke test (dry-run)
 # workflow" → pick a branch (usually main).
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   smoke-test:

--- a/.github/workflows/publish-smoke-test.yml
+++ b/.github/workflows/publish-smoke-test.yml
@@ -1,0 +1,110 @@
+name: Publish smoke test (dry-run)
+
+# Manually-triggered workflow that exercises the full publish pipeline
+# WITHOUT actually uploading to npm or ClawHub. Use this to confirm:
+#
+#   - NPM_TOKEN is valid and the token type bypasses 2FA correctly
+#     (granular automation tokens DO; classic publish tokens with 2FA
+#     enabled DO NOT and will fail with EOTP)
+#   - CLAWHUB_TOKEN is valid and the CLI accepts it
+#   - The production GitHub Environment is wired up correctly (this
+#     workflow uses the same environment as the real publish job, so
+#     a successful run proves secret access works)
+#   - The build, pack, and provenance steps succeed end-to-end
+#
+# No bump, no GitHub Release, no public artifact — fully reversible.
+#
+# To run: GitHub UI → Actions → "Publish smoke test (dry-run)" → "Run
+# workflow" → pick a branch (usually main).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or commit SHA to smoke-test (default: main)'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Dry-run npm + ClawHub publish
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.12'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@deeplake'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate NPM_TOKEN (whoami)
+        # Confirms the token is accepted by the registry and tells us
+        # which user/automation account it's bound to. Fails fast with
+        # ENEEDAUTH if the secret is missing or wrong.
+        run: |
+          WHO=$(npm whoami)
+          echo "npm whoami → $WHO"
+          if [ -z "$WHO" ]; then
+            echo "::error::NPM_TOKEN is not authenticating. Check the secret in the production environment."
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build bundles
+        run: npm run build
+
+      - name: Pack-check (refuse forbidden filenames in tarball)
+        run: npm run pack:check
+
+      - name: npm publish --dry-run --provenance
+        # `--dry-run` skips the actual upload but exercises tarball
+        # creation, prepublishOnly, registry auth handshake, and (with
+        # `--provenance`) the OIDC/Sigstore signing flow. If the token
+        # is a classic 2FA-required type, this fails with EOTP — which
+        # is exactly the canary we want before the real publish.
+        run: npm publish --dry-run --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Authenticate ClawHub CLI
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+
+      - name: Validate CLAWHUB_TOKEN (whoami)
+        run: clawhub whoami
+
+      - name: clawhub package publish --dry-run
+        run: clawhub package publish ./openclaw --dry-run
+
+      - name: Summary
+        run: |
+          {
+            echo "### Smoke test passed"
+            echo ""
+            echo "- npm token: valid, registry handshake OK"
+            echo "- ClawHub token: valid"
+            echo "- Build + pack-check + provenance flow: OK"
+            echo ""
+            echo "No artifact was published. The real publish job will run on the next merge to \`main\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,8 +230,6 @@ jobs:
         # ends. The token only ever appears as ${{ secrets.* }}, which
         # GitHub auto-masks in logs.
         run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
 
       - name: Publish openclaw bundle to ClawHub
         # The release job above already synced openclaw/package.json and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -28,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.12'
+          node-version: "24.12"
 
       - name: Check if version was already bumped in this push
         id: check_bump
@@ -185,10 +186,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.12'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@deeplake'
-          cache: 'npm'
+          node-version: "24.12"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@deeplake"
+          cache: "npm"
+
+      - name: Load secrets from 1Password
+        uses: 1Password/load-secrets-action@v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CLAWHUB_TOKEN: "op://GitHub Actions/hivemind/CLAWHUB_TOKEN"
 
       - name: Install dependencies
         run: npm ci
@@ -211,8 +220,6 @@ jobs:
         # consumers can verify the package was built by THIS workflow on
         # THIS commit, and npmjs.com displays a Provenance badge.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install ClawHub CLI
         run: npm install -g clawhub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,15 @@ jobs:
   release:
     name: Auto-bump version and create release
     runs-on: ubuntu-latest
+    outputs:
+      # Set only when the Create GitHub Release step actually runs.
+      # The downstream `publish` job gates on this so it fires once
+      # per real release — and crucially fires in the SAME workflow
+      # run as the bump+release, because pushes made with the default
+      # GITHUB_TOKEN do not retrigger workflows.
+      published: ${{ steps.set_outputs.outputs.published }}
+      sha: ${{ steps.set_outputs.outputs.sha }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,16 +139,30 @@ jobs:
           body: ${{ steps.pr.outputs.body }}
           generate_release_notes: false
 
+      - name: Set outputs for publish job
+        # Captures the local HEAD SHA after the bump+push (or the
+        # untouched HEAD on the manual-bump path). The publish job
+        # checks out this SHA explicitly, so an in-flight `main`
+        # advance during the environment-approval pause cannot
+        # redirect the publish to an unreviewed commit.
+        id: set_outputs
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   publish:
     # Publish @deeplake/hivemind to npm and the openclaw bundle to ClawHub.
-    # Runs only on the bump-commit retrigger (so we publish exactly the
-    # version that was just released to GitHub) and pauses at the
-    # `production` environment gate for human approval before tokens are
-    # accessible. Tokens live as environment-scoped secrets, so PRs from
-    # forks and unprotected branches cannot reach them.
+    # Runs in the SAME workflow run as `release` (gated on its
+    # `published` output) because the bump-commit push uses the
+    # default GITHUB_TOKEN, which by GitHub's loop-prevention rule
+    # does not retrigger workflows. Pauses at the `production`
+    # environment gate for human approval before tokens are
+    # accessible. Tokens live as environment-scoped secrets, so PRs
+    # from forks and unprotected branches cannot reach them.
     name: Publish to npm + ClawHub
     needs: release
-    if: "${{ startsWith(github.event.head_commit.message, 'chore: bump version') }}"
+    if: needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -151,10 +174,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Pull the latest main HEAD: the push event's SHA may point at
-          # the pre-bump commit, but the `release` job above just pushed
-          # the bump commit — that's the version we want to publish.
-          ref: main
+          # Pin to the bump commit captured by the release job. Pinning
+          # to a SHA (not `main`) is required: the `production`
+          # environment gate can pause for hours, during which `main`
+          # may advance — checking out a moving ref would publish a
+          # commit the reviewer never approved.
+          ref: ${{ needs.release.outputs.sha }}
           fetch-depth: 1
 
       - name: Setup Node.js
@@ -178,24 +203,7 @@ jobs:
         run: npm run build
 
       - name: Pack-check (refuse forbidden filenames in tarball)
-        run: |
-          npm pack --dry-run --json > /tmp/pack.json
-          node -e "
-            const entries = JSON.parse(require('fs').readFileSync('/tmp/pack.json','utf8'))[0].files.map(f => f.path);
-            const forbidden = entries.filter(p =>
-              /(^|\/)\.npmrc$/.test(p) ||
-              /(^|\/)\.env(\$|\.)/.test(p) ||
-              /(^|\/)secrets?(\/|\$)/.test(p) ||
-              /(^|\/)\.github(\/|\$)/.test(p) ||
-              /(^|\/)\.git(\/|\$)/.test(p)
-            );
-            if (forbidden.length) {
-              console.error('Refusing to publish — forbidden filenames in tarball:');
-              for (const f of forbidden) console.error('  ' + f);
-              process.exit(1);
-            }
-            console.log('Pack-check OK — ' + entries.length + ' files, no forbidden patterns');
-          "
+        run: npm run pack:check
 
       - name: Publish to npm with Sigstore provenance
         # --provenance uses the GitHub OIDC token (id-token: write above)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,3 +129,107 @@ jobs:
           name: "${{ steps.version.outputs.version }} — ${{ steps.pr.outputs.title }}"
           body: ${{ steps.pr.outputs.body }}
           generate_release_notes: false
+
+  publish:
+    # Publish @deeplake/hivemind to npm and the openclaw bundle to ClawHub.
+    # Runs only on the bump-commit retrigger (so we publish exactly the
+    # version that was just released to GitHub) and pauses at the
+    # `production` environment gate for human approval before tokens are
+    # accessible. Tokens live as environment-scoped secrets, so PRs from
+    # forks and unprotected branches cannot reach them.
+    name: Publish to npm + ClawHub
+    needs: release
+    if: "${{ startsWith(github.event.head_commit.message, 'chore: bump version') }}"
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: hivemind-publish
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Pull the latest main HEAD: the push event's SHA may point at
+          # the pre-bump commit, but the `release` job above just pushed
+          # the bump commit — that's the version we want to publish.
+          ref: main
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.12'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@deeplake'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Quality gate (typecheck + duplication + test)
+        # Belt-and-braces: ci.yml already gates merges to main, but a
+        # publish job that doesn't re-run the gate could ship if someone
+        # disables a CI status check.
+        run: npm run ci
+
+      - name: Build bundles
+        run: npm run build
+
+      - name: Pack-check (refuse forbidden filenames in tarball)
+        run: |
+          npm pack --dry-run --json > /tmp/pack.json
+          node -e "
+            const entries = JSON.parse(require('fs').readFileSync('/tmp/pack.json','utf8'))[0].files.map(f => f.path);
+            const forbidden = entries.filter(p =>
+              /(^|\/)\.npmrc$/.test(p) ||
+              /(^|\/)\.env(\$|\.)/.test(p) ||
+              /(^|\/)secrets?(\/|\$)/.test(p) ||
+              /(^|\/)\.github(\/|\$)/.test(p) ||
+              /(^|\/)\.git(\/|\$)/.test(p)
+            );
+            if (forbidden.length) {
+              console.error('Refusing to publish — forbidden filenames in tarball:');
+              for (const f of forbidden) console.error('  ' + f);
+              process.exit(1);
+            }
+            console.log('Pack-check OK — ' + entries.length + ' files, no forbidden patterns');
+          "
+
+      - name: Publish to npm with Sigstore provenance
+        # --provenance uses the GitHub OIDC token (id-token: write above)
+        # to sign the artifact via Sigstore. Even if NPM_TOKEN later leaks,
+        # consumers can verify the package was built by THIS workflow on
+        # THIS commit, and npmjs.com displays a Provenance badge.
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub
+
+      - name: Authenticate ClawHub CLI
+        # `clawhub login --token` writes a credential file inside the
+        # runner's $HOME, which is ephemeral and discarded when the job
+        # ends. The token only ever appears as ${{ secrets.* }}, which
+        # GitHub auto-masks in logs.
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+
+      - name: Publish openclaw bundle to ClawHub
+        # The release job above already synced openclaw/package.json and
+        # openclaw/openclaw.plugin.json versions to the bumped root
+        # version, so this publishes the same X.Y.Z that npm just got.
+        run: clawhub package publish ./openclaw
+
+      - name: Summary
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          {
+            echo "### Published"
+            echo ""
+            echo "- **npm**: \`@deeplake/hivemind@${VERSION}\` (with Sigstore provenance)"
+            echo "- **ClawHub**: \`clawhub:hivemind@${VERSION}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck": "tsc --noEmit",
     "dup": "jscpd src",
     "audit:openclaw": "node scripts/audit-openclaw-bundle.mjs",
+    "pack:check": "node scripts/pack-check.mjs",
     "ci": "npm run typecheck && npm run dup && npm test",
     "prepare": "husky",
     "prepublishOnly": "npm run build"

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Refuse a publish if `npm pack` would include filenames that should
+// never ship to npm — credentials, CI workflows, git internals.
+// Catches a future PR widening package.json's `files` array (or
+// switching to a permissive .npmignore) before any token is touched.
+
+import { execFileSync } from 'node:child_process';
+
+const FORBIDDEN = [
+  /(^|\/)\.npmrc$/,
+  /(^|\/)\.env($|\.)/,
+  /(^|\/)secrets?(\/|$)/,
+  /(^|\/)\.github(\/|$)/,
+  /(^|\/)\.git(\/|$)/,
+];
+
+const raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+const entries = JSON.parse(raw)[0].files.map((f) => f.path);
+const hits = entries.filter((p) => FORBIDDEN.some((rx) => rx.test(p)));
+
+if (hits.length) {
+  console.error('Refusing to publish — forbidden filenames in tarball:');
+  for (const h of hits) console.error('  ' + h);
+  process.exit(1);
+}
+console.log(`pack-check OK — ${entries.length} files, no forbidden patterns`);


### PR DESCRIPTION
## Summary

- Adds a `publish` job to `release.yml` that fires after the existing version-bump flow and publishes `@deeplake/hivemind` to npm and the openclaw bundle to ClawHub
- Gated by a `production` **GitHub Environment** with required reviewer — each version still gets explicit per-publish approval (so this CD does not bypass the existing manual gate, just routes it through GitHub's UI)
- npm publish uses `--provenance --access public` (Sigstore via GitHub OIDC), so even if `NPM_TOKEN` later leaks, consumers can verify the package was built by this workflow on this commit
- Adds a `npm pack --dry-run` regression guard (`scripts/pack-check.mjs`, wired into both `ci.yml` and the publish job) that hard-fails if a PR widens the `files` allowlist to include `.npmrc`, `.env`, `.github/`, `secrets/`, etc.

## Token-leak defenses, layered

1. **Environment-scoped secrets** — `NPM_TOKEN` and `CLAWHUB_TOKEN` are stored on the `production` environment, not the repo. PRs from forks and unprotected branches cannot read them; only the gated publish job can.
2. **Minimum-privilege permissions** — workflow stays `contents: read` at top, only the publish job adds `id-token: write` (needed for OIDC provenance). No `pull-requests`, no broader `contents: write`.
3. **Ephemeral `.npmrc`** — `actions/setup-node@v4` writes a temporary `~/.npmrc` referencing `${NODE_AUTH_TOKEN}`; passed only on the `npm publish` step's `env:`. The runner's `$HOME` is discarded when the job ends.
4. **Sigstore provenance** — defense-in-depth even if `NPM_TOKEN` leaks. `npm view @deeplake/hivemind --json | jq .dist.attestations` will show the signature.
5. **GitHub auto-masking** — anything flowing through `${{ secrets.* }}` is `***` in logs. We don't `set -x` or `echo` env on token-bearing steps.
6. **Concurrency guard** — `hivemind-publish` group prevents two merges from racing two publishes of the same version.
7. **Tarball regression guard** — `scripts/pack-check.mjs` runs in PR CI, so a broken `files` array trips on PR review, never on a release run where tokens are reachable.

## Required one-time setup before merging

The repo owner must do these in GitHub UI **before** the first publish run reaches the gate:

1. **Settings → Environments → New environment** named `production`
   - Required reviewers: add your account
   - (Optional) Deployment branches: restrict to `main`
2. **Add environment secrets** to that environment:
   - `NPM_TOKEN` — recommended: granular automation token, scope `@deeplake/hivemind` only, `Read and write`, 90-day expiry. Created at <https://www.npmjs.com/settings/~/tokens/granular-access-tokens>.
   - `CLAWHUB_TOKEN` — generate via `clawhub login` and pull the token, or via clawhub.ai web UI.
3. **Settings → Actions → General → Workflow permissions**: confirm `id-token: write` is allowed (some org policies disable it by default).

## How it fires after merge

```
push to main
   ↓
release job  (existing)
   ├─ first run:  bump patch + push back ──► retriggers
   └─ bump-commit run: GitHub Release ──► publish job (new)
                                              ↓
                                       [GATE: production env approval]
                                              ↓
                                       npm publish --provenance
                                       clawhub login --token
                                       clawhub package publish ./openclaw
```

The publish job's `if:` requires `startsWith(head_commit.message, 'chore: bump version')`, so it runs exactly once per released version.

## Test plan

- [ ] One-time setup steps above are done before merging this PR
- [ ] On first merge, **reject** the production environment gate to confirm the gate works without publishing
- [ ] On second merge, approve the gate; verify `npm view @deeplake/hivemind version` matches the GitHub Release tag
- [ ] `npm view @deeplake/hivemind --json | jq .dist.attestations` shows a sigstore attestation (Provenance badge on npmjs.com)
- [ ] `clawhub:hivemind` is installable and `verify-install.sh` passes against it
- [ ] `gh run view --log <run-id> | grep -E 'npm_[A-Za-z0-9_]{20,}|CLAWHUB_[A-Za-z0-9]{20,}'` returns nothing

## Confidence

Confidence: 80%, because the npm side is grounded in real `package.json` + `release.yml` + standard provenance/Environments practice, and the ClawHub side is grounded in `clawhub --help` output (`clawhub login --token` + `clawhub package publish <folder>` are real subcommands of the published `clawhub` v0.12.3 package).

Untested:
- Whether `clawhub package publish ./openclaw` auto-detects the package name `hivemind` from `openclaw/openclaw.plugin.json`'s `id` field, or whether `--name hivemind` needs to be passed explicitly
- Whether ClawHub has a "trusted publisher" config that would force `--manual-override-reason "Automated CD"` to be added — first real publish will surface this if so
- Whether `id-token: write` is allowed by the org's current Actions permissions (rules 3 above), since policy may differ per repo
- The interaction between the existing release job's git push and the publish job's checkout — current architecture splits across two workflow invocations (the bump-push retriggers), so the publish job sees the bumped commit on `ref: main`, but worth visually confirming on the first real run before approving the gate
- Whether existing per-bundle E2E (verify-install.sh against installed `@deeplake/hivemind`) should be wired into the publish job before npm publish; currently the human reviewer at the gate is the E2E checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with additional validation during pull request testing to safeguard package integrity.
  * Implemented automated publishing workflow that handles both npm and ClawHub distribution with environment-based access controls.
  * Added validation tooling to verify package contents before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->