### PR TITLE
fix(release): pin clawhub publish to --family code-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,16 @@ jobs:
         # The release job above already synced openclaw/package.json and
         # openclaw/openclaw.plugin.json versions to the bumped root
         # version, so this publishes the same X.Y.Z that npm just got.
-        run: clawhub package publish ./openclaw
+        #
+        # --family code-plugin: the existing `hivemind` package on ClawHub
+        # was originally registered with family=code-plugin (see
+        # `clawhub package inspect hivemind` → "Family: Code Plugin"). The
+        # CLI's auto-detection picks a different default (bundle-plugin) on
+        # this layout, and ClawHub's server rejects with
+        # `Package already exists as a code-plugin; family changes are not
+        # allowed` (convex/packages.ts:4305). Pinning the family explicitly
+        # matches what's already registered and lets the publish proceed.
+        run: clawhub package publish ./openclaw --family code-plugin
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Adds `--family code-plugin` to the `clawhub package publish` invocation in `release.yml`. **Was meant to land in PR #107 but the merge happened before this commit got included** — the family-fix commit (`5759109`) was pushed to that branch but the merge was finalized using an earlier tip. Re-opening it stand-alone here.

## Why

After PR #107 merged, the next Release run is going to hit this on the ClawHub publish step:

```
ConvexError: Package "hivemind" already exists as a code-plugin;
family changes are not allowed
    at handler (../convex/packages.ts:4305:8)
```

The existing `hivemind` package on ClawHub was originally registered with `family=code-plugin` (verified via `clawhub package inspect hivemind` → `Family: Code Plugin`). The clawhub CLI's auto-detection on this openclaw plugin layout picks a different default (bundle-plugin), so without an explicit `--family` flag it tries to publish as the wrong family and ClawHub refuses.

## Fix

One-line change in `.github/workflows/release.yml`:

```diff
-        run: clawhub package publish ./openclaw
+        run: clawhub package publish ./openclaw --family code-plugin
```

Plus a comment block explaining why.

## Verified locally

Test publish run from this machine using the @kaghni token (matches what 1Password now hands CI):

```
$ clawhub package publish /home/ubuntu/al-projects/hivemind/openclaw \
    --family code-plugin --name hivemind --version 0.0.1-test --tags test
- Preparing hivemind@0.0.1-test
✔ OK. Published hivemind@0.0.1-test (rd7d1frmgts4j1z9mpv9bqk4jd8697hg)
```

Without `--family code-plugin` the same auth/data hits `family changes are not allowed` every time. With it, publish succeeds. Latest tag on ClawHub stayed at 0.6.56 (test publish only set a `test` tag). Ownership/auth verified working under @kaghni.

## Test plan

- [ ] CI passes on this PR
- [ ] On merge: auto-bump fires (0.7.11 → 0.7.12), Release workflow runs, the publish job clears all upstream gates (build, npm publish), and the clawhub publish step now finds the right family and succeeds — ClawHub's `latest` tag bumps from 0.6.56 to 0.7.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package publishing configuration to resolve deployment issues during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->