### PR TITLE
fix(release): unblock publish job (build-before-test + repository field)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,14 +202,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build bundles
+        # Must run BEFORE the quality gate. `npm run ci` includes vitest,
+        # and the bundle-scan tests under
+        # claude-code/tests/skilify-session-start-injection.test.ts read
+        # openclaw/dist/index.js + openclaw/dist/skilify-worker.js
+        # directly. openclaw/dist/ is gitignored — it only exists after
+        # `npm run build`. Without this step before the gate, vitest
+        # fails with ENOENT and the publish aborts. Same root cause as
+        # 64cac0b in ci.yml; that fix never propagated to this job.
+        run: npm run build
+
       - name: Quality gate (typecheck + duplication + test)
         # Belt-and-braces: ci.yml already gates merges to main, but a
         # publish job that doesn't re-run the gate could ship if someone
         # disables a CI status check.
         run: npm run ci
-
-      - name: Build bundles
-        run: npm run build
 
       - name: Pack-check (refuse forbidden filenames in tarball)
         run: npm run pack:check

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.8",
   "description": "Cloud-backed persistent shared memory for AI agents powered by Deeplake",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeloopai/hivemind.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

The publish job in `release.yml` has been broken since it landed on main — every Release run that actually exercises it has failed. Two independent bugs were gating it; this PR fixes both.

| # | Bug | Failure mode | Fixed by |
|---|---|---|---|
| 1 | Build runs AFTER quality gate | `vitest` ENOENT on `openclaw/dist/index.js` | reorder steps in `release.yml` |
| 2 | `package.json` has no `repository` field | `npm publish --provenance` rejected with HTTP 422 (Sigstore can't verify source URL) | add `repository` to `package.json` |

Without both fixes, the publish flow can't ship a release end-to-end. Bug #1 is what's failing right now (run [25484806027](https://github.com/activeloopai/hivemind/actions/runs/25484806027) on `5a38c50`); bug #2 is what failed [run 25482668127](https://github.com/activeloopai/hivemind/actions/runs/25482668127) on `df5ced18` — the first run that actually got past the quality gate, before PR #98 landed.

## Bug #1 — build-before-test

Publish job step order was:

```yaml
1. npm ci                   # install deps
2. npm run ci               # typecheck + dup + test     ← TESTS RUN HERE
3. npm run build            # build bundles               ← BUILD RUNS AFTER
4. npm run pack:check
5. npm publish --provenance
```

Bundle-scan tests in `claude-code/tests/skilify-session-start-injection.test.ts` (added by PR #98) read `openclaw/dist/index.js` and `openclaw/dist/skilify-worker.js` directly. `openclaw/dist/` is gitignored — only exists after `npm run build`. Step 2 failed with ENOENT, publish aborted.

Same root cause as `64cac0b` (`ci: replace typecheck step with full build...`) which fixed it for `ci.yml`'s `Typecheck and Test` job. That fix never propagated to the publish job in `release.yml` (added later in `a436373`).

**Fix:** pure step reorder. Move `npm run build` before `npm run ci`.

## Bug #2 — provenance verification

`npm publish --provenance` requires `package.json.repository.url` to match the source URL claimed by the GitHub Actions OIDC token. `package.json` on main has no `repository` field at all, so npm rejects:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@deeplake%2fhivemind
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/activeloopai/hivemind" from provenance
```

Bug #1 was masking bug #2 once PR #98 landed (the gate failed before the provenance check could run). Before PR #98 landed, run #95 hit bug #2 directly.

**Fix:** add the standard npm repository shape:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/activeloopai/hivemind.git"
}
```

Format follows [npm's recommended shape](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) — `git+` prefix + `.git` suffix, both required for provenance to verify.

## Test plan

- [ ] CI passes on this PR (the publish job doesn't run on PRs — it's gated `on: push: branches: [main]` — so confidence here is by inspection: build is a strict superset of typecheck, and the repository field is mechanically required by npm)
- [ ] On merge: auto-bump triggers `release.yml`, the bump pushes a `chore: bump version` commit which retriggers Release, which runs the publish job. Build runs first → quality gate finds `openclaw/dist/` → vitest passes → build → pack-check → `npm publish` → provenance verifies (repository field now present) → ClawHub publish
- [ ] Look for `npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/...` followed by HTTP 201 (not 422)