### PR TITLE
openclaw: patch plugins.allow at install time + drop blocking auto-recall

### DIFF
--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4909,9 +4909,9 @@ if (process.argv[1] && process.argv[1].endsWith("auth-login.js")) {
 }
 
 // dist/src/commands/skillify.js
-import { readdirSync as readdirSync4, existsSync as existsSync21, readFileSync as readFileSync15, mkdirSync as mkdirSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { dirname as dirname4, join as join24 } from "node:path";
+import { readdirSync as readdirSync5, existsSync as existsSync25, readFileSync as readFileSync18, mkdirSync as mkdirSync10, renameSync as renameSync5 } from "node:fs";
+import { homedir as homedir18 } from "node:os";
+import { dirname as dirname6, join as join28 } from "node:path";
 
 // dist/src/skillify/scope-config.js
 import { existsSync as existsSync15, mkdirSync as mkdirSync4, readFileSync as readFileSync11, writeFileSync as writeFileSync8 } from "node:fs";
@@ -4995,6 +4995,35 @@ function assertValidSkillName(name) {
     throw new Error(`invalid skill name: must be kebab-case (lowercase a-z, 0-9, hyphen): ${name}`);
   }
 }
+function skillDir(skillsRoot, name) {
+  return join19(skillsRoot, name);
+}
+function skillPath(skillsRoot, name) {
+  return join19(skillDir(skillsRoot, name), "SKILL.md");
+}
+function renderFrontmatter(fm) {
+  const lines = ["---"];
+  lines.push(`name: ${fm.name}`);
+  lines.push(`description: ${JSON.stringify(fm.description)}`);
+  if (fm.trigger)
+    lines.push(`trigger: ${JSON.stringify(fm.trigger)}`);
+  if (fm.author)
+    lines.push(`author: ${fm.author}`);
+  lines.push(`source_sessions:`);
+  for (const s of fm.source_sessions)
+    lines.push(`  - ${s}`);
+  if (fm.contributors && fm.contributors.length > 0) {
+    lines.push(`contributors:`);
+    for (const c of fm.contributors)
+      lines.push(`  - ${c}`);
+  }
+  lines.push(`version: ${fm.version}`);
+  lines.push(`created_by_agent: ${fm.created_by_agent}`);
+  lines.push(`created_at: ${fm.created_at}`);
+  lines.push(`updated_at: ${fm.updated_at}`);
+  lines.push("---");
+  return lines.join("\n");
+}
 function parseFrontmatter(text) {
   if (!text.startsWith("---\n") && !text.startsWith("---\r\n"))
     return null;
@@ -5043,6 +5072,62 @@ function parseFrontmatter(text) {
     fm[k] = val;
   }
   return { fm, body };
+}
+function writeNewSkill(args) {
+  assertValidSkillName(args.name);
+  const dir = skillDir(args.skillsRoot, args.name);
+  const path = skillPath(args.skillsRoot, args.name);
+  if (existsSync16(path)) {
+    throw new Error(`skill already exists at ${path}; use mergeSkill`);
+  }
+  mkdirSync5(dir, { recursive: true });
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  const author = args.author && args.author.length > 0 ? args.author : void 0;
+  const contributors = author ? [author] : [];
+  const fm = {
+    name: args.name,
+    description: args.description,
+    trigger: args.trigger,
+    author,
+    source_sessions: args.sourceSessions,
+    contributors,
+    version: 1,
+    created_by_agent: args.agent,
+    created_at: now,
+    updated_at: now
+  };
+  const text = `${renderFrontmatter(fm)}
+
+${args.body.trim()}
+`;
+  writeFileSync9(path, text);
+  return {
+    path,
+    action: "created",
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    author,
+    contributors
+  };
+}
+function listSkills(skillsRoot) {
+  if (!existsSync16(skillsRoot))
+    return [];
+  const out = [];
+  for (const name of readdirSync2(skillsRoot)) {
+    const skillFile = join19(skillsRoot, name, "SKILL.md");
+    if (existsSync16(skillFile) && statSync2(skillFile).isFile()) {
+      out.push({ name, body: readFileSync12(skillFile, "utf-8") });
+    }
+  }
+  return out;
+}
+function resolveSkillsRoot(install, cwd) {
+  if (install === "global") {
+    return join19(homedir9(), ".claude", "skills");
+  }
+  return join19(cwd, ".claude", "skills");
 }
 
 // dist/src/skillify/manifest.js
@@ -5336,7 +5421,7 @@ function renderSkillFile(row) {
     updated_at: String(row.updated_at ?? (/* @__PURE__ */ new Date()).toISOString())
   };
   const body = String(row.body ?? "").trim();
-  return `${renderFrontmatter(fm)}
+  return `${renderFrontmatter2(fm)}
 
 ${body}
 `;
@@ -5367,7 +5452,7 @@ function parseContributors(v) {
   }
   return [];
 }
-function renderFrontmatter(fm) {
+function renderFrontmatter2(fm) {
   const lines = ["---"];
   lines.push(`name: ${fm.name}`);
   lines.push(`description: ${JSON.stringify(fm.description)}`);
@@ -5489,8 +5574,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join22(root, dirName);
-    const skillFile = join22(skillDir, "SKILL.md");
+    const skillDir2 = join22(root, dirName);
+    const skillFile = join22(skillDir2, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -5501,7 +5586,7 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync7(skillDir, { recursive: true });
+      mkdirSync7(skillDir2, { recursive: true });
       if (existsSync19(skillFile)) {
         try {
           renameSync4(skillFile, `${skillFile}.bak`);
@@ -5509,7 +5594,7 @@ async function runPull(opts) {
         }
       }
       writeFileSync11(skillFile, renderSkillFile(row));
-      const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
+      const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir2, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
           dirName,
@@ -5717,9 +5802,913 @@ function decideTargetForManifestEntry(entry, opts, userFilter, haveUserFilter) {
   return { shouldRemove: true };
 }
 
+// dist/src/commands/mine-local.js
+import { spawn } from "node:child_process";
+import { existsSync as existsSync24, mkdirSync as mkdirSync9, readFileSync as readFileSync17, writeFileSync as writeFileSync13 } from "node:fs";
+import { homedir as homedir17 } from "node:os";
+import { basename, dirname as dirname5, join as join27 } from "node:path";
+
+// dist/src/skillify/local-source.js
+import { readdirSync as readdirSync4, readFileSync as readFileSync15, existsSync as existsSync21, statSync as statSync4 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { join as join24 } from "node:path";
+var HOME2 = homedir14();
+function encodeCwdClaudeCode(cwd) {
+  return cwd.replace(/[/_]/g, "-");
+}
+function detectInstalledAgents() {
+  const installs = [];
+  const claudeRoot = join24(HOME2, ".claude", "projects");
+  if (existsSync21(claudeRoot)) {
+    installs.push({
+      agent: "claude_code",
+      sessionRoot: claudeRoot,
+      encodeCwd: encodeCwdClaudeCode
+    });
+  }
+  const codexRoot = join24(HOME2, ".codex", "sessions");
+  if (existsSync21(codexRoot)) {
+    installs.push({
+      agent: "codex",
+      sessionRoot: codexRoot,
+      encodeCwd: () => "__cwd_unknown__"
+    });
+  }
+  return installs;
+}
+function detectHostAgent() {
+  if (process.env.CLAUDECODE === "1" || process.env.CLAUDE_CODE_ENTRYPOINT)
+    return "claude_code";
+  if (process.env.CODEX_HOME || process.env.CODEX_SESSION_ID)
+    return "codex";
+  return null;
+}
+function listLocalSessions(installs, cwd) {
+  const out = [];
+  for (const install of installs) {
+    const cwdEncoded = install.encodeCwd(cwd);
+    let subdirs = [];
+    try {
+      subdirs = readdirSync4(install.sessionRoot);
+    } catch {
+      continue;
+    }
+    for (const sub of subdirs) {
+      const subdirPath = join24(install.sessionRoot, sub);
+      try {
+        if (!statSync4(subdirPath).isDirectory())
+          continue;
+      } catch {
+        continue;
+      }
+      const inCwd = sub === cwdEncoded;
+      let files = [];
+      try {
+        files = readdirSync4(subdirPath);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        if (!f.endsWith(".jsonl"))
+          continue;
+        const fullPath = join24(subdirPath, f);
+        let stats;
+        try {
+          stats = statSync4(fullPath);
+        } catch {
+          continue;
+        }
+        if (!stats.isFile())
+          continue;
+        const sessionId = f.replace(/\.jsonl$/, "");
+        out.push({
+          agent: install.agent,
+          path: fullPath,
+          mtime: stats.mtimeMs,
+          inCwd,
+          sessionId
+        });
+      }
+    }
+  }
+  return out;
+}
+function pickSessions(candidates, opts) {
+  const { n, epsilon } = opts;
+  if (n <= 0 || candidates.length === 0)
+    return [];
+  const sorted = [...candidates].sort((a, b) => b.mtime - a.mtime);
+  const cwdQuota = Math.ceil((1 - epsilon) * n);
+  const globalQuota = Math.floor(epsilon * n);
+  const picked = [];
+  const taken = /* @__PURE__ */ new Set();
+  for (const s of sorted) {
+    if (picked.length >= cwdQuota)
+      break;
+    if (s.inCwd && !taken.has(s.path)) {
+      picked.push(s);
+      taken.add(s.path);
+    }
+  }
+  const cap2 = picked.length + globalQuota;
+  for (const s of sorted) {
+    if (picked.length >= cap2)
+      break;
+    if (!taken.has(s.path)) {
+      picked.push(s);
+      taken.add(s.path);
+    }
+  }
+  for (const s of sorted) {
+    if (picked.length >= n)
+      break;
+    if (!taken.has(s.path)) {
+      picked.push(s);
+      taken.add(s.path);
+    }
+  }
+  return picked;
+}
+function nativeJsonlToRows(filePath, sessionId, agent) {
+  let raw;
+  try {
+    raw = readFileSync15(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+  const rows = [];
+  let pendingAsstText;
+  let pendingAsstTs;
+  const flushAssistant = () => {
+    if (pendingAsstText && pendingAsstText.trim().length > 0) {
+      rows.push({
+        type: "assistant_message",
+        content: pendingAsstText,
+        creation_date: pendingAsstTs,
+        session_id: sessionId,
+        agent
+      });
+    }
+    pendingAsstText = void 0;
+    pendingAsstTs = void 0;
+  };
+  for (const line of raw.split(/\n/)) {
+    if (!line)
+      continue;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const t = obj?.type;
+    const ts = obj?.timestamp ?? obj?.created_at;
+    if (t === "user") {
+      const c = obj?.message?.content;
+      if (typeof c === "string" && c.trim().length > 0) {
+        flushAssistant();
+        rows.push({
+          type: "user_message",
+          content: c,
+          creation_date: ts,
+          session_id: sessionId,
+          agent
+        });
+      }
+    } else if (t === "assistant") {
+      const c = obj?.message?.content;
+      if (Array.isArray(c)) {
+        const text = c.filter((b) => b?.type === "text" && typeof b.text === "string").map((b) => b.text).join("\n\n");
+        if (text.trim().length > 0) {
+          pendingAsstText = text;
+          pendingAsstTs = ts;
+        }
+      }
+    }
+  }
+  flushAssistant();
+  return rows;
+}
+
+// dist/src/skillify/extractors/index.js
+function extractPairs(rows) {
+  const pairs2 = [];
+  let pendingPrompt = null;
+  let pendingAnswer = [];
+  function flush() {
+    if (pendingPrompt && pendingAnswer.length > 0) {
+      pairs2.push({
+        sessionId: pendingPrompt.row.session_id ?? "",
+        agent: pendingPrompt.row.agent ?? null,
+        date: pendingPrompt.row.creation_date ?? null,
+        prompt: pendingPrompt.content,
+        answer: pendingAnswer.join("\n\n")
+      });
+    }
+    pendingPrompt = null;
+    pendingAnswer = [];
+  }
+  for (const r of rows) {
+    if (r.type === "user_message" && typeof r.content === "string") {
+      flush();
+      pendingPrompt = { content: r.content, row: r };
+    } else if (r.type === "assistant_message" && typeof r.content === "string" && pendingPrompt) {
+      if (r.content.trim().length > 0)
+        pendingAnswer.push(r.content);
+    }
+  }
+  flush();
+  return pairs2;
+}
+
+// dist/src/skillify/gate-runner.js
+import { execFileSync as execFileSync4 } from "node:child_process";
+import { existsSync as existsSync22 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { join as join25 } from "node:path";
+function findAgentBin(agent) {
+  const which = (name) => {
+    try {
+      const out = execFileSync4("which", [name], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"]
+      });
+      return out.trim() || null;
+    } catch {
+      return null;
+    }
+  };
+  switch (agent) {
+    case "claude_code":
+      return which("claude") ?? join25(homedir15(), ".claude", "local", "claude");
+    case "codex":
+      return which("codex") ?? "/usr/local/bin/codex";
+    case "cursor":
+      return which("cursor-agent") ?? "/usr/local/bin/cursor-agent";
+    case "hermes":
+      return which("hermes") ?? join25(homedir15(), ".local", "bin", "hermes");
+    case "pi":
+      return which("pi") ?? join25(homedir15(), ".local", "bin", "pi");
+  }
+}
+
+// dist/src/skillify/gate-parser.js
+function extractJsonBlock(s) {
+  const trimmed = s.trim();
+  if (!trimmed)
+    return null;
+  const fenced = trimmed.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
+  if (fenced)
+    return fenced[1].trim();
+  const start = trimmed.indexOf("{");
+  if (start < 0)
+    return null;
+  let depth = 0;
+  for (let i = start; i < trimmed.length; i++) {
+    const c = trimmed[i];
+    if (c === "{")
+      depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0)
+        return trimmed.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+// dist/src/skillify/local-manifest.js
+import { existsSync as existsSync23, mkdirSync as mkdirSync8, readFileSync as readFileSync16, writeFileSync as writeFileSync12 } from "node:fs";
+import { homedir as homedir16 } from "node:os";
+import { dirname as dirname4, join as join26 } from "node:path";
+var LOCAL_MANIFEST_PATH = join26(homedir16(), ".claude", "hivemind", "local-mined.json");
+var LOCAL_MINE_LOCK_PATH = join26(homedir16(), ".claude", "hivemind", "local-mined.lock");
+function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
+  if (!existsSync23(path))
+    return null;
+  try {
+    return JSON.parse(readFileSync16(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+function writeLocalManifest(m, path = LOCAL_MANIFEST_PATH) {
+  mkdirSync8(dirname4(path), { recursive: true });
+  writeFileSync12(path, JSON.stringify(m, null, 2));
+}
+
+// dist/src/commands/mine-local.js
+import { unlinkSync as unlinkSync9 } from "node:fs";
+var EPSILON = 0.3;
+var DEFAULT_N = 8;
+var PAIR_CHAR_CAP = 4e3;
+var PER_SESSION_PAIR_CAP = 30;
+var PER_SESSION_PROMPT_CAP = 12e4;
+var GATE_CONCURRENCY = 4;
+var IN_FLIGHT_MAX_AGE_MS = 6e4;
+var GATE_TIMEOUT_MS = 24e4;
+var MANIFEST_PATH = LOCAL_MANIFEST_PATH;
+function runGateViaStdin(opts) {
+  return new Promise((resolve) => {
+    if (opts.agent !== "claude_code") {
+      resolve({
+        stdout: "",
+        stderr: "",
+        errored: true,
+        errorMessage: `stdin gate runner only supports claude_code (got ${opts.agent}); for other agents the prompt must fit in argv`
+      });
+      return;
+    }
+    if (!existsSync24(opts.bin)) {
+      resolve({
+        stdout: "",
+        stderr: "",
+        errored: true,
+        errorMessage: `agent binary not found at ${opts.bin}`
+      });
+      return;
+    }
+    const args = [
+      "-p",
+      "--no-session-persistence",
+      "--model",
+      "haiku",
+      "--permission-mode",
+      "bypassPermissions"
+    ];
+    const child = spawn(opts.bin, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" }
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (r) => {
+      if (settled)
+        return;
+      settled = true;
+      resolve(r);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+      finish({
+        stdout,
+        stderr,
+        errored: true,
+        errorMessage: `gate timed out after ${opts.timeoutMs}ms`
+      });
+    }, opts.timeoutMs);
+    child.stdout.on("data", (b) => {
+      stdout += b.toString("utf-8");
+    });
+    child.stderr.on("data", (b) => {
+      stderr += b.toString("utf-8");
+    });
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      finish({ stdout, stderr, errored: true, errorMessage: e.message });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      finish({
+        stdout,
+        stderr,
+        errored: code !== 0,
+        errorMessage: code !== 0 ? `claude_code CLI exited with code ${code}` : void 0
+      });
+    });
+    child.stdin.on("error", (e) => {
+      clearTimeout(timer);
+      finish({ stdout, stderr, errored: true, errorMessage: `stdin write failed: ${e.message}` });
+    });
+    child.stdin.end(opts.prompt);
+  });
+}
+var loadManifest2 = readLocalManifest;
+var saveManifest2 = writeLocalManifest;
+function truncate(s, max) {
+  if (s.length <= max)
+    return s;
+  return s.slice(0, max) + `
+[\u2026truncated ${s.length - max} chars]`;
+}
+function renderPairsBlock(pairs2) {
+  let total = 0;
+  const out = [];
+  for (const [i, p] of pairs2.entries()) {
+    const block = `--- exchange ${i + 1} ---
+USER:
+${truncate(p.prompt, PAIR_CHAR_CAP)}
+
+ASSISTANT:
+${truncate(p.answer, PAIR_CHAR_CAP)}
+`;
+    if (total + block.length > PER_SESSION_PROMPT_CAP) {
+      out.push(`[\u2026${pairs2.length - i} more exchanges omitted to stay under budget]`);
+      break;
+    }
+    out.push(block);
+    total += block.length;
+  }
+  return out.join("\n");
+}
+function buildSessionPrompt(pairs2, session, verdictPath) {
+  return [
+    `You are a skill curator examining ONE session of recent agent activity.`,
+    `Your job: identify up to 3 distinct, non-overlapping reusable skills hiding in this session.`,
+    `Distinct = different problem domains. Empty list is fine if nothing qualifies.`,
+    ``,
+    `Session: ${session.sessionId} (agent: ${session.agent})`,
+    ``,
+    `RULES:`,
+    `- A skill qualifies if it captures a concrete, repeatable workflow OR a non-obvious`,
+    `  constraint/gotcha a future engineer would benefit from knowing. Intra-session is fine \u2014`,
+    `  one deep dive yielding a generalizable takeaway counts.`,
+    `- Skip patterns that are obvious from reading the codebase or already in CLAUDE.md.`,
+    `- Each body uses short sections (When to use, Workflow, Anti-patterns), concrete commands`,
+    `  / paths / snippets drawn from the exchanges below, no marketing, no emojis.`,
+    `- Each body under ~3000 characters.`,
+    `- Skill names are kebab-case slugs (lowercase letters/digits/hyphens only).`,
+    ``,
+    `=== EXCHANGES (user prompts + assistant final answers, tool calls stripped) ===`,
+    renderPairsBlock(pairs2),
+    ``,
+    `=== YOUR TASK ===`,
+    `Output a single JSON object. You may either:`,
+    `  (a) Write the JSON to this exact path using the Write tool: ${verdictPath}`,
+    `  (b) Print the JSON object to stdout as your final message, nothing else.`,
+    `Pick whichever you prefer. Do not do both.`,
+    ``,
+    `Required shape:`,
+    `{`,
+    `  "reason": "<one-line justification>",`,
+    `  "skills": [`,
+    `    {`,
+    `      "name": "<kebab-case>",`,
+    `      "description": "<one-line>",`,
+    `      "trigger": "<short trigger>",`,
+    `      "body": "<full SKILL.md body without frontmatter>"`,
+    `    },`,
+    `    ... up to 3 entries, or [] if nothing qualifies`,
+    `  ]`,
+    `}`,
+    ``,
+    `If you print to stdout, do not include any prose before or after the JSON.`
+  ].join("\n");
+}
+function parseMultiVerdict(raw) {
+  const block = extractJsonBlock(raw);
+  if (!block)
+    return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(block);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object")
+    return null;
+  const skills = parsed.skills;
+  if (!Array.isArray(skills))
+    return null;
+  const out = [];
+  for (const s of skills) {
+    if (!s || typeof s !== "object")
+      continue;
+    const name = typeof s.name === "string" ? s.name.trim() : "";
+    const description = typeof s.description === "string" ? s.description.trim() : "";
+    const body = typeof s.body === "string" ? s.body.trim() : "";
+    const trigger = typeof s.trigger === "string" ? s.trigger.trim() : void 0;
+    if (!name || !body)
+      continue;
+    out.push({ name, description, body, trigger });
+  }
+  return { reason: typeof parsed.reason === "string" ? parsed.reason : void 0, skills: out };
+}
+function gateAgentFor(host, fallback, installs) {
+  const installed = new Set(installs.map((i) => i.agent));
+  if (installed.has("claude_code"))
+    return "claude_code";
+  return host ?? fallback;
+}
+async function parallelMap(items, concurrency, fn) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const workers = [];
+  for (let w = 0; w < Math.min(concurrency, items.length); w++) {
+    workers.push((async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length)
+          return;
+        results[i] = await fn(items[i], i);
+      }
+    })());
+  }
+  await Promise.all(workers);
+  return results;
+}
+var SUMMARY_STOPWORDS = /* @__PURE__ */ new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "into",
+  "via",
+  "this",
+  "that",
+  "your",
+  "you",
+  "are",
+  "was",
+  "were",
+  "use",
+  "using",
+  "uses",
+  "used",
+  "skill",
+  "when",
+  "what",
+  "where",
+  "which",
+  "while",
+  "how",
+  "non",
+  "any",
+  "all",
+  "code",
+  "file",
+  "files",
+  "way",
+  "ways",
+  "via"
+]);
+function summaryTokens(s) {
+  return new Set(s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 3 && !SUMMARY_STOPWORDS.has(t)));
+}
+function jaccard(a, b) {
+  if (a.size === 0 || b.size === 0)
+    return 0;
+  let intersection = 0;
+  for (const t of a)
+    if (b.has(t))
+      intersection++;
+  return intersection / (a.size + b.size - intersection);
+}
+var OVERLAP_THRESHOLD = 0.4;
+function findOverlap(candidateDesc, others) {
+  const ct = summaryTokens(candidateDesc);
+  let best = null;
+  for (const e of others) {
+    const score = jaccard(ct, summaryTokens(e.desc));
+    if (score >= OVERLAP_THRESHOLD && (!best || score > best.score)) {
+      best = { name: e.name, score };
+    }
+  }
+  return best;
+}
+function loadExistingSummaries(skillsRoot) {
+  const out = [];
+  for (const s of listSkills(skillsRoot)) {
+    const parsed = parseFrontmatter(s.body);
+    const desc = parsed?.fm.description ?? "";
+    if (desc)
+      out.push({ name: s.name, desc });
+  }
+  return out;
+}
+function takeFlagValue(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx < 0)
+    return null;
+  const v = args[idx + 1];
+  if (v === void 0 || v.startsWith("--")) {
+    console.error(`${flag} requires a value`);
+    process.exit(1);
+  }
+  args.splice(idx, 2);
+  return v;
+}
+function takeBoolFlag(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx < 0)
+    return false;
+  args.splice(idx, 1);
+  return true;
+}
+async function runMineLocal(args) {
+  let lockReleased = false;
+  const releaseLock = () => {
+    if (lockReleased)
+      return;
+    lockReleased = true;
+    try {
+      unlinkSync9(LOCAL_MINE_LOCK_PATH);
+    } catch {
+    }
+  };
+  process.on("exit", releaseLock);
+  try {
+    return await runMineLocalImpl(args);
+  } finally {
+    releaseLock();
+  }
+}
+async function runMineLocalImpl(args) {
+  const work = [...args];
+  const force = takeBoolFlag(work, "--force");
+  const dryRun = takeBoolFlag(work, "--dry-run");
+  const nRaw = takeFlagValue(work, "--n");
+  if (loadManifest2() && !force) {
+    console.error(`Local skills have already been mined on this machine.`);
+    console.error(`Manifest: ${MANIFEST_PATH}`);
+    console.error(`Pass --force to re-mine.`);
+    process.exit(1);
+  }
+  const installs = detectInstalledAgents();
+  if (installs.length === 0) {
+    console.error(`No agent session directories detected. Run a session first.`);
+    process.exit(1);
+  }
+  console.log(`Detected installed agents: ${installs.map((i) => i.agent).join(", ")}`);
+  const host = detectHostAgent();
+  const fallback = installs[0].agent;
+  const gateAgent = gateAgentFor(host, fallback, installs);
+  if (gateAgent !== "claude_code") {
+    console.error(`mine-local v1 requires the Claude Code CLI as its LLM gate.`);
+    console.error(`Detected gate agent: ${gateAgent} (no claude_code session dir found at ~/.claude/projects/).`);
+    console.error(`Install Claude Code, or run a Claude Code session once, then re-run.`);
+    process.exit(1);
+  }
+  const gateBin = findAgentBin(gateAgent);
+  console.log(`Gate CLI: ${gateAgent} (${gateBin})${host ? " \u2014 host-agent detected" : ""}`);
+  const cwd = process.cwd();
+  const rawSessions = listLocalSessions(installs, cwd);
+  const now = Date.now();
+  const allSessions = rawSessions.filter((s) => now - s.mtime >= IN_FLIGHT_MAX_AGE_MS);
+  const dropped = rawSessions.length - allSessions.length;
+  const cwdCount = allSessions.filter((s) => s.inCwd).length;
+  console.log(`Found ${allSessions.length} local session(s) (${cwdCount} in cwd${dropped > 0 ? `, ${dropped} in-flight skipped` : ""})`);
+  if (allSessions.length === 0) {
+    console.error(`No mineable session files (all were modified within the last ${IN_FLIGHT_MAX_AGE_MS / 1e3}s).`);
+    process.exit(1);
+  }
+  const n = nRaw === "all" ? allSessions.length : nRaw ? Math.max(1, parseInt(nRaw, 10) || DEFAULT_N) : DEFAULT_N;
+  const picked = pickSessions(allSessions, { n, epsilon: EPSILON });
+  console.log(`Picking ${picked.length} session(s) (\u03B5=${EPSILON}, N=${n}): ${picked.map((s) => s.sessionId.slice(0, 8)).join(", ")}`);
+  if (dryRun) {
+    console.log(`Dry-run: would invoke ${gateAgent} gate on ${picked.length} session(s) in parallel (concurrency=${GATE_CONCURRENCY}).`);
+    return;
+  }
+  const tmpDir = join27(homedir17(), ".claude", "hivemind", `mine-local-${Date.now()}`);
+  mkdirSync9(tmpDir, { recursive: true });
+  console.log(`Running ${picked.length} gate call(s) in parallel (concurrency=${GATE_CONCURRENCY}, timeout=${GATE_TIMEOUT_MS / 1e3}s each)...`);
+  const results = await parallelMap(picked, GATE_CONCURRENCY, async (s) => {
+    const shortId = s.sessionId.slice(0, 8);
+    const rows = nativeJsonlToRows(s.path, s.sessionId, s.agent);
+    const pairs2 = extractPairs(rows);
+    if (pairs2.length === 0) {
+      console.log(`  [${shortId}] no usable pairs \u2014 skipped`);
+      return { session: s, skills: [], reason: "no pairs", error: null };
+    }
+    const tail = pairs2.slice(-PER_SESSION_PAIR_CAP);
+    const sessionTmp = join27(tmpDir, `s-${shortId}`);
+    mkdirSync9(sessionTmp, { recursive: true });
+    const verdictPath = join27(sessionTmp, "verdict.json");
+    const prompt = buildSessionPrompt(tail, s, verdictPath);
+    writeFileSync13(join27(sessionTmp, "prompt.txt"), prompt);
+    const gate = await runGateViaStdin({ agent: gateAgent, bin: gateBin, prompt, timeoutMs: GATE_TIMEOUT_MS });
+    try {
+      writeFileSync13(join27(sessionTmp, "gate-stdout.txt"), gate.stdout);
+      if (gate.stderr)
+        writeFileSync13(join27(sessionTmp, "gate-stderr.txt"), gate.stderr);
+    } catch {
+    }
+    if (gate.errored) {
+      console.log(`  [${shortId}] gate failed: ${gate.errorMessage}`);
+      return { session: s, skills: [], reason: null, error: gate.errorMessage ?? "gate failed" };
+    }
+    const verdictText = existsSync24(verdictPath) ? readFileSync17(verdictPath, "utf-8") : gate.stdout;
+    const mv = parseMultiVerdict(verdictText);
+    if (!mv) {
+      console.log(`  [${shortId}] unparseable verdict (kept at ${sessionTmp})`);
+      return { session: s, skills: [], reason: null, error: "unparseable verdict" };
+    }
+    console.log(`  [${shortId}] ${mv.skills.length} skill candidate(s) \u2014 ${mv.reason ?? "no reason given"}`);
+    return { session: s, skills: mv.skills, reason: mv.reason ?? null, error: null };
+  });
+  const skillsRoot = resolveSkillsRoot("global", cwd);
+  const totalCandidates = results.reduce((sum, r) => sum + r.skills.length, 0);
+  const existingSummaries = loadExistingSummaries(skillsRoot);
+  console.log("");
+  console.log(`Got ${totalCandidates} candidate(s) across ${picked.length} session(s). Checking overlap against ${existingSummaries.length} installed skill(s) + each new write.`);
+  if (totalCandidates === 0) {
+    const existing = loadManifest2();
+    saveManifest2({
+      created_at: existing?.created_at ?? (/* @__PURE__ */ new Date()).toISOString(),
+      entries: existing?.entries ?? []
+    });
+    console.log(`No skills to write.`);
+    console.log(`tmp dir kept for inspection: ${tmpDir}`);
+    return;
+  }
+  const flat = [];
+  for (const r of results) {
+    for (const sk of r.skills)
+      flat.push({ skill: sk, session: r.session });
+  }
+  flat.sort((a, b) => b.session.mtime - a.session.mtime);
+  const fanOutRoots = detectAgentSkillsRoots(skillsRoot);
+  if (fanOutRoots.length > 0) {
+    console.log(`Fan-out targets: ${fanOutRoots.join(", ")}`);
+  }
+  const written = [];
+  const knownSummaries = [...existingSummaries];
+  for (const { skill, session } of flat) {
+    const overlap = findOverlap(skill.description, knownSummaries);
+    if (overlap) {
+      console.log(`  skipped ${skill.name} \u2190 session ${session.sessionId.slice(0, 8)} (description overlaps "${overlap.name}", Jaccard=${overlap.score.toFixed(2)})`);
+      continue;
+    }
+    try {
+      const result = writeNewSkill({
+        skillsRoot,
+        name: skill.name,
+        description: skill.description,
+        trigger: skill.trigger,
+        body: skill.body,
+        sourceSessions: [session.sessionId],
+        agent: gateAgent
+      });
+      const canonicalDir = dirname5(result.path);
+      const symlinks = fanOutRoots.length > 0 ? fanOutSymlinks(canonicalDir, basename(canonicalDir), fanOutRoots) : [];
+      const symlinkSuffix = symlinks.length > 0 ? `, fan-out \u2192 ${symlinks.length} root(s)` : "";
+      console.log(`  wrote ${skill.name} \u2190 session ${session.sessionId.slice(0, 8)} (${session.agent}${symlinkSuffix})`);
+      written.push({ skill, session, result, symlinks });
+      knownSummaries.push({ name: skill.name, desc: skill.description });
+    } catch (e) {
+      if (/already exists/i.test(e.message ?? "")) {
+        console.log(`  skipped ${skill.name} (file already exists at ${skillsRoot})`);
+      } else {
+        console.log(`  failed ${skill.name}: ${e.message}`);
+      }
+    }
+  }
+  if (written.length > 0) {
+    const existing = loadManifest2();
+    const newEntries = written.map(({ skill, session, result, symlinks }) => ({
+      skill_name: skill.name,
+      canonical_path: result.path,
+      symlinks,
+      source_session_ids: [session.sessionId],
+      source_session_paths: [session.path],
+      source_agent: session.agent,
+      gate_agent: gateAgent,
+      created_at: result.createdAt,
+      uploaded: false
+    }));
+    saveManifest2({
+      created_at: existing?.created_at ?? (/* @__PURE__ */ new Date()).toISOString(),
+      entries: [...existing?.entries ?? [], ...newEntries]
+    });
+  }
+  console.log("");
+  console.log(`Mined ${written.length} skill(s) from ${picked.length} session(s) (${results.filter((r) => r.skills.length > 0).length} session(s) contributed candidate(s)).`);
+  console.log(`Installed to ${skillsRoot}/ \u2014 local-only, not shared.`);
+  console.log(`Sign in with 'hivemind login' to share with your team later.`);
+}
+
+// dist/src/cli/skillify-spec.js
+var SKILLIFY_SPEC = [
+  {
+    cmd: "hivemind skillify",
+    desc: "show scope, team, install, per-project state"
+  },
+  {
+    cmd: "hivemind skillify pull",
+    desc: "sync project skills from the org table to local FS",
+    options: [
+      { flag: "--user <email>", desc: "only skills authored by that user" },
+      { flag: "--users <a,b,c>", desc: "only skills from those authors" },
+      { flag: "--all-users", desc: 'explicit "no author filter" (default)' },
+      { flag: "--to <project|global>", desc: "install location (project=cwd/.claude/skills, global=~/.claude/skills)" },
+      { flag: "--dry-run", desc: "preview without touching disk" },
+      { flag: "--force", desc: "overwrite local files even if up-to-date (creates .bak)" },
+      { flag: "<skill-name>", desc: "pull only that one skill (combines with --user)" }
+    ],
+    note: "every agent's SessionStart hook auto-runs 'pull --all-users --to global' on every session. File writes are idempotent (skipped when local is at-or-newer than remote). Disable via HIVEMIND_AUTOPULL_DISABLED=1."
+  },
+  {
+    cmd: "hivemind skillify unpull",
+    desc: "remove every skill previously installed by pull",
+    options: [
+      { flag: "--user <email>", desc: "remove only that author's pulls" },
+      { flag: "--not-mine", desc: "remove all pulls except your own" },
+      { flag: "--dry-run", desc: "preview without touching disk" }
+    ]
+  },
+  {
+    cmd: "hivemind skillify scope",
+    args: "<me|team|org>",
+    desc: "sharing scope for newly mined skills"
+  },
+  {
+    cmd: "hivemind skillify install",
+    args: "<project|global>",
+    desc: "default install location for new skills"
+  },
+  {
+    cmd: "hivemind skillify promote",
+    args: "<skill-name>",
+    desc: "move a project skill to the global location"
+  },
+  {
+    cmd: "hivemind skillify team add|remove|list",
+    args: "<name>",
+    desc: "manage team member list"
+  },
+  {
+    cmd: "hivemind skillify mine-local",
+    desc: "one-shot: mine skills from local sessions (no auth needed)",
+    options: [
+      { flag: "--n <num|all>", desc: "how many sessions to mine (default: 8)" },
+      { flag: "--force", desc: "re-run even if the manifest sentinel exists" },
+      { flag: "--dry-run", desc: "stop before calling the LLM gate" }
+    ]
+  }
+];
+function renderCliHelpBlock() {
+  const INDENT = "  ";
+  const CMD_COL_WIDTH = 42;
+  const lines = [];
+  for (const sub of SKILLIFY_SPEC) {
+    const left = sub.args ? `${sub.cmd} ${sub.args}` : sub.cmd;
+    const padded = left.length >= CMD_COL_WIDTH ? `${left}  ` : left.padEnd(CMD_COL_WIDTH);
+    lines.push(`${INDENT}${padded}${capitalize(sub.desc)}.`);
+    if (sub.options && sub.options.length > 0) {
+      const optsList = sub.options.map((o) => o.flag).join(", ");
+      lines.push(`${INDENT}${" ".repeat(CMD_COL_WIDTH)}Options: ${optsList}.`);
+    }
+    if (sub.note) {
+      const noteWrapped = wrapAt(`Note: ${sub.note}`, 72);
+      for (const noteLine of noteWrapped) {
+        lines.push(`${INDENT}${" ".repeat(CMD_COL_WIDTH)}${noteLine}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+function renderSubcommandUsageBlock() {
+  const INDENT = "  ";
+  const SUB_INDENT = "    ";
+  const FLAG_INDENT = "      ";
+  const CMD_COL_WIDTH = 44;
+  const FLAG_COL_WIDTH = 26;
+  const lines = [];
+  for (const sub of SKILLIFY_SPEC) {
+    const left = sub.args ? `${sub.cmd} ${sub.args}` : sub.cmd;
+    const padded = left.length >= CMD_COL_WIDTH ? `${left}  ` : left.padEnd(CMD_COL_WIDTH);
+    lines.push(`${INDENT}${padded}${sub.desc}`);
+    if (sub.options && sub.options.length > 0) {
+      const tail = sub.cmd.split(" ").slice(-1)[0];
+      lines.push(`${SUB_INDENT}Options for ${tail}:`);
+      for (const opt of sub.options) {
+        const flagPadded = opt.flag.length >= FLAG_COL_WIDTH ? `${opt.flag}  ` : opt.flag.padEnd(FLAG_COL_WIDTH);
+        lines.push(`${FLAG_INDENT}${flagPadded}${opt.desc}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+function capitalize(s) {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+function wrapAt(s, max) {
+  const words = s.split(/\s+/);
+  const out = [];
+  let cur = "";
+  for (const w of words) {
+    if (cur.length === 0) {
+      cur = w;
+    } else if (cur.length + 1 + w.length > max) {
+      out.push(cur);
+      cur = w;
+    } else {
+      cur += " " + w;
+    }
+  }
+  if (cur)
+    out.push(cur);
+  return out;
+}
+
 // dist/src/commands/skillify.js
 function stateDir() {
-  return join24(homedir14(), ".deeplake", "state", "skillify");
+  return join28(homedir18(), ".deeplake", "state", "skillify");
 }
 function showStatus() {
   const cfg = loadScopeConfig();
@@ -5727,11 +6716,11 @@ function showStatus() {
   console.log(`team:    ${cfg.team.length === 0 ? "(empty)" : cfg.team.join(", ")}`);
   console.log(`install: ${cfg.install}  (${cfg.install === "global" ? "~/.claude/skills/" : "<project>/.claude/skills/"})`);
   const dir = stateDir();
-  if (!existsSync21(dir)) {
+  if (!existsSync25(dir)) {
     console.log(`state: (no projects tracked yet)`);
     return;
   }
-  const files = readdirSync4(dir).filter((f) => f.endsWith(".json") && f !== "config.json" && f !== "pulled.json" && f !== "autopull-last-run.json");
+  const files = readdirSync5(dir).filter((f) => f.endsWith(".json") && f !== "config.json" && f !== "pulled.json" && f !== "autopull-last-run.json");
   if (files.length === 0) {
     console.log(`state: (no projects tracked yet)`);
     return;
@@ -5739,7 +6728,7 @@ function showStatus() {
   console.log(`state: ${files.length} project(s) tracked`);
   for (const f of files) {
     try {
-      const s = JSON.parse(readFileSync15(join24(dir, f), "utf-8"));
+      const s = JSON.parse(readFileSync18(join28(dir, f), "utf-8"));
       const last = typeof s.updatedAt === "number" ? new Date(s.updatedAt).toISOString() : s.lastDate ?? "never";
       const skills = Array.isArray(s.skillsGenerated) && s.skillsGenerated.length > 0 ? s.skillsGenerated.join(", ") : "none";
       console.log(`  - ${s.project} (counter=${s.counter}, last=${last}, skills=${skills})`);
@@ -5766,7 +6755,7 @@ function setInstall(loc) {
   }
   const cfg = loadScopeConfig();
   saveScopeConfig({ ...cfg, install: loc });
-  const path = loc === "global" ? join24(homedir14(), ".claude", "skills") : "<cwd>/.claude/skills";
+  const path = loc === "global" ? join28(homedir18(), ".claude", "skills") : "<cwd>/.claude/skills";
   console.log(`Install location set to '${loc}'. New skills will be written to ${path}/<name>/SKILL.md.`);
 }
 function promoteSkill(name, cwd) {
@@ -5774,17 +6763,17 @@ function promoteSkill(name, cwd) {
     console.error("Usage: hivemind skillify promote <skill-name>");
     process.exit(1);
   }
-  const projectPath = join24(cwd, ".claude", "skills", name);
-  const globalPath = join24(homedir14(), ".claude", "skills", name);
-  if (!existsSync21(join24(projectPath, "SKILL.md"))) {
+  const projectPath = join28(cwd, ".claude", "skills", name);
+  const globalPath = join28(homedir18(), ".claude", "skills", name);
+  if (!existsSync25(join28(projectPath, "SKILL.md"))) {
     console.error(`Skill '${name}' not found at ${projectPath}/SKILL.md`);
     process.exit(1);
   }
-  if (existsSync21(join24(globalPath, "SKILL.md"))) {
+  if (existsSync25(join28(globalPath, "SKILL.md"))) {
     console.error(`Skill '${name}' already exists at ${globalPath}/SKILL.md \u2014 refusing to overwrite. Remove it first or rename the project skill.`);
     process.exit(1);
   }
-  mkdirSync8(dirname4(globalPath), { recursive: true });
+  mkdirSync10(dirname6(globalPath), { recursive: true });
   renameSync5(projectPath, globalPath);
   console.log(`Promoted '${name}' from ${projectPath} \u2192 ${globalPath}.`);
 }
@@ -5827,33 +6816,9 @@ function teamList() {
 }
 function usage() {
   console.log("Usage:");
-  console.log("  hivemind skillify                            show current scope, team, install, and per-project state");
-  console.log("  hivemind skillify scope <me|team>            set the mining scope");
-  console.log("  hivemind skillify install <project|global>   set where new skills are written");
-  console.log("  hivemind skillify promote <skill-name>       move a project skill to the global location");
-  console.log("  hivemind skillify team add <username>        add a username to the team list");
-  console.log("  hivemind skillify team remove <username>     remove a username from the team list");
-  console.log("  hivemind skillify team list                  list current team members");
-  console.log("  hivemind skillify pull [skill-name] [opts]   fetch skills from Deeplake to local FS");
-  console.log("    Options for pull:");
-  console.log("      --to <project|global>     destination (default: global)");
-  console.log("      --user <name>             only skills authored by this user");
-  console.log("      --users <a,b,c>           only skills authored by these users");
-  console.log("      --all-users               all authors (default \u2014 equivalent to no filter)");
-  console.log("      --dry-run                 show what would be written, don't touch disk");
-  console.log("      --force                   overwrite even when local version >= remote");
-  console.log("  hivemind skillify unpull [opts]              remove skills previously installed by pull");
-  console.log("    Options for unpull:");
-  console.log("      --to <project|global>     where to scan (default: global)");
-  console.log("      --user <name>             only entries authored by this user");
-  console.log("      --users <a,b,c>           only entries authored by these users");
-  console.log("      --not-mine                remove all pulled entries except your own");
-  console.log("      --dry-run                 show what would be removed");
-  console.log("      --all                     also remove flat-layout (locally-mined) entries");
-  console.log("      --legacy-cleanup          also remove pre-`--author`-layout legacy `<projectKey>/` dirs");
-  console.log("  hivemind skillify status                     show per-project state");
+  console.log(renderSubcommandUsageBlock());
 }
-function takeFlagValue(args, flag) {
+function takeFlagValue2(args, flag) {
   const idx = args.indexOf(flag);
   if (idx < 0)
     return null;
@@ -5874,9 +6839,9 @@ function takeBooleanFlag(args, flag) {
 }
 async function pullSkills(args) {
   const work = [...args];
-  const toRaw = takeFlagValue(work, "--to") ?? "global";
-  const userOne = takeFlagValue(work, "--user");
-  const usersMany = takeFlagValue(work, "--users");
+  const toRaw = takeFlagValue2(work, "--to") ?? "global";
+  const userOne = takeFlagValue2(work, "--user");
+  const usersMany = takeFlagValue2(work, "--users");
   const allUsers = takeBooleanFlag(work, "--all-users");
   const dryRun = takeBooleanFlag(work, "--dry-run");
   const force = takeBooleanFlag(work, "--force");
@@ -5915,7 +6880,7 @@ async function pullSkills(args) {
     console.error(`pull failed: ${e?.message ?? e}`);
     process.exit(1);
   }
-  const dest = toRaw === "global" ? join24(homedir14(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join28(homedir18(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterDesc = users.length === 0 ? "all users" : users.join(", ");
   console.log(`Destination: ${dest}`);
   console.log(`Filter:      ${filterDesc}${skillName ? ` \xB7 skill='${skillName}'` : ""}${dryRun ? " \xB7 dry-run" : ""}${force ? " \xB7 force" : ""}`);
@@ -5932,9 +6897,9 @@ async function pullSkills(args) {
 }
 async function unpullSkills(args) {
   const work = [...args];
-  const toRaw = takeFlagValue(work, "--to") ?? "global";
-  const userOne = takeFlagValue(work, "--user");
-  const usersMany = takeFlagValue(work, "--users");
+  const toRaw = takeFlagValue2(work, "--to") ?? "global";
+  const userOne = takeFlagValue2(work, "--user");
+  const usersMany = takeFlagValue2(work, "--users");
   const notMine = takeBooleanFlag(work, "--not-mine");
   const dryRun = takeBooleanFlag(work, "--dry-run");
   const all = takeBooleanFlag(work, "--all");
@@ -5965,7 +6930,7 @@ async function unpullSkills(args) {
     all,
     legacyCleanup
   });
-  const dest = toRaw === "global" ? join24(homedir14(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join28(homedir18(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterParts = [];
   if (users.length > 0)
     filterParts.push(`users=${users.join(",")}`);
@@ -6040,6 +7005,13 @@ function runSkillifyCommand(args) {
     console.error("Usage: hivemind skillify team <add|remove|list> [name]");
     process.exit(1);
   }
+  if (sub === "mine-local") {
+    runMineLocal(args.slice(1)).catch((e) => {
+      console.error(`mine-local error: ${e?.message ?? e}`);
+      process.exit(1);
+    });
+    return;
+  }
   if (sub === "--help" || sub === "-h" || sub === "help") {
     usage();
     return;
@@ -6053,14 +7025,14 @@ if (process.argv[1] && process.argv[1].endsWith("skillify.js")) {
 }
 
 // dist/src/cli/update.js
-import { execFileSync as execFileSync4 } from "node:child_process";
-import { existsSync as existsSync22, readFileSync as readFileSync17, realpathSync } from "node:fs";
-import { dirname as dirname6, sep } from "node:path";
+import { execFileSync as execFileSync5 } from "node:child_process";
+import { existsSync as existsSync26, readFileSync as readFileSync20, realpathSync } from "node:fs";
+import { dirname as dirname8, sep } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync16 } from "node:fs";
-import { dirname as dirname5, join as join25 } from "node:path";
+import { readFileSync as readFileSync19 } from "node:fs";
+import { dirname as dirname7, join as join29 } from "node:path";
 function isNewer(latest, current) {
   const parse = (v) => v.split(".").map(Number);
   const [la, lb, lc] = parse(latest);
@@ -6079,24 +7051,24 @@ function detectInstallKind(argv1) {
       return argv1 ?? process.argv[1] ?? fileURLToPath2(import.meta.url);
     }
   })();
-  let dir = dirname6(realArgv1);
+  let dir = dirname8(realArgv1);
   let installDir = null;
   for (let i = 0; i < 10; i++) {
     const pkgPath = `${dir}${sep}package.json`;
     try {
-      const pkg = JSON.parse(readFileSync17(pkgPath, "utf-8"));
+      const pkg = JSON.parse(readFileSync20(pkgPath, "utf-8"));
       if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
         installDir = dir;
         break;
       }
     } catch {
     }
-    const parent = dirname6(dir);
+    const parent = dirname8(dir);
     if (parent === dir)
       break;
     dir = parent;
   }
-  installDir ??= dirname6(realArgv1);
+  installDir ??= dirname8(realArgv1);
   if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
     return { kind: "npx", installDir };
   }
@@ -6105,10 +7077,10 @@ function detectInstallKind(argv1) {
   }
   let gitDir = installDir;
   for (let i = 0; i < 6; i++) {
-    if (existsSync22(`${gitDir}${sep}.git`)) {
+    if (existsSync26(`${gitDir}${sep}.git`)) {
       return { kind: "local-dev", installDir };
     }
-    const parent = dirname6(gitDir);
+    const parent = dirname8(gitDir);
     if (parent === gitDir)
       break;
     gitDir = parent;
@@ -6127,7 +7099,7 @@ async function getLatestNpmVersion(timeoutMs = 5e3) {
   }
 }
 var defaultSpawn = (cmd, args) => {
-  execFileSync4(cmd, args, { stdio: "inherit" });
+  execFileSync5(cmd, args, { stdio: "inherit" });
 };
 async function runUpdate(opts = {}) {
   const current = opts.currentVersionOverride ?? getVersion();
@@ -6143,7 +7115,7 @@ async function runUpdate(opts = {}) {
   }
   log(`Update available: ${current} \u2192 ${latest}`);
   const detected = opts.installKindOverride ?? detectInstallKind();
-  const spawn = opts.spawn ?? defaultSpawn;
+  const spawn2 = opts.spawn ?? defaultSpawn;
   switch (detected.kind) {
     case "npm-global": {
       if (opts.dryRun) {
@@ -6153,7 +7125,7 @@ async function runUpdate(opts = {}) {
       }
       log(`Upgrading via npm\u2026`);
       try {
-        spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
+        spawn2("npm", ["install", "-g", `${PKG_NAME}@latest`]);
       } catch (e) {
         warn(`npm install failed: ${e.message}`);
         warn(`Try running it manually: npm install -g ${PKG_NAME}@latest`);
@@ -6162,7 +7134,7 @@ async function runUpdate(opts = {}) {
       log(``);
       log(`Refreshing agent bundles\u2026`);
       try {
-        spawn("hivemind", ["install", "--skip-auth"]);
+        spawn2("hivemind", ["install", "--skip-auth"]);
       } catch (e) {
         warn(`Agent refresh failed: ${e.message}`);
         warn(`Run manually: hivemind install`);
@@ -6262,28 +7234,7 @@ Semantic search (embeddings):
   to run "embeddings install" automatically after installing the agent(s).
 
 Skill management (mine + share reusable Claude skills across the org):
-  hivemind skillify                         Show scope, team, install, and per-project state.
-  hivemind skillify pull [skill-name]       Sync skills from the org table to local FS.
-                                           Options: --user <email>, --users a,b,c,
-                                           --all-users, --to <project|global>,
-                                           --dry-run, --force.
-                                           Note: every agent's SessionStart hook
-                                           auto-runs 'pull --all-users --to global'
-                                           on every session. File writes are
-                                           idempotent (skipped when local is
-                                           at-or-newer than remote). Disable via
-                                           HIVEMIND_AUTOPULL_DISABLED=1.
-  hivemind skillify unpull                  Remove skills previously installed by pull.
-                                           Options: --user, --users, --not-mine,
-                                           --to <project|global>, --dry-run,
-                                           --all (also locally-mined),
-                                           --legacy-cleanup (pre-suffix-author dirs).
-  hivemind skillify scope <me|team>         Set the sharing scope for newly mined skills.
-  hivemind skillify install <project|global>  Set where new skills are written.
-  hivemind skillify promote <name>          Move a project skill to the global location.
-  hivemind skillify team add <username>     Add a username to the team list.
-  hivemind skillify team remove <username>  Remove a username from the team list.
-  hivemind skillify team list               List current team members.
+${renderCliHelpBlock()}
 
 Account / org / workspace:
   hivemind whoami                          Show current user, org, workspace.

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync12, mkdirSync as mkdirSync3, readFileSync as readFileSync9, writeFileSync as writeFileSync6 } from "node:fs";
-import { join as join15 } from "node:path";
+import { existsSync as existsSync13, mkdirSync as mkdirSync3, readFileSync as readFileSync10, writeFileSync as writeFileSync7 } from "node:fs";
+import { join as join16 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join15(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join16(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join15(getIndexMarkerDir(), `${markerKey}.json`);
+  return join16(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
-  if (!existsSync12(markerPath))
+  if (!existsSync13(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync9(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync10(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -42,7 +42,7 @@ function hasFreshIndexMarker(markerPath) {
 }
 function writeIndexMarker(markerPath) {
   mkdirSync3(getIndexMarkerDir(), { recursive: true });
-  writeFileSync6(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  writeFileSync7(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,6 +54,9 @@ var init_index_marker_store = __esm({
 
 // dist/src/cli/install-claude.js
 import { execFileSync } from "node:child_process";
+import { existsSync as existsSync2, readFileSync as readFileSync2, writeFileSync as writeFileSync2 } from "node:fs";
+import { homedir as homedir2 } from "node:os";
+import { join as join2 } from "node:path";
 
 // dist/src/cli/util.js
 import { existsSync, mkdirSync, readFileSync, writeFileSync, cpSync, symlinkSync, unlinkSync, lstatSync } from "node:fs";
@@ -178,6 +181,75 @@ function pluginAlreadyInstalled() {
   return r.stdout.includes(PLUGIN_KEY);
 }
 var PLUGIN_SCOPES = ["user", "project", "local", "managed"];
+function settingsJsonPath() {
+  return join2(homedir2(), ".claude", "settings.json");
+}
+var LEGACY_PATH_FRAGMENT = ".claude/plugins/hivemind/bundle/";
+function isBrokenHivemindHookEntry(h) {
+  if (typeof h.command !== "string")
+    return false;
+  const normalized = h.command.replace(/\\/g, "/");
+  if (!normalized.includes(LEGACY_PATH_FRAGMENT))
+    return false;
+  const match = normalized.match(/"([^"]+\.claude\/plugins\/hivemind\/bundle\/[^"]+)"/);
+  const filePath = match ? match[1] : null;
+  if (!filePath)
+    return false;
+  return !existsSync2(filePath);
+}
+function cleanupBrokenSettingsHooks() {
+  const settingsPath = settingsJsonPath();
+  if (!existsSync2(settingsPath))
+    return { removed: 0, events: [] };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync2(settingsPath, "utf-8"));
+  } catch {
+    return { removed: 0, events: [] };
+  }
+  if (!parsed || typeof parsed !== "object")
+    return { removed: 0, events: [] };
+  const settings = parsed;
+  if (!settings.hooks || typeof settings.hooks !== "object")
+    return { removed: 0, events: [] };
+  let removed = 0;
+  const touchedEvents = [];
+  for (const [event, matchers] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(matchers))
+      continue;
+    const cleanedMatchers = [];
+    let eventTouched = false;
+    for (const m of matchers) {
+      if (!m || !Array.isArray(m.hooks)) {
+        cleanedMatchers.push(m);
+        continue;
+      }
+      const keptHooks = m.hooks.filter((h) => {
+        const broken = isBrokenHivemindHookEntry(h);
+        if (broken) {
+          removed += 1;
+          eventTouched = true;
+        }
+        return !broken;
+      });
+      if (keptHooks.length > 0) {
+        cleanedMatchers.push({ ...m, hooks: keptHooks });
+      } else if (m.hooks.length > 0) {
+        eventTouched = true;
+      } else {
+        cleanedMatchers.push(m);
+      }
+    }
+    if (eventTouched) {
+      settings.hooks[event] = cleanedMatchers;
+      touchedEvents.push(event);
+    }
+  }
+  if (removed > 0) {
+    writeFileSync2(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+  }
+  return { removed, events: touchedEvents };
+}
 function installClaude() {
   requireClaudeCli();
   if (!marketplaceAlreadyAdded()) {
@@ -200,6 +272,14 @@ function installClaude() {
     log(`  Claude Code    refreshed via marketplace ${MARKETPLACE_SOURCE}`);
   }
   runClaude(["plugin", "enable", PLUGIN_KEY]);
+  try {
+    const cleanup = cleanupBrokenSettingsHooks();
+    if (cleanup.removed > 0) {
+      log(`  Claude Code    settings.json cleaned: removed ${cleanup.removed} stale hook entr${cleanup.removed === 1 ? "y" : "ies"} (events: ${cleanup.events.join(", ")})`);
+    }
+  } catch (e) {
+    log(`  Claude Code    settings.json cleanup skipped: ${e?.message ?? String(e)}`);
+  }
 }
 function uninstallClaude() {
   try {
@@ -214,16 +294,16 @@ function uninstallClaude() {
 }
 
 // dist/src/cli/install-codex.js
-import { existsSync as existsSync2, readFileSync as readFileSync3, unlinkSync as unlinkSync2 } from "node:fs";
+import { existsSync as existsSync3, readFileSync as readFileSync4, unlinkSync as unlinkSync2 } from "node:fs";
 import { execFileSync as execFileSync2 } from "node:child_process";
-import { join as join3 } from "node:path";
+import { join as join4 } from "node:path";
 
 // dist/src/cli/version.js
-import { readFileSync as readFileSync2 } from "node:fs";
-import { join as join2 } from "node:path";
+import { readFileSync as readFileSync3 } from "node:fs";
+import { join as join3 } from "node:path";
 function getVersion() {
   try {
-    const pkg = JSON.parse(readFileSync2(join2(pkgRoot(), "package.json"), "utf-8"));
+    const pkg = JSON.parse(readFileSync3(join3(pkgRoot(), "package.json"), "utf-8"));
     return pkg.version ?? "0.0.0";
   } catch {
     return "0.0.0";
@@ -231,16 +311,16 @@ function getVersion() {
 }
 
 // dist/src/cli/install-codex.js
-var CODEX_HOME = join3(HOME, ".codex");
-var PLUGIN_DIR = join3(CODEX_HOME, "hivemind");
-var HOOKS_PATH = join3(CODEX_HOME, "hooks.json");
-var AGENTS_SKILLS_DIR = join3(HOME, ".agents", "skills");
-var SKILL_LINK = join3(AGENTS_SKILLS_DIR, "hivemind-memory");
+var CODEX_HOME = join4(HOME, ".codex");
+var PLUGIN_DIR = join4(CODEX_HOME, "hivemind");
+var HOOKS_PATH = join4(CODEX_HOME, "hooks.json");
+var AGENTS_SKILLS_DIR = join4(HOME, ".agents", "skills");
+var SKILL_LINK = join4(AGENTS_SKILLS_DIR, "hivemind-memory");
 function hookCmd(bundleFile, timeout, matcher) {
   const block = {
     hooks: [{
       type: "command",
-      command: `node "${join3(PLUGIN_DIR, "bundle", bundleFile)}"`,
+      command: `node "${join4(PLUGIN_DIR, "bundle", bundleFile)}"`,
       timeout
     }]
   };
@@ -314,8 +394,8 @@ function mergeHooks(existing, ours, pluginDir = PLUGIN_DIR) {
 function mergeHooksJson(ours) {
   let existing = {};
   try {
-    if (existsSync2(HOOKS_PATH)) {
-      const parsed = JSON.parse(readFileSync3(HOOKS_PATH, "utf-8"));
+    if (existsSync3(HOOKS_PATH)) {
+      const parsed = JSON.parse(readFileSync4(HOOKS_PATH, "utf-8"));
       if (parsed && typeof parsed === "object")
         existing = parsed;
     }
@@ -354,20 +434,20 @@ function tryEnableCodexHooks() {
   }
 }
 function installCodex() {
-  const srcBundle = join3(pkgRoot(), "codex", "bundle");
-  const srcSkills = join3(pkgRoot(), "codex", "skills");
-  if (!existsSync2(srcBundle)) {
+  const srcBundle = join4(pkgRoot(), "codex", "bundle");
+  const srcSkills = join4(pkgRoot(), "codex", "skills");
+  if (!existsSync3(srcBundle)) {
     throw new Error(`Codex bundle missing at ${srcBundle}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR);
-  copyDir(srcBundle, join3(PLUGIN_DIR, "bundle"));
-  if (existsSync2(srcSkills))
-    copyDir(srcSkills, join3(PLUGIN_DIR, "skills"));
+  copyDir(srcBundle, join4(PLUGIN_DIR, "bundle"));
+  if (existsSync3(srcSkills))
+    copyDir(srcSkills, join4(PLUGIN_DIR, "skills"));
   tryEnableCodexHooks();
   writeJson(HOOKS_PATH, mergeHooksJson(buildHooksJson()));
   ensureDir(AGENTS_SKILLS_DIR);
-  const skillTarget = join3(PLUGIN_DIR, "skills", "deeplake-memory");
-  if (existsSync2(skillTarget)) {
+  const skillTarget = join4(PLUGIN_DIR, "skills", "deeplake-memory");
+  if (existsSync3(skillTarget)) {
     symlinkForce(skillTarget, SKILL_LINK);
   } else {
     warn(`  Codex          skill source missing at ${skillTarget}; skipping symlink`);
@@ -376,10 +456,10 @@ function installCodex() {
   log(`  Codex          installed -> ${PLUGIN_DIR}`);
 }
 function uninstallCodex() {
-  if (existsSync2(HOOKS_PATH)) {
+  if (existsSync3(HOOKS_PATH)) {
     let existing = {};
     try {
-      const raw = JSON.parse(readFileSync3(HOOKS_PATH, "utf-8"));
+      const raw = JSON.parse(readFileSync4(HOOKS_PATH, "utf-8"));
       if (raw && typeof raw === "object")
         existing = raw;
     } catch {
@@ -400,7 +480,7 @@ function uninstallCodex() {
       }
     }
   }
-  if (existsSync2(SKILL_LINK)) {
+  if (existsSync3(SKILL_LINK)) {
     unlinkSync2(SKILL_LINK);
     log(`  Codex          removed ${SKILL_LINK}`);
   }
@@ -408,16 +488,16 @@ function uninstallCodex() {
 }
 
 // dist/src/cli/install-openclaw.js
-import { existsSync as existsSync4, copyFileSync, rmSync } from "node:fs";
-import { join as join5 } from "node:path";
+import { existsSync as existsSync5, copyFileSync, rmSync } from "node:fs";
+import { join as join6 } from "node:path";
 
 // dist/openclaw/src/setup-config.js
-import { existsSync as existsSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync2, renameSync } from "node:fs";
-import { homedir as homedir2 } from "node:os";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync4, readFileSync as readFileSync5, writeFileSync as writeFileSync3, renameSync } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join5 } from "node:path";
 var HIVEMIND_TOOL_NAMES = ["hivemind_search", "hivemind_read", "hivemind_index"];
 function getOpenclawConfigPath() {
-  return join4(homedir2(), ".openclaw", "openclaw.json");
+  return join5(homedir3(), ".openclaw", "openclaw.json");
 }
 function isAllowlistCoveringHivemind(alsoAllow) {
   if (!Array.isArray(alsoAllow))
@@ -440,12 +520,12 @@ function isPluginsAllowMissingHivemind(allow) {
 }
 function ensureHivemindAllowlisted() {
   const configPath = getOpenclawConfigPath();
-  if (!existsSync3(configPath)) {
+  if (!existsSync4(configPath)) {
     return { status: "error", configPath, error: "openclaw config file not found" };
   }
   let parsed;
   try {
-    const raw = readFileSync4(configPath, "utf-8");
+    const raw = readFileSync5(configPath, "utf-8");
     parsed = JSON.parse(raw);
   } catch (e) {
     return { status: "error", configPath, error: `could not read/parse config: ${e instanceof Error ? e.message : String(e)}` };
@@ -476,8 +556,8 @@ function ensureHivemindAllowlisted() {
   const backupPath = `${configPath}.bak-hivemind-${Date.now()}`;
   const tmpPath = `${configPath}.tmp-hivemind-${process.pid}`;
   try {
-    writeFileSync2(backupPath, readFileSync4(configPath, "utf-8"));
-    writeFileSync2(tmpPath, JSON.stringify(updated, null, 2) + "\n");
+    writeFileSync3(backupPath, readFileSync5(configPath, "utf-8"));
+    writeFileSync3(tmpPath, JSON.stringify(updated, null, 2) + "\n");
     renameSync(tmpPath, configPath);
   } catch (e) {
     return { status: "error", configPath, error: `could not write config: ${e instanceof Error ? e.message : String(e)}` };
@@ -494,23 +574,23 @@ function ensureHivemindAllowlisted() {
 }
 
 // dist/src/cli/install-openclaw.js
-var PLUGIN_DIR2 = join5(HOME, ".openclaw", "extensions", "hivemind");
+var PLUGIN_DIR2 = join6(HOME, ".openclaw", "extensions", "hivemind");
 function installOpenclaw() {
-  const srcDist = join5(pkgRoot(), "openclaw", "dist");
-  const srcManifest = join5(pkgRoot(), "openclaw", "openclaw.plugin.json");
-  const srcPkg = join5(pkgRoot(), "openclaw", "package.json");
-  const srcSkills = join5(pkgRoot(), "openclaw", "skills");
-  if (!existsSync4(srcDist)) {
+  const srcDist = join6(pkgRoot(), "openclaw", "dist");
+  const srcManifest = join6(pkgRoot(), "openclaw", "openclaw.plugin.json");
+  const srcPkg = join6(pkgRoot(), "openclaw", "package.json");
+  const srcSkills = join6(pkgRoot(), "openclaw", "skills");
+  if (!existsSync5(srcDist)) {
     throw new Error(`OpenClaw bundle missing at ${srcDist}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR2);
-  copyDir(srcDist, join5(PLUGIN_DIR2, "dist"));
-  if (existsSync4(srcManifest))
-    copyFileSync(srcManifest, join5(PLUGIN_DIR2, "openclaw.plugin.json"));
-  if (existsSync4(srcPkg))
-    copyFileSync(srcPkg, join5(PLUGIN_DIR2, "package.json"));
-  if (existsSync4(srcSkills))
-    copyDir(srcSkills, join5(PLUGIN_DIR2, "skills"));
+  copyDir(srcDist, join6(PLUGIN_DIR2, "dist"));
+  if (existsSync5(srcManifest))
+    copyFileSync(srcManifest, join6(PLUGIN_DIR2, "openclaw.plugin.json"));
+  if (existsSync5(srcPkg))
+    copyFileSync(srcPkg, join6(PLUGIN_DIR2, "package.json"));
+  if (existsSync5(srcSkills))
+    copyDir(srcSkills, join6(PLUGIN_DIR2, "skills"));
   writeVersionStamp(PLUGIN_DIR2, getVersion());
   log(`  OpenClaw       installed -> ${PLUGIN_DIR2}`);
   const result = ensureHivemindAllowlisted();
@@ -529,7 +609,7 @@ function installOpenclaw() {
   }
 }
 function uninstallOpenclaw() {
-  if (existsSync4(PLUGIN_DIR2)) {
+  if (existsSync5(PLUGIN_DIR2)) {
     rmSync(PLUGIN_DIR2, { recursive: true, force: true });
     log(`  OpenClaw       removed ${PLUGIN_DIR2}`);
   } else {
@@ -538,23 +618,23 @@ function uninstallOpenclaw() {
 }
 
 // dist/src/cli/install-cursor.js
-import { existsSync as existsSync5, unlinkSync as unlinkSync3 } from "node:fs";
-import { join as join6 } from "node:path";
-var CURSOR_HOME = join6(HOME, ".cursor");
-var PLUGIN_DIR3 = join6(CURSOR_HOME, "hivemind");
-var HOOKS_PATH2 = join6(CURSOR_HOME, "hooks.json");
+import { existsSync as existsSync6, unlinkSync as unlinkSync3 } from "node:fs";
+import { join as join7 } from "node:path";
+var CURSOR_HOME = join7(HOME, ".cursor");
+var PLUGIN_DIR3 = join7(CURSOR_HOME, "hivemind");
+var HOOKS_PATH2 = join7(CURSOR_HOME, "hooks.json");
 var HIVEMIND_MARKER_KEY = "_hivemindManaged";
 function buildHookCmd(bundleFile, timeout) {
   return {
     type: "command",
-    command: `node "${join6(PLUGIN_DIR3, "bundle", bundleFile)}"`,
+    command: `node "${join7(PLUGIN_DIR3, "bundle", bundleFile)}"`,
     timeout
   };
 }
 function buildHookCmdShellMatcher(bundleFile, timeout) {
   return {
     type: "command",
-    command: `node "${join6(PLUGIN_DIR3, "bundle", bundleFile)}"`,
+    command: `node "${join7(PLUGIN_DIR3, "bundle", bundleFile)}"`,
     timeout,
     matcher: "Shell"
   };
@@ -610,12 +690,12 @@ function stripHooksFromConfig(existing) {
   return existing;
 }
 function installCursor() {
-  const srcBundle = join6(pkgRoot(), "cursor", "bundle");
-  if (!existsSync5(srcBundle)) {
+  const srcBundle = join7(pkgRoot(), "cursor", "bundle");
+  if (!existsSync6(srcBundle)) {
     throw new Error(`Cursor bundle missing at ${srcBundle}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR3);
-  copyDir(srcBundle, join6(PLUGIN_DIR3, "bundle"));
+  copyDir(srcBundle, join7(PLUGIN_DIR3, "bundle"));
   const existing = readJson(HOOKS_PATH2);
   const merged = mergeHooks2(existing);
   writeJson(HOOKS_PATH2, merged);
@@ -631,7 +711,7 @@ function uninstallCursor() {
   const stripped = stripHooksFromConfig(existing);
   const meaningfulKeys = stripped ? Object.keys(stripped).filter((k) => k !== "version").length : 0;
   if (!stripped || meaningfulKeys === 0) {
-    if (existsSync5(HOOKS_PATH2))
+    if (existsSync6(HOOKS_PATH2))
       unlinkSync3(HOOKS_PATH2);
   } else {
     writeJson(HOOKS_PATH2, stripped);
@@ -640,8 +720,8 @@ function uninstallCursor() {
 }
 
 // dist/src/cli/install-hermes.js
-import { existsSync as existsSync7, writeFileSync as writeFileSync3, readFileSync as readFileSync5, rmSync as rmSync2, unlinkSync as unlinkSync4 } from "node:fs";
-import { join as join8 } from "node:path";
+import { existsSync as existsSync8, writeFileSync as writeFileSync4, readFileSync as readFileSync6, rmSync as rmSync2, unlinkSync as unlinkSync4 } from "node:fs";
+import { join as join9 } from "node:path";
 
 // node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
@@ -3230,15 +3310,15 @@ var safeLoadAll = renamed("safeLoadAll", "loadAll");
 var safeDump = renamed("safeDump", "dump");
 
 // dist/src/cli/install-mcp-shared.js
-import { existsSync as existsSync6 } from "node:fs";
-import { join as join7 } from "node:path";
-var HIVEMIND_DIR = join7(HOME, ".hivemind");
-var MCP_DIR = join7(HIVEMIND_DIR, "mcp");
-var MCP_SERVER_PATH = join7(MCP_DIR, "server.js");
-var MCP_PACKAGE_JSON = join7(MCP_DIR, "package.json");
+import { existsSync as existsSync7 } from "node:fs";
+import { join as join8 } from "node:path";
+var HIVEMIND_DIR = join8(HOME, ".hivemind");
+var MCP_DIR = join8(HIVEMIND_DIR, "mcp");
+var MCP_SERVER_PATH = join8(MCP_DIR, "server.js");
+var MCP_PACKAGE_JSON = join8(MCP_DIR, "package.json");
 function ensureMcpServerInstalled() {
-  const srcDir = join7(pkgRoot(), "mcp", "bundle");
-  if (!existsSync6(srcDir)) {
+  const srcDir = join8(pkgRoot(), "mcp", "bundle");
+  if (!existsSync7(srcDir)) {
     throw new Error(`MCP server bundle missing at ${srcDir}. Run 'npm run build' to produce it before installing Tier B consumers.`);
   }
   ensureDir(MCP_DIR);
@@ -3248,11 +3328,11 @@ function ensureMcpServerInstalled() {
 }
 
 // dist/src/cli/install-hermes.js
-var HERMES_HOME = join8(HOME, ".hermes");
-var SKILLS_DIR = join8(HERMES_HOME, "skills", "hivemind-memory");
-var HIVEMIND_DIR2 = join8(HERMES_HOME, "hivemind");
-var BUNDLE_DIR = join8(HIVEMIND_DIR2, "bundle");
-var CONFIG_PATH = join8(HERMES_HOME, "config.yaml");
+var HERMES_HOME = join9(HOME, ".hermes");
+var SKILLS_DIR = join9(HERMES_HOME, "skills", "hivemind-memory");
+var HIVEMIND_DIR2 = join9(HERMES_HOME, "hivemind");
+var BUNDLE_DIR = join9(HIVEMIND_DIR2, "bundle");
+var CONFIG_PATH = join9(HERMES_HOME, "config.yaml");
 var SERVER_KEY = "hivemind";
 var SKILL_BODY = `---
 name: hivemind-memory
@@ -3310,7 +3390,7 @@ function isHivemindHook(entry) {
 }
 function buildHookEntry(bundleFile, timeout, matcher) {
   const entry = {
-    command: `node ${join8(BUNDLE_DIR, bundleFile)}`,
+    command: `node ${join9(BUNDLE_DIR, bundleFile)}`,
     timeout
   };
   if (matcher)
@@ -3354,10 +3434,10 @@ function stripHivemindHooks(existing) {
   return Object.keys(out).length > 0 ? out : void 0;
 }
 function readConfig() {
-  if (!existsSync7(CONFIG_PATH))
+  if (!existsSync8(CONFIG_PATH))
     return {};
   try {
-    const raw = readFileSync5(CONFIG_PATH, "utf-8");
+    const raw = readFileSync6(CONFIG_PATH, "utf-8");
     const parsed = load(raw);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return parsed;
@@ -3370,15 +3450,15 @@ function readConfig() {
 function writeConfig(cfg) {
   ensureDir(HERMES_HOME);
   const dumped = dump(cfg, { lineWidth: 100, noRefs: true });
-  writeFileSync3(CONFIG_PATH, dumped);
+  writeFileSync4(CONFIG_PATH, dumped);
 }
 function installHermes() {
   ensureDir(SKILLS_DIR);
-  writeFileSync3(join8(SKILLS_DIR, "SKILL.md"), SKILL_BODY);
+  writeFileSync4(join9(SKILLS_DIR, "SKILL.md"), SKILL_BODY);
   writeVersionStamp(SKILLS_DIR, getVersion());
   log(`  Hermes         skill installed -> ${SKILLS_DIR}`);
-  const srcBundle = join8(pkgRoot(), "hermes", "bundle");
-  if (!existsSync7(srcBundle)) {
+  const srcBundle = join9(pkgRoot(), "hermes", "bundle");
+  if (!existsSync8(srcBundle)) {
     throw new Error(`Hermes bundle missing at ${srcBundle}. Run 'npm run build' first.`);
   }
   ensureDir(HIVEMIND_DIR2);
@@ -3399,15 +3479,15 @@ function installHermes() {
   log(`  Hermes         config updated -> ${CONFIG_PATH} (mcp_servers + hooks + hooks_auto_accept)`);
 }
 function uninstallHermes() {
-  if (existsSync7(SKILLS_DIR)) {
+  if (existsSync8(SKILLS_DIR)) {
     rmSync2(SKILLS_DIR, { recursive: true, force: true });
     log(`  Hermes         removed ${SKILLS_DIR}`);
   }
-  if (existsSync7(HIVEMIND_DIR2)) {
+  if (existsSync8(HIVEMIND_DIR2)) {
     rmSync2(HIVEMIND_DIR2, { recursive: true, force: true });
     log(`  Hermes         removed ${HIVEMIND_DIR2}`);
   }
-  if (existsSync7(CONFIG_PATH)) {
+  if (existsSync8(CONFIG_PATH)) {
     const cfg = readConfig();
     let touched = false;
     if (cfg.mcp_servers && typeof cfg.mcp_servers === "object" && SERVER_KEY in cfg.mcp_servers) {
@@ -3440,18 +3520,18 @@ function uninstallHermes() {
 }
 
 // dist/src/cli/install-pi.js
-import { existsSync as existsSync8, writeFileSync as writeFileSync4, rmSync as rmSync3, readFileSync as readFileSync6, copyFileSync as copyFileSync2 } from "node:fs";
-import { join as join9 } from "node:path";
-var PI_AGENT_DIR = join9(HOME, ".pi", "agent");
-var AGENTS_MD = join9(PI_AGENT_DIR, "AGENTS.md");
-var LEGACY_SKILL_DIR = join9(PI_AGENT_DIR, "skills", "hivemind-memory");
-var EXTENSIONS_DIR = join9(PI_AGENT_DIR, "extensions");
-var EXTENSION_PATH = join9(EXTENSIONS_DIR, "hivemind.ts");
-var VERSION_DIR = join9(PI_AGENT_DIR, ".hivemind");
-var WIKI_WORKER_DIR = join9(PI_AGENT_DIR, "hivemind");
-var WIKI_WORKER_PATH = join9(WIKI_WORKER_DIR, "wiki-worker.js");
-var SKILLIFY_WORKER_PATH = join9(WIKI_WORKER_DIR, "skillify-worker.js");
-var AUTOPULL_WORKER_PATH = join9(WIKI_WORKER_DIR, "autopull-worker.js");
+import { existsSync as existsSync9, writeFileSync as writeFileSync5, rmSync as rmSync3, readFileSync as readFileSync7, copyFileSync as copyFileSync2 } from "node:fs";
+import { join as join10 } from "node:path";
+var PI_AGENT_DIR = join10(HOME, ".pi", "agent");
+var AGENTS_MD = join10(PI_AGENT_DIR, "AGENTS.md");
+var LEGACY_SKILL_DIR = join10(PI_AGENT_DIR, "skills", "hivemind-memory");
+var EXTENSIONS_DIR = join10(PI_AGENT_DIR, "extensions");
+var EXTENSION_PATH = join10(EXTENSIONS_DIR, "hivemind.ts");
+var VERSION_DIR = join10(PI_AGENT_DIR, ".hivemind");
+var WIKI_WORKER_DIR = join10(PI_AGENT_DIR, "hivemind");
+var WIKI_WORKER_PATH = join10(WIKI_WORKER_DIR, "wiki-worker.js");
+var SKILLIFY_WORKER_PATH = join10(WIKI_WORKER_DIR, "skillify-worker.js");
+var AUTOPULL_WORKER_PATH = join10(WIKI_WORKER_DIR, "autopull-worker.js");
 var HIVEMIND_BLOCK_START = "<!-- BEGIN hivemind-memory -->";
 var HIVEMIND_BLOCK_END = "<!-- END hivemind-memory -->";
 var HIVEMIND_BLOCK_BODY = `${HIVEMIND_BLOCK_START}
@@ -3519,30 +3599,30 @@ ${after}`;
 }
 function installPi() {
   ensureDir(PI_AGENT_DIR);
-  if (existsSync8(LEGACY_SKILL_DIR)) {
+  if (existsSync9(LEGACY_SKILL_DIR)) {
     rmSync3(LEGACY_SKILL_DIR, { recursive: true, force: true });
   }
-  const prior = existsSync8(AGENTS_MD) ? readFileSync6(AGENTS_MD, "utf-8") : null;
+  const prior = existsSync9(AGENTS_MD) ? readFileSync7(AGENTS_MD, "utf-8") : null;
   const next = upsertHivemindBlock(prior);
-  writeFileSync4(AGENTS_MD, next);
-  const srcExtension = join9(pkgRoot(), "pi", "extension-source", "hivemind.ts");
-  if (!existsSync8(srcExtension)) {
+  writeFileSync5(AGENTS_MD, next);
+  const srcExtension = join10(pkgRoot(), "pi", "extension-source", "hivemind.ts");
+  if (!existsSync9(srcExtension)) {
     throw new Error(`pi extension source missing at ${srcExtension}. Reinstall the @deeplake/hivemind package.`);
   }
   ensureDir(EXTENSIONS_DIR);
   copyFileSync2(srcExtension, EXTENSION_PATH);
-  const srcWorker = join9(pkgRoot(), "pi", "bundle", "wiki-worker.js");
-  if (existsSync8(srcWorker)) {
+  const srcWorker = join10(pkgRoot(), "pi", "bundle", "wiki-worker.js");
+  if (existsSync9(srcWorker)) {
     ensureDir(WIKI_WORKER_DIR);
     copyFileSync2(srcWorker, WIKI_WORKER_PATH);
   }
-  const srcSkillifyWorker = join9(pkgRoot(), "pi", "bundle", "skillify-worker.js");
-  if (existsSync8(srcSkillifyWorker)) {
+  const srcSkillifyWorker = join10(pkgRoot(), "pi", "bundle", "skillify-worker.js");
+  if (existsSync9(srcSkillifyWorker)) {
     ensureDir(WIKI_WORKER_DIR);
     copyFileSync2(srcSkillifyWorker, SKILLIFY_WORKER_PATH);
   }
-  const srcAutopullWorker = join9(pkgRoot(), "pi", "bundle", "autopull-worker.js");
-  if (existsSync8(srcAutopullWorker)) {
+  const srcAutopullWorker = join10(pkgRoot(), "pi", "bundle", "autopull-worker.js");
+  if (existsSync9(srcAutopullWorker)) {
     ensureDir(WIKI_WORKER_DIR);
     copyFileSync2(srcAutopullWorker, AUTOPULL_WORKER_PATH);
   }
@@ -3550,82 +3630,82 @@ function installPi() {
   writeVersionStamp(VERSION_DIR, getVersion());
   log(`  pi             AGENTS.md updated -> ${AGENTS_MD}`);
   log(`  pi             extension installed -> ${EXTENSION_PATH}`);
-  if (existsSync8(WIKI_WORKER_PATH)) {
+  if (existsSync9(WIKI_WORKER_PATH)) {
     log(`  pi             wiki-worker installed -> ${WIKI_WORKER_PATH}`);
   }
-  if (existsSync8(SKILLIFY_WORKER_PATH)) {
+  if (existsSync9(SKILLIFY_WORKER_PATH)) {
     log(`  pi             skillify-worker installed -> ${SKILLIFY_WORKER_PATH}`);
   }
-  if (existsSync8(AUTOPULL_WORKER_PATH)) {
+  if (existsSync9(AUTOPULL_WORKER_PATH)) {
     log(`  pi             autopull-worker installed -> ${AUTOPULL_WORKER_PATH}`);
   }
 }
 function uninstallPi() {
-  if (existsSync8(LEGACY_SKILL_DIR)) {
+  if (existsSync9(LEGACY_SKILL_DIR)) {
     rmSync3(LEGACY_SKILL_DIR, { recursive: true, force: true });
     log(`  pi             removed ${LEGACY_SKILL_DIR}`);
   }
-  if (existsSync8(EXTENSION_PATH)) {
+  if (existsSync9(EXTENSION_PATH)) {
     rmSync3(EXTENSION_PATH, { force: true });
     log(`  pi             removed extension ${EXTENSION_PATH}`);
   }
-  if (existsSync8(WIKI_WORKER_DIR)) {
+  if (existsSync9(WIKI_WORKER_DIR)) {
     rmSync3(WIKI_WORKER_DIR, { recursive: true, force: true });
     log(`  pi             removed wiki-worker dir ${WIKI_WORKER_DIR}`);
   }
-  if (existsSync8(AGENTS_MD)) {
-    const prior = readFileSync6(AGENTS_MD, "utf-8");
+  if (existsSync9(AGENTS_MD)) {
+    const prior = readFileSync7(AGENTS_MD, "utf-8");
     const stripped = stripHivemindBlock(prior);
     if (stripped.trim().length === 0) {
       rmSync3(AGENTS_MD, { force: true });
       log(`  pi             removed empty ${AGENTS_MD}`);
     } else {
-      writeFileSync4(AGENTS_MD, stripped);
+      writeFileSync5(AGENTS_MD, stripped);
       log(`  pi             stripped hivemind block from ${AGENTS_MD}`);
     }
   }
-  if (existsSync8(VERSION_DIR)) {
+  if (existsSync9(VERSION_DIR)) {
     rmSync3(VERSION_DIR, { recursive: true, force: true });
   }
 }
 
 // dist/src/cli/embeddings.js
-import { copyFileSync as copyFileSync3, chmodSync, existsSync as existsSync9, lstatSync as lstatSync2, readdirSync, readlinkSync, rmSync as rmSync4, statSync, unlinkSync as unlinkSync5 } from "node:fs";
+import { copyFileSync as copyFileSync3, chmodSync, existsSync as existsSync10, lstatSync as lstatSync2, readdirSync, readlinkSync, rmSync as rmSync4, statSync, unlinkSync as unlinkSync5 } from "node:fs";
 import { execFileSync as execFileSync3 } from "node:child_process";
-import { join as join10 } from "node:path";
-var SHARED_DIR = join10(HOME, ".hivemind", "embed-deps");
-var SHARED_NODE_MODULES = join10(SHARED_DIR, "node_modules");
-var SHARED_DAEMON_PATH = join10(SHARED_DIR, "embed-daemon.js");
+import { join as join11 } from "node:path";
+var SHARED_DIR = join11(HOME, ".hivemind", "embed-deps");
+var SHARED_NODE_MODULES = join11(SHARED_DIR, "node_modules");
+var SHARED_DAEMON_PATH = join11(SHARED_DIR, "embed-daemon.js");
 var TRANSFORMERS_PKG = "@huggingface/transformers";
 var TRANSFORMERS_RANGE = "^3.0.0";
 function findHivemindInstalls(home = HOME) {
   const out = [];
   const fixed = [
-    { id: "codex", pluginDir: join10(home, ".codex", "hivemind") },
-    { id: "cursor", pluginDir: join10(home, ".cursor", "hivemind") },
-    { id: "hermes", pluginDir: join10(home, ".hermes", "hivemind") }
+    { id: "codex", pluginDir: join11(home, ".codex", "hivemind") },
+    { id: "cursor", pluginDir: join11(home, ".cursor", "hivemind") },
+    { id: "hermes", pluginDir: join11(home, ".hermes", "hivemind") }
   ];
   for (const inst of fixed) {
-    if (existsSync9(join10(inst.pluginDir, "bundle")))
+    if (existsSync10(join11(inst.pluginDir, "bundle")))
       out.push(inst);
   }
-  const ccCache = join10(home, ".claude", "plugins", "cache", "hivemind", "hivemind");
-  if (existsSync9(ccCache)) {
+  const ccCache = join11(home, ".claude", "plugins", "cache", "hivemind", "hivemind");
+  if (existsSync10(ccCache)) {
     let entries = [];
     try {
       entries = readdirSync(ccCache);
     } catch {
     }
     for (const ver of entries) {
-      const dir = join10(ccCache, ver);
+      const dir = join11(ccCache, ver);
       try {
         if (!statSync(dir).isDirectory())
           continue;
       } catch {
         continue;
       }
-      const candidates = [join10(dir, "bundle"), join10(dir, "claude-code", "bundle")];
-      if (candidates.some((p) => existsSync9(p))) {
+      const candidates = [join11(dir, "bundle"), join11(dir, "claude-code", "bundle")];
+      if (candidates.some((p) => existsSync10(p))) {
         out.push({ id: `claude (${ver})`, pluginDir: dir });
       }
     }
@@ -3633,10 +3713,10 @@ function findHivemindInstalls(home = HOME) {
   return out;
 }
 function isSharedDepsInstalled(sharedNodeModules = SHARED_NODE_MODULES) {
-  return existsSync9(join10(sharedNodeModules, TRANSFORMERS_PKG));
+  return existsSync10(join11(sharedNodeModules, TRANSFORMERS_PKG));
 }
 function isSymlinkToSharedDeps(linkPath, sharedNodeModules) {
-  if (!existsSync9(linkPath))
+  if (!existsSync10(linkPath))
     return false;
   try {
     if (!lstatSync2(linkPath).isSymbolicLink())
@@ -3647,8 +3727,8 @@ function isSymlinkToSharedDeps(linkPath, sharedNodeModules) {
   }
 }
 function linkStateFor(install, sharedNodeModules = SHARED_NODE_MODULES) {
-  const link = join10(install.pluginDir, "node_modules");
-  if (!existsSync9(link) && !isSymbolicLink(link))
+  const link = join11(install.pluginDir, "node_modules");
+  if (!existsSync10(link) && !isSymbolicLink(link))
     return { kind: "no-node-modules" };
   try {
     if (lstatSync2(link).isSymbolicLink()) {
@@ -3672,7 +3752,7 @@ function ensureSharedDeps() {
     log(`  Embeddings     installing ${TRANSFORMERS_PKG}@${TRANSFORMERS_RANGE} into ${SHARED_DIR}`);
     log(`                 (~600 MB; first install only \u2014 every agent will share this)`);
     ensureDir(SHARED_DIR);
-    writeJson(join10(SHARED_DIR, "package.json"), {
+    writeJson(join11(SHARED_DIR, "package.json"), {
       name: "hivemind-embed-deps",
       version: "1.0.0",
       private: true,
@@ -3686,8 +3766,8 @@ function ensureSharedDeps() {
     log(`  Embeddings     shared deps already present at ${SHARED_DIR}`);
   }
   ensureDir(SHARED_DIR);
-  const src = join10(pkgRoot(), "embeddings", "embed-daemon.js");
-  if (existsSync9(src)) {
+  const src = join11(pkgRoot(), "embeddings", "embed-daemon.js");
+  if (existsSync10(src)) {
     copyFileSync3(src, SHARED_DAEMON_PATH);
     chmodSync(SHARED_DAEMON_PATH, 493);
   } else {
@@ -3695,7 +3775,7 @@ function ensureSharedDeps() {
   }
 }
 function linkAgent(install) {
-  const link = join10(install.pluginDir, "node_modules");
+  const link = join11(install.pluginDir, "node_modules");
   symlinkForce(SHARED_NODE_MODULES, link);
   log(`  Embeddings     linked ${install.id.padEnd(20)} -> shared deps`);
 }
@@ -3714,13 +3794,13 @@ function enableEmbeddings() {
 function disableEmbeddings(opts) {
   const installs = findHivemindInstalls();
   for (const inst of installs) {
-    const link = join10(inst.pluginDir, "node_modules");
+    const link = join11(inst.pluginDir, "node_modules");
     if (isSymlinkToSharedDeps(link, SHARED_NODE_MODULES)) {
       unlinkSync5(link);
       log(`  Embeddings     unlinked ${inst.id}`);
     }
   }
-  if (opts?.prune && existsSync9(SHARED_DIR)) {
+  if (opts?.prune && existsSync10(SHARED_DIR)) {
     rmSync4(SHARED_DIR, { recursive: true, force: true });
     log(`  Embeddings     pruned ${SHARED_DIR}`);
   }
@@ -3728,7 +3808,7 @@ function disableEmbeddings(opts) {
 function statusEmbeddings() {
   log(`Shared deps:   ${SHARED_DIR}`);
   log(`Installed:     ${isSharedDepsInstalled() ? "yes" : "no"}`);
-  log(`Daemon:        ${existsSync9(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : "(not present)"}`);
+  log(`Daemon:        ${existsSync10(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : "(not present)"}`);
   log("");
   log(`Agent installs:`);
   const installs = findHivemindInstalls();
@@ -3759,8 +3839,8 @@ function statusEmbeddings() {
 }
 
 // dist/src/cli/auth.js
-import { existsSync as existsSync10 } from "node:fs";
-import { join as join12 } from "node:path";
+import { existsSync as existsSync11 } from "node:fs";
+import { join as join13 } from "node:path";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -3775,25 +3855,25 @@ function deeplakeClientHeader() {
 }
 
 // dist/src/commands/auth-creds.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync5, mkdirSync as mkdirSync2, unlinkSync as unlinkSync6 } from "node:fs";
-import { join as join11 } from "node:path";
-import { homedir as homedir3 } from "node:os";
+import { readFileSync as readFileSync8, writeFileSync as writeFileSync6, mkdirSync as mkdirSync2, unlinkSync as unlinkSync6 } from "node:fs";
+import { join as join12 } from "node:path";
+import { homedir as homedir4 } from "node:os";
 function configDir() {
-  return join11(homedir3(), ".deeplake");
+  return join12(homedir4(), ".deeplake");
 }
 function credsPath() {
-  return join11(configDir(), "credentials.json");
+  return join12(configDir(), "credentials.json");
 }
 function loadCredentials() {
   try {
-    return JSON.parse(readFileSync7(credsPath(), "utf-8"));
+    return JSON.parse(readFileSync8(credsPath(), "utf-8"));
   } catch {
     return null;
   }
 }
 function saveCredentials(creds) {
   mkdirSync2(configDir(), { recursive: true, mode: 448 });
-  writeFileSync5(credsPath(), JSON.stringify({ ...creds, savedAt: (/* @__PURE__ */ new Date()).toISOString() }, null, 2), { mode: 384 });
+  writeFileSync6(credsPath(), JSON.stringify({ ...creds, savedAt: (/* @__PURE__ */ new Date()).toISOString() }, null, 2), { mode: 384 });
 }
 function deleteCredentials() {
   try {
@@ -3982,9 +4062,9 @@ Using: ${orgName}
 }
 
 // dist/src/cli/auth.js
-var CREDS_PATH = join12(HOME, ".deeplake", "credentials.json");
+var CREDS_PATH = join13(HOME, ".deeplake", "credentials.json");
 function isLoggedIn() {
-  return existsSync10(CREDS_PATH) && loadCredentials() !== null;
+  return existsSync11(CREDS_PATH) && loadCredentials() !== null;
 }
 async function ensureLoggedIn() {
   if (isLoggedIn())
@@ -4017,16 +4097,16 @@ async function maybeShowOrgChoice() {
 }
 
 // dist/src/config.js
-import { readFileSync as readFileSync8, existsSync as existsSync11 } from "node:fs";
-import { join as join13 } from "node:path";
-import { homedir as homedir4, userInfo } from "node:os";
+import { readFileSync as readFileSync9, existsSync as existsSync12 } from "node:fs";
+import { join as join14 } from "node:path";
+import { homedir as homedir5, userInfo } from "node:os";
 function loadConfig() {
-  const home = homedir4();
-  const credPath = join13(home, ".deeplake", "credentials.json");
+  const home = homedir5();
+  const credPath = join14(home, ".deeplake", "credentials.json");
   let creds = null;
-  if (existsSync11(credPath)) {
+  if (existsSync12(credPath)) {
     try {
-      creds = JSON.parse(readFileSync8(credPath, "utf-8"));
+      creds = JSON.parse(readFileSync9(credPath, "utf-8"));
     } catch {
       return null;
     }
@@ -4045,7 +4125,7 @@ function loadConfig() {
     tableName: process.env.HIVEMIND_TABLE ?? "memory",
     sessionsTableName: process.env.HIVEMIND_SESSIONS_TABLE ?? "sessions",
     skillsTableName: process.env.HIVEMIND_SKILLS_TABLE ?? "skills",
-    memoryPath: process.env.HIVEMIND_MEMORY_PATH ?? join13(home, ".deeplake", "memory")
+    memoryPath: process.env.HIVEMIND_MEMORY_PATH ?? join14(home, ".deeplake", "memory")
   };
 }
 
@@ -4054,10 +4134,10 @@ import { randomUUID } from "node:crypto";
 
 // dist/src/utils/debug.js
 import { appendFileSync } from "node:fs";
-import { join as join14 } from "node:path";
-import { homedir as homedir5 } from "node:os";
+import { join as join15 } from "node:path";
+import { homedir as homedir6 } from "node:os";
 var DEBUG = process.env.HIVEMIND_DEBUG === "1";
-var LOG = join14(homedir5(), ".deeplake", "hook-debug.log");
+var LOG = join15(homedir6(), ".deeplake", "hook-debug.log");
 function log2(tag, msg) {
   if (!DEBUG)
     return;
@@ -4442,13 +4522,14 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log3(`table "${tbl}" not found, creating`);
-      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
+      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
       log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
     await this.ensureEmbeddingColumn(tbl, SUMMARY_EMBEDDING_COL);
     await this.ensureColumn(tbl, "agent", "TEXT NOT NULL DEFAULT ''");
+    await this.ensureColumn(tbl, "plugin_version", "TEXT NOT NULL DEFAULT ''");
   }
   /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
@@ -4456,13 +4537,14 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
       log3(`table "${safe}" not found, creating`);
-      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
+      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
       log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
     await this.ensureEmbeddingColumn(safe, MESSAGE_EMBEDDING_COL);
     await this.ensureColumn(safe, "agent", "TEXT NOT NULL DEFAULT ''");
+    await this.ensureColumn(safe, "plugin_version", "TEXT NOT NULL DEFAULT ''");
     await this.ensureLookupIndex(safe, "path_creation_date", `("path", "creation_date")`);
   }
   /**
@@ -4817,31 +4899,31 @@ if (process.argv[1] && process.argv[1].endsWith("auth-login.js")) {
 }
 
 // dist/src/commands/skillify.js
-import { readdirSync as readdirSync4, existsSync as existsSync20, readFileSync as readFileSync14, mkdirSync as mkdirSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { dirname as dirname4, join as join23 } from "node:path";
+import { readdirSync as readdirSync4, existsSync as existsSync21, readFileSync as readFileSync15, mkdirSync as mkdirSync8, renameSync as renameSync5 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { dirname as dirname4, join as join24 } from "node:path";
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync14, mkdirSync as mkdirSync4, readFileSync as readFileSync10, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join17 } from "node:path";
+import { existsSync as existsSync15, mkdirSync as mkdirSync4, readFileSync as readFileSync11, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join18 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync13, renameSync as renameSync2 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join16 } from "node:path";
+import { existsSync as existsSync14, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join17 } from "node:path";
 var dlog = (msg) => log2("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join16(homedir6(), ".deeplake", "state");
-  const legacy = join16(root, "skilify");
-  const current = join16(root, "skillify");
-  if (!existsSync13(legacy))
+  const root = join17(homedir7(), ".deeplake", "state");
+  const legacy = join17(root, "skilify");
+  const current = join17(root, "skillify");
+  if (!existsSync14(legacy))
     return;
-  if (existsSync13(current))
+  if (existsSync14(current))
     return;
   try {
     renameSync2(legacy, current);
@@ -4857,16 +4939,16 @@ function migrateLegacyStateDir() {
 }
 
 // dist/src/skillify/scope-config.js
-var STATE_DIR = join17(homedir7(), ".deeplake", "state", "skillify");
-var CONFIG_PATH2 = join17(STATE_DIR, "config.json");
+var STATE_DIR = join18(homedir8(), ".deeplake", "state", "skillify");
+var CONFIG_PATH2 = join18(STATE_DIR, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
-  if (!existsSync14(CONFIG_PATH2))
+  if (!existsSync15(CONFIG_PATH2))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync10(CONFIG_PATH2, "utf-8"));
-    const scope = raw.scope === "team" || raw.scope === "org" ? raw.scope : "me";
+    const raw = JSON.parse(readFileSync11(CONFIG_PATH2, "utf-8"));
+    const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
     return { scope, team, install };
@@ -4877,18 +4959,18 @@ function loadScopeConfig() {
 function saveScopeConfig(cfg) {
   migrateLegacyStateDir();
   mkdirSync4(STATE_DIR, { recursive: true });
-  writeFileSync7(CONFIG_PATH2, JSON.stringify(cfg, null, 2));
+  writeFileSync8(CONFIG_PATH2, JSON.stringify(cfg, null, 2));
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync18, readFileSync as readFileSync13, writeFileSync as writeFileSync10, mkdirSync as mkdirSync7, renameSync as renameSync4, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync8 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { dirname as dirname3, join as join21 } from "node:path";
+import { existsSync as existsSync19, readFileSync as readFileSync14, writeFileSync as writeFileSync11, mkdirSync as mkdirSync7, renameSync as renameSync4, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync8 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { dirname as dirname3, join as join22 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync15, mkdirSync as mkdirSync5, readFileSync as readFileSync11, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join18 } from "node:path";
+import { existsSync as existsSync16, mkdirSync as mkdirSync5, readFileSync as readFileSync12, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join19 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -4912,18 +4994,25 @@ function parseFrontmatter(text) {
   const head = text.slice(4, end).trim();
   const body = text.slice(end + 4).replace(/^\r?\n/, "");
   const fm = { source_sessions: [] };
-  let mode = "kv";
+  let arrayKey = null;
   for (const raw of head.split(/\r?\n/)) {
-    if (mode === "sources") {
+    if (arrayKey) {
       const m2 = raw.match(/^\s+-\s+(.+)$/);
       if (m2) {
-        fm.source_sessions.push(m2[1].trim());
+        const arr = fm[arrayKey] ?? [];
+        arr.push(m2[1].trim());
+        fm[arrayKey] = arr;
         continue;
       }
-      mode = "kv";
+      arrayKey = null;
     }
     if (raw.startsWith("source_sessions:")) {
-      mode = "sources";
+      arrayKey = "source_sessions";
+      continue;
+    }
+    if (raw.startsWith("contributors:")) {
+      arrayKey = "contributors";
+      fm.contributors = [];
       continue;
     }
     const m = raw.match(/^([a-zA-Z_]+):\s*(.*)$/);
@@ -4947,22 +5036,22 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync16, lstatSync as lstatSync3, mkdirSync as mkdirSync6, readFileSync as readFileSync12, renameSync as renameSync3, unlinkSync as unlinkSync7, writeFileSync as writeFileSync9 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { dirname as dirname2, join as join19 } from "node:path";
+import { existsSync as existsSync17, lstatSync as lstatSync3, mkdirSync as mkdirSync6, readFileSync as readFileSync13, renameSync as renameSync3, unlinkSync as unlinkSync7, writeFileSync as writeFileSync10 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { dirname as dirname2, join as join20 } from "node:path";
 function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join19(homedir9(), ".deeplake", "state", "skillify", "pulled.json");
+  return join20(homedir10(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
-  if (!existsSync16(path))
+  if (!existsSync17(path))
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync12(path, "utf-8");
+    raw = readFileSync13(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -5011,7 +5100,7 @@ function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
   mkdirSync6(dirname2(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync9(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  writeFileSync10(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
   renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
@@ -5054,7 +5143,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync16(join19(e.installRoot, e.dirName))) {
+    if (existsSync17(join20(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -5067,26 +5156,26 @@ function pruneOrphanedEntries(path = manifestPath()) {
 }
 
 // dist/src/skillify/agent-roots.js
-import { existsSync as existsSync17 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join20 } from "node:path";
+import { existsSync as existsSync18 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join21 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync17(join20(home, ".codex"));
-  const piInstalled = existsSync17(join20(home, ".pi", "agent"));
-  const hermesInstalled = existsSync17(join20(home, ".hermes"));
+  const codexInstalled = existsSync18(join21(home, ".codex"));
+  const piInstalled = existsSync18(join21(home, ".pi", "agent"));
+  const hermesInstalled = existsSync18(join21(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join20(home, ".agents", "skills"));
+    out.push(join21(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join20(home, ".hermes", "skills"));
+    out.push(join21(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join20(home, ".pi", "agent", "skills"));
+    out.push(join21(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir10()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir11()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -5113,24 +5202,32 @@ function buildPullSql(args) {
     where.push(`name = '${esc(args.skillName)}'`);
   }
   const whereClause = where.length > 0 ? ` WHERE ${where.join(" AND ")}` : "";
-  return `SELECT name, project, project_key, body, version, source_agent, scope, author, description, trigger_text, source_sessions, install, created_at, updated_at FROM "${args.tableName}"${whereClause} ORDER BY project_key ASC, name ASC, version DESC`;
+  const contributorsCol = args.includeContributors === false ? "" : "contributors, ";
+  return `SELECT name, project, project_key, body, version, source_agent, scope, author, ${contributorsCol}description, trigger_text, source_sessions, install, created_at, updated_at FROM "${args.tableName}"${whereClause} ORDER BY project_key ASC, name ASC, version DESC`;
+}
+function isMissingContributorsColumnError(message) {
+  if (!message)
+    return false;
+  return /contributors.*(?:does not exist|not found|unknown)/i.test(message) || /(?:does not exist|unknown column).*contributors/i.test(message);
 }
 function isMissingTableError(message) {
   if (!message)
+    return false;
+  if (/\bcolumn\b/i.test(message))
     return false;
   return /Table does not exist|relation .* does not exist|no such table/i.test(message);
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join21(homedir11(), ".claude", "skills");
+    return join22(homedir12(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join21(cwd, ".claude", "skills");
+  return join22(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join21(root, dirName);
+    const link = join22(root, dirName);
     let existing;
     try {
       existing = lstatSync4(link);
@@ -5173,8 +5270,8 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join21(entry.installRoot, entry.dirName);
-    if (!existsSync18(canonical))
+    const canonical = join22(entry.installRoot, entry.dirName);
+    if (!existsSync19(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
     if (sameSorted(fresh, entry.symlinks))
@@ -5213,11 +5310,16 @@ function selectLatestPerName(rows) {
 }
 function renderSkillFile(row) {
   const sources = parseSourceSessions(row.source_sessions);
+  const author = typeof row.author === "string" && row.author.length > 0 ? row.author : void 0;
+  const contributors = parseContributors(row.contributors);
+  const renderedContributors = contributors.length > 0 ? contributors : author ? [author] : [];
   const fm = {
     name: String(row.name ?? ""),
     description: String(row.description ?? ""),
     trigger: typeof row.trigger_text === "string" && row.trigger_text.length > 0 ? String(row.trigger_text) : void 0,
+    author,
     source_sessions: sources,
+    contributors: renderedContributors,
     version: Number(row.version ?? 1),
     created_by_agent: String(row.source_agent ?? "unknown"),
     created_at: String(row.created_at ?? (/* @__PURE__ */ new Date()).toISOString()),
@@ -5242,15 +5344,35 @@ function parseSourceSessions(v) {
   }
   return [];
 }
+function parseContributors(v) {
+  if (Array.isArray(v))
+    return v.map(String);
+  if (typeof v === "string") {
+    try {
+      const parsed = JSON.parse(v);
+      if (Array.isArray(parsed))
+        return parsed.map(String);
+    } catch {
+    }
+  }
+  return [];
+}
 function renderFrontmatter(fm) {
   const lines = ["---"];
   lines.push(`name: ${fm.name}`);
   lines.push(`description: ${JSON.stringify(fm.description)}`);
   if (fm.trigger)
     lines.push(`trigger: ${JSON.stringify(fm.trigger)}`);
+  if (fm.author)
+    lines.push(`author: ${fm.author}`);
   lines.push(`source_sessions:`);
   for (const s of fm.source_sessions)
     lines.push(`  - ${s}`);
+  if (fm.contributors && fm.contributors.length > 0) {
+    lines.push(`contributors:`);
+    for (const c of fm.contributors)
+      lines.push(`  - ${c}`);
+  }
   lines.push(`version: ${fm.version}`);
   lines.push(`created_by_agent: ${fm.created_by_agent}`);
   lines.push(`created_at: ${fm.created_at}`);
@@ -5259,10 +5381,10 @@ function renderFrontmatter(fm) {
   return lines.join("\n");
 }
 function readLocalVersion(path) {
-  if (!existsSync18(path))
+  if (!existsSync19(path))
     return null;
   try {
-    const text = readFileSync13(path, "utf-8");
+    const text = readFileSync14(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -5290,10 +5412,19 @@ async function runPull(opts) {
   try {
     rows = await opts.query(sql);
   } catch (e) {
-    if (isMissingTableError(e?.message))
+    if (isMissingTableError(e?.message)) {
       rows = [];
-    else
+    } else if (isMissingContributorsColumnError(e?.message)) {
+      const legacySql = buildPullSql({
+        tableName: opts.tableName,
+        users: opts.users,
+        skillName: opts.skillName,
+        includeContributors: false
+      });
+      rows = await opts.query(legacySql);
+    } else {
       throw e;
+    }
   }
   const latest = selectLatestPerName(rows);
   const root = resolvePullDestination(opts.install, opts.cwd);
@@ -5348,8 +5479,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join21(root, dirName);
-    const skillFile = join21(skillDir, "SKILL.md");
+    const skillDir = join22(root, dirName);
+    const skillFile = join22(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -5361,13 +5492,13 @@ async function runPull(opts) {
     let manifestError;
     if (action === "wrote") {
       mkdirSync7(skillDir, { recursive: true });
-      if (existsSync18(skillFile)) {
+      if (existsSync19(skillFile)) {
         try {
           renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync10(skillFile, renderSkillFile(row));
+      writeFileSync11(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -5409,15 +5540,15 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/unpull.js
-import { existsSync as existsSync19, readdirSync as readdirSync3, rmSync as rmSync5, statSync as statSync3 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join22 } from "node:path";
+import { existsSync as existsSync20, readdirSync as readdirSync3, rmSync as rmSync5, statSync as statSync3 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { join as join23 } from "node:path";
 function resolveUnpullRoot(install, cwd) {
   if (install === "global")
-    return join22(homedir12(), ".claude", "skills");
+    return join23(homedir13(), ".claude", "skills");
   if (!cwd)
     throw new Error("cwd required when install === 'project'");
-  return join22(cwd, ".claude", "skills");
+  return join23(cwd, ".claude", "skills");
 }
 function runUnpull(opts) {
   const root = resolveUnpullRoot(opts.install, opts.cwd);
@@ -5440,8 +5571,8 @@ function runUnpull(opts) {
   const entries = entriesForRoot(manifest, opts.install, root);
   for (const entry of entries) {
     summary.scanned++;
-    const path = join22(root, entry.dirName);
-    if (!existsSync19(path)) {
+    const path = join23(root, entry.dirName);
+    if (!existsSync20(path)) {
       if (!opts.dryRun) {
         unlinkSymlinks(entry.symlinks);
         removePullEntry(opts.install, entry.installRoot, entry.dirName);
@@ -5494,12 +5625,12 @@ function runUnpull(opts) {
     }
     summary.entries.push(result);
   }
-  if (existsSync19(root) && (opts.all || opts.legacyCleanup)) {
+  if (existsSync20(root) && (opts.all || opts.legacyCleanup)) {
     const manifestDirNames = new Set(entries.map((e) => e.dirName));
     for (const dirName of readdirSync3(root)) {
       if (manifestDirNames.has(dirName))
         continue;
-      const path = join22(root, dirName);
+      const path = join23(root, dirName);
       let st;
       try {
         st = statSync3(path);
@@ -5578,7 +5709,7 @@ function decideTargetForManifestEntry(entry, opts, userFilter, haveUserFilter) {
 
 // dist/src/commands/skillify.js
 function stateDir() {
-  return join23(homedir13(), ".deeplake", "state", "skillify");
+  return join24(homedir14(), ".deeplake", "state", "skillify");
 }
 function showStatus() {
   const cfg = loadScopeConfig();
@@ -5586,7 +5717,7 @@ function showStatus() {
   console.log(`team:    ${cfg.team.length === 0 ? "(empty)" : cfg.team.join(", ")}`);
   console.log(`install: ${cfg.install}  (${cfg.install === "global" ? "~/.claude/skills/" : "<project>/.claude/skills/"})`);
   const dir = stateDir();
-  if (!existsSync20(dir)) {
+  if (!existsSync21(dir)) {
     console.log(`state: (no projects tracked yet)`);
     return;
   }
@@ -5598,7 +5729,7 @@ function showStatus() {
   console.log(`state: ${files.length} project(s) tracked`);
   for (const f of files) {
     try {
-      const s = JSON.parse(readFileSync14(join23(dir, f), "utf-8"));
+      const s = JSON.parse(readFileSync15(join24(dir, f), "utf-8"));
       const last = typeof s.updatedAt === "number" ? new Date(s.updatedAt).toISOString() : s.lastDate ?? "never";
       const skills = Array.isArray(s.skillsGenerated) && s.skillsGenerated.length > 0 ? s.skillsGenerated.join(", ") : "none";
       console.log(`  - ${s.project} (counter=${s.counter}, last=${last}, skills=${skills})`);
@@ -5607,8 +5738,8 @@ function showStatus() {
   }
 }
 function setScope(scope) {
-  if (scope !== "me" && scope !== "team" && scope !== "org") {
-    console.error(`Invalid scope '${scope}'. Use one of: me, team, org`);
+  if (scope !== "me" && scope !== "team") {
+    console.error(`Invalid scope '${scope}'. Use one of: me, team`);
     process.exit(1);
   }
   const cfg = loadScopeConfig();
@@ -5625,7 +5756,7 @@ function setInstall(loc) {
   }
   const cfg = loadScopeConfig();
   saveScopeConfig({ ...cfg, install: loc });
-  const path = loc === "global" ? join23(homedir13(), ".claude", "skills") : "<cwd>/.claude/skills";
+  const path = loc === "global" ? join24(homedir14(), ".claude", "skills") : "<cwd>/.claude/skills";
   console.log(`Install location set to '${loc}'. New skills will be written to ${path}/<name>/SKILL.md.`);
 }
 function promoteSkill(name, cwd) {
@@ -5633,13 +5764,13 @@ function promoteSkill(name, cwd) {
     console.error("Usage: hivemind skillify promote <skill-name>");
     process.exit(1);
   }
-  const projectPath = join23(cwd, ".claude", "skills", name);
-  const globalPath = join23(homedir13(), ".claude", "skills", name);
-  if (!existsSync20(join23(projectPath, "SKILL.md"))) {
+  const projectPath = join24(cwd, ".claude", "skills", name);
+  const globalPath = join24(homedir14(), ".claude", "skills", name);
+  if (!existsSync21(join24(projectPath, "SKILL.md"))) {
     console.error(`Skill '${name}' not found at ${projectPath}/SKILL.md`);
     process.exit(1);
   }
-  if (existsSync20(join23(globalPath, "SKILL.md"))) {
+  if (existsSync21(join24(globalPath, "SKILL.md"))) {
     console.error(`Skill '${name}' already exists at ${globalPath}/SKILL.md \u2014 refusing to overwrite. Remove it first or rename the project skill.`);
     process.exit(1);
   }
@@ -5687,7 +5818,7 @@ function teamList() {
 function usage() {
   console.log("Usage:");
   console.log("  hivemind skillify                            show current scope, team, install, and per-project state");
-  console.log("  hivemind skillify scope <me|team|org>        set the mining scope");
+  console.log("  hivemind skillify scope <me|team>            set the mining scope");
   console.log("  hivemind skillify install <project|global>   set where new skills are written");
   console.log("  hivemind skillify promote <skill-name>       move a project skill to the global location");
   console.log("  hivemind skillify team add <username>        add a username to the team list");
@@ -5774,7 +5905,7 @@ async function pullSkills(args) {
     console.error(`pull failed: ${e?.message ?? e}`);
     process.exit(1);
   }
-  const dest = toRaw === "global" ? join23(homedir13(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join24(homedir14(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterDesc = users.length === 0 ? "all users" : users.join(", ");
   console.log(`Destination: ${dest}`);
   console.log(`Filter:      ${filterDesc}${skillName ? ` \xB7 skill='${skillName}'` : ""}${dryRun ? " \xB7 dry-run" : ""}${force ? " \xB7 force" : ""}`);
@@ -5824,7 +5955,7 @@ async function unpullSkills(args) {
     all,
     legacyCleanup
   });
-  const dest = toRaw === "global" ? join23(homedir13(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join24(homedir14(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterParts = [];
   if (users.length > 0)
     filterParts.push(`users=${users.join(",")}`);
@@ -5913,13 +6044,13 @@ if (process.argv[1] && process.argv[1].endsWith("skillify.js")) {
 
 // dist/src/cli/update.js
 import { execFileSync as execFileSync4 } from "node:child_process";
-import { existsSync as existsSync21, readFileSync as readFileSync16, realpathSync } from "node:fs";
+import { existsSync as existsSync22, readFileSync as readFileSync17, realpathSync } from "node:fs";
 import { dirname as dirname6, sep } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync15 } from "node:fs";
-import { dirname as dirname5, join as join24 } from "node:path";
+import { readFileSync as readFileSync16 } from "node:fs";
+import { dirname as dirname5, join as join25 } from "node:path";
 function isNewer(latest, current) {
   const parse = (v) => v.split(".").map(Number);
   const [la, lb, lc] = parse(latest);
@@ -5943,7 +6074,7 @@ function detectInstallKind(argv1) {
   for (let i = 0; i < 10; i++) {
     const pkgPath = `${dir}${sep}package.json`;
     try {
-      const pkg = JSON.parse(readFileSync16(pkgPath, "utf-8"));
+      const pkg = JSON.parse(readFileSync17(pkgPath, "utf-8"));
       if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
         installDir = dir;
         break;
@@ -5964,7 +6095,7 @@ function detectInstallKind(argv1) {
   }
   let gitDir = installDir;
   for (let i = 0; i < 6; i++) {
-    if (existsSync21(`${gitDir}${sep}.git`)) {
+    if (existsSync22(`${gitDir}${sep}.git`)) {
       return { kind: "local-dev", installDir };
     }
     const parent = dirname6(gitDir);
@@ -6137,7 +6268,7 @@ Skill management (mine + share reusable Claude skills across the org):
                                            --to <project|global>, --dry-run,
                                            --all (also locally-mined),
                                            --legacy-cleanup (pre-suffix-author dirs).
-  hivemind skillify scope <me|team|org>     Set the sharing scope for newly mined skills.
+  hivemind skillify scope <me|team>         Set the sharing scope for newly mined skills.
   hivemind skillify install <project|global>  Set where new skills are written.
   hivemind skillify promote <name>          Move a project skill to the global location.
   hivemind skillify team add <username>     Add a username to the team list.

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -588,6 +588,7 @@ function installOpenclaw() {
     throw new Error(`OpenClaw bundle missing at ${srcDist}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR2);
+  rmSync(join6(PLUGIN_DIR2, "dist"), { recursive: true, force: true });
   copyDir(srcDist, join6(PLUGIN_DIR2, "dist"));
   if (existsSync5(srcManifest))
     copyFileSync(srcManifest, join6(PLUGIN_DIR2, "openclaw.plugin.json"));
@@ -4146,10 +4147,12 @@ import { randomUUID } from "node:crypto";
 import { appendFileSync } from "node:fs";
 import { join as join15 } from "node:path";
 import { homedir as homedir6 } from "node:os";
-var DEBUG = process.env.HIVEMIND_DEBUG === "1";
 var LOG = join15(homedir6(), ".deeplake", "hook-debug.log");
+function isDebug() {
+  return process.env.HIVEMIND_DEBUG === "1";
+}
 function log2(tag, msg) {
-  if (!DEBUG)
+  if (!isDebug())
     return;
   appendFileSync(LOG, `${(/* @__PURE__ */ new Date()).toISOString()} [${tag}] ${msg}
 `);
@@ -4195,7 +4198,9 @@ var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
 var BASE_DELAY_MS = 500;
 var MAX_CONCURRENCY = 5;
-var QUERY_TIMEOUT_MS = Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
+function getQueryTimeoutMs() {
+  return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
+}
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -4276,8 +4281,9 @@ var DeeplakeApi = class {
     let lastError;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       let resp;
+      const timeoutMs = getQueryTimeoutMs();
       try {
-        const signal = AbortSignal.timeout(QUERY_TIMEOUT_MS);
+        const signal = AbortSignal.timeout(timeoutMs);
         resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables/query`, {
           method: "POST",
           headers: {
@@ -4291,7 +4297,7 @@ var DeeplakeApi = class {
         });
       } catch (e) {
         if (isTimeoutError(e)) {
-          lastError = new Error(`Query timeout after ${QUERY_TIMEOUT_MS}ms`);
+          lastError = new Error(`Query timeout after ${timeoutMs}ms`);
           throw lastError;
         }
         lastError = e instanceof Error ? e : new Error(String(e));
@@ -6022,33 +6028,69 @@ function extractPairs(rows) {
 }
 
 // dist/src/skillify/gate-runner.js
-import { execFileSync as execFileSync4 } from "node:child_process";
 import { existsSync as existsSync22 } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir as homedir15 } from "node:os";
 import { join as join25 } from "node:path";
+var requireForCp = createRequire(import.meta.url);
+var { execFileSync: runChildProcess } = requireForCp("node:child_process");
+var inheritedEnv = process;
+function firstExistingPath(candidates) {
+  for (const c of candidates) {
+    if (existsSync22(c))
+      return c;
+  }
+  return null;
+}
 function findAgentBin(agent) {
-  const which = (name) => {
-    try {
-      const out = execFileSync4("which", [name], {
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"]
-      });
-      return out.trim() || null;
-    } catch {
-      return null;
-    }
-  };
+  const home = homedir15();
   switch (agent) {
+    // /usr/bin/<name> is included in every candidate list — that's the
+    // common Linux package-manager install path (apt, dnf, pacman). Old
+    // code used `which` which always checked it; the static-scan fix
+    // dropped `which`, so /usr/bin needs to be explicit. CodeRabbit on
+    // #170 caught the gap.
     case "claude_code":
-      return which("claude") ?? join25(homedir15(), ".claude", "local", "claude");
+      return firstExistingPath([
+        join25(home, ".claude", "local", "claude"),
+        "/usr/local/bin/claude",
+        "/usr/bin/claude",
+        join25(home, ".npm-global", "bin", "claude"),
+        join25(home, ".local", "bin", "claude"),
+        "/opt/homebrew/bin/claude"
+      ]) ?? join25(home, ".claude", "local", "claude");
     case "codex":
-      return which("codex") ?? "/usr/local/bin/codex";
+      return firstExistingPath([
+        "/usr/local/bin/codex",
+        "/usr/bin/codex",
+        join25(home, ".npm-global", "bin", "codex"),
+        join25(home, ".local", "bin", "codex"),
+        "/opt/homebrew/bin/codex"
+      ]) ?? "/usr/local/bin/codex";
     case "cursor":
-      return which("cursor-agent") ?? "/usr/local/bin/cursor-agent";
+      return firstExistingPath([
+        "/usr/local/bin/cursor-agent",
+        "/usr/bin/cursor-agent",
+        join25(home, ".npm-global", "bin", "cursor-agent"),
+        join25(home, ".local", "bin", "cursor-agent"),
+        "/opt/homebrew/bin/cursor-agent"
+      ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
-      return which("hermes") ?? join25(homedir15(), ".local", "bin", "hermes");
+      return firstExistingPath([
+        join25(home, ".local", "bin", "hermes"),
+        "/usr/local/bin/hermes",
+        "/usr/bin/hermes",
+        join25(home, ".npm-global", "bin", "hermes"),
+        "/opt/homebrew/bin/hermes"
+      ]) ?? join25(home, ".local", "bin", "hermes");
     case "pi":
-      return which("pi") ?? join25(homedir15(), ".local", "bin", "pi");
+      return firstExistingPath([
+        join25(home, ".local", "bin", "pi"),
+        "/usr/local/bin/pi",
+        "/usr/bin/pi",
+        join25(home, ".npm-global", "bin", "pi"),
+        "/opt/homebrew/bin/pi"
+      ]) ?? join25(home, ".local", "bin", "pi");
   }
 }
 
@@ -7025,7 +7067,7 @@ if (process.argv[1] && process.argv[1].endsWith("skillify.js")) {
 }
 
 // dist/src/cli/update.js
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import { existsSync as existsSync26, readFileSync as readFileSync20, realpathSync } from "node:fs";
 import { dirname as dirname8, sep } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
@@ -7099,7 +7141,7 @@ async function getLatestNpmVersion(timeoutMs = 5e3) {
   }
 }
 var defaultSpawn = (cmd, args) => {
-  execFileSync5(cmd, args, { stdio: "inherit" });
+  execFileSync4(cmd, args, { stdio: "inherit" });
 };
 async function runUpdate(opts = {}) {
   const current = opts.currentVersionOverride ?? getVersion();

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -530,12 +530,15 @@ function ensureHivemindAllowlisted() {
   } catch (e) {
     return { status: "error", configPath, error: `could not read/parse config: ${e instanceof Error ? e.message : String(e)}` };
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { status: "error", configPath, error: "openclaw config is not a JSON object" };
+  }
   const plugins = parsed.plugins ?? {};
   const pluginsAllowRaw = plugins.allow;
   const tools = parsed.tools ?? {};
-  const alsoAllowRaw = Array.isArray(tools.alsoAllow) ? tools.alsoAllow : [];
+  const alsoAllowRaw = tools.alsoAllow;
   const pluginsAllowNeedsPatch = isPluginsAllowMissingHivemind(pluginsAllowRaw);
-  const toolsAlsoAllowNeedsPatch = !isAllowlistCoveringHivemind(alsoAllowRaw);
+  const toolsAlsoAllowNeedsPatch = Array.isArray(alsoAllowRaw) && alsoAllowRaw.length > 0 && !isAllowlistCoveringHivemind(alsoAllowRaw);
   if (!pluginsAllowNeedsPatch && !toolsAlsoAllowNeedsPatch) {
     return { status: "already-set", configPath };
   }
@@ -550,6 +553,7 @@ function ensureHivemindAllowlisted() {
   if (toolsAlsoAllowNeedsPatch) {
     updated.tools = {
       ...tools,
+      // Cast safe — the needs-patch check above guarantees Array.
       alsoAllow: [...alsoAllowRaw, "hivemind"]
     };
   }
@@ -606,6 +610,12 @@ function installOpenclaw() {
     log(`  OpenClaw       capture starts on the NEXT turn \u2014 earlier turns are NOT backfilled`);
   } else if (result.status === "already-set") {
     log(`  OpenClaw       allowlist already covers hivemind in ${result.configPath}`);
+  } else if (result.status === "error") {
+    if (result.error === "openclaw config file not found") {
+      log(`  OpenClaw       openclaw.json not present at ${result.configPath} \u2014 run openclaw once, then \`hivemind claw install\` again`);
+    } else {
+      warn(`  OpenClaw       could not patch allowlist in ${result.configPath}: ${result.error}`);
+    }
   }
 }
 function uninstallOpenclaw() {

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -54,9 +54,6 @@ var init_index_marker_store = __esm({
 
 // dist/src/cli/install-claude.js
 import { execFileSync } from "node:child_process";
-import { existsSync as existsSync2, readFileSync as readFileSync2, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir2 } from "node:os";
-import { join as join2 } from "node:path";
 
 // dist/src/cli/util.js
 import { existsSync, mkdirSync, readFileSync, writeFileSync, cpSync, symlinkSync, unlinkSync, lstatSync } from "node:fs";
@@ -181,75 +178,6 @@ function pluginAlreadyInstalled() {
   return r.stdout.includes(PLUGIN_KEY);
 }
 var PLUGIN_SCOPES = ["user", "project", "local", "managed"];
-function settingsJsonPath() {
-  return join2(homedir2(), ".claude", "settings.json");
-}
-var LEGACY_PATH_FRAGMENT = ".claude/plugins/hivemind/bundle/";
-function isBrokenHivemindHookEntry(h) {
-  if (typeof h.command !== "string")
-    return false;
-  const normalized = h.command.replace(/\\/g, "/");
-  if (!normalized.includes(LEGACY_PATH_FRAGMENT))
-    return false;
-  const match = normalized.match(/"([^"]+\.claude\/plugins\/hivemind\/bundle\/[^"]+)"/);
-  const filePath = match ? match[1] : null;
-  if (!filePath)
-    return false;
-  return !existsSync2(filePath);
-}
-function cleanupBrokenSettingsHooks() {
-  const settingsPath = settingsJsonPath();
-  if (!existsSync2(settingsPath))
-    return { removed: 0, events: [] };
-  let parsed;
-  try {
-    parsed = JSON.parse(readFileSync2(settingsPath, "utf-8"));
-  } catch {
-    return { removed: 0, events: [] };
-  }
-  if (!parsed || typeof parsed !== "object")
-    return { removed: 0, events: [] };
-  const settings = parsed;
-  if (!settings.hooks || typeof settings.hooks !== "object")
-    return { removed: 0, events: [] };
-  let removed = 0;
-  const touchedEvents = [];
-  for (const [event, matchers] of Object.entries(settings.hooks)) {
-    if (!Array.isArray(matchers))
-      continue;
-    const cleanedMatchers = [];
-    let eventTouched = false;
-    for (const m of matchers) {
-      if (!m || !Array.isArray(m.hooks)) {
-        cleanedMatchers.push(m);
-        continue;
-      }
-      const keptHooks = m.hooks.filter((h) => {
-        const broken = isBrokenHivemindHookEntry(h);
-        if (broken) {
-          removed += 1;
-          eventTouched = true;
-        }
-        return !broken;
-      });
-      if (keptHooks.length > 0) {
-        cleanedMatchers.push({ ...m, hooks: keptHooks });
-      } else if (m.hooks.length > 0) {
-        eventTouched = true;
-      } else {
-        cleanedMatchers.push(m);
-      }
-    }
-    if (eventTouched) {
-      settings.hooks[event] = cleanedMatchers;
-      touchedEvents.push(event);
-    }
-  }
-  if (removed > 0) {
-    writeFileSync2(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
-  }
-  return { removed, events: touchedEvents };
-}
 function installClaude() {
   requireClaudeCli();
   if (!marketplaceAlreadyAdded()) {
@@ -272,14 +200,6 @@ function installClaude() {
     log(`  Claude Code    refreshed via marketplace ${MARKETPLACE_SOURCE}`);
   }
   runClaude(["plugin", "enable", PLUGIN_KEY]);
-  try {
-    const cleanup = cleanupBrokenSettingsHooks();
-    if (cleanup.removed > 0) {
-      log(`  Claude Code    settings.json cleaned: removed ${cleanup.removed} stale hook entr${cleanup.removed === 1 ? "y" : "ies"} (events: ${cleanup.events.join(", ")})`);
-    }
-  } catch (e) {
-    log(`  Claude Code    settings.json cleanup skipped: ${e?.message ?? String(e)}`);
-  }
 }
 function uninstallClaude() {
   try {
@@ -294,16 +214,16 @@ function uninstallClaude() {
 }
 
 // dist/src/cli/install-codex.js
-import { existsSync as existsSync3, readFileSync as readFileSync4, unlinkSync as unlinkSync2 } from "node:fs";
+import { existsSync as existsSync2, readFileSync as readFileSync3, unlinkSync as unlinkSync2 } from "node:fs";
 import { execFileSync as execFileSync2 } from "node:child_process";
-import { join as join4 } from "node:path";
+import { join as join3 } from "node:path";
 
 // dist/src/cli/version.js
-import { readFileSync as readFileSync3 } from "node:fs";
-import { join as join3 } from "node:path";
+import { readFileSync as readFileSync2 } from "node:fs";
+import { join as join2 } from "node:path";
 function getVersion() {
   try {
-    const pkg = JSON.parse(readFileSync3(join3(pkgRoot(), "package.json"), "utf-8"));
+    const pkg = JSON.parse(readFileSync2(join2(pkgRoot(), "package.json"), "utf-8"));
     return pkg.version ?? "0.0.0";
   } catch {
     return "0.0.0";
@@ -311,16 +231,16 @@ function getVersion() {
 }
 
 // dist/src/cli/install-codex.js
-var CODEX_HOME = join4(HOME, ".codex");
-var PLUGIN_DIR = join4(CODEX_HOME, "hivemind");
-var HOOKS_PATH = join4(CODEX_HOME, "hooks.json");
-var AGENTS_SKILLS_DIR = join4(HOME, ".agents", "skills");
-var SKILL_LINK = join4(AGENTS_SKILLS_DIR, "hivemind-memory");
+var CODEX_HOME = join3(HOME, ".codex");
+var PLUGIN_DIR = join3(CODEX_HOME, "hivemind");
+var HOOKS_PATH = join3(CODEX_HOME, "hooks.json");
+var AGENTS_SKILLS_DIR = join3(HOME, ".agents", "skills");
+var SKILL_LINK = join3(AGENTS_SKILLS_DIR, "hivemind-memory");
 function hookCmd(bundleFile, timeout, matcher) {
   const block = {
     hooks: [{
       type: "command",
-      command: `node "${join4(PLUGIN_DIR, "bundle", bundleFile)}"`,
+      command: `node "${join3(PLUGIN_DIR, "bundle", bundleFile)}"`,
       timeout
     }]
   };
@@ -394,8 +314,8 @@ function mergeHooks(existing, ours, pluginDir = PLUGIN_DIR) {
 function mergeHooksJson(ours) {
   let existing = {};
   try {
-    if (existsSync3(HOOKS_PATH)) {
-      const parsed = JSON.parse(readFileSync4(HOOKS_PATH, "utf-8"));
+    if (existsSync2(HOOKS_PATH)) {
+      const parsed = JSON.parse(readFileSync3(HOOKS_PATH, "utf-8"));
       if (parsed && typeof parsed === "object")
         existing = parsed;
     }
@@ -434,20 +354,20 @@ function tryEnableCodexHooks() {
   }
 }
 function installCodex() {
-  const srcBundle = join4(pkgRoot(), "codex", "bundle");
-  const srcSkills = join4(pkgRoot(), "codex", "skills");
-  if (!existsSync3(srcBundle)) {
+  const srcBundle = join3(pkgRoot(), "codex", "bundle");
+  const srcSkills = join3(pkgRoot(), "codex", "skills");
+  if (!existsSync2(srcBundle)) {
     throw new Error(`Codex bundle missing at ${srcBundle}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR);
-  copyDir(srcBundle, join4(PLUGIN_DIR, "bundle"));
-  if (existsSync3(srcSkills))
-    copyDir(srcSkills, join4(PLUGIN_DIR, "skills"));
+  copyDir(srcBundle, join3(PLUGIN_DIR, "bundle"));
+  if (existsSync2(srcSkills))
+    copyDir(srcSkills, join3(PLUGIN_DIR, "skills"));
   tryEnableCodexHooks();
   writeJson(HOOKS_PATH, mergeHooksJson(buildHooksJson()));
   ensureDir(AGENTS_SKILLS_DIR);
-  const skillTarget = join4(PLUGIN_DIR, "skills", "deeplake-memory");
-  if (existsSync3(skillTarget)) {
+  const skillTarget = join3(PLUGIN_DIR, "skills", "deeplake-memory");
+  if (existsSync2(skillTarget)) {
     symlinkForce(skillTarget, SKILL_LINK);
   } else {
     warn(`  Codex          skill source missing at ${skillTarget}; skipping symlink`);
@@ -456,10 +376,10 @@ function installCodex() {
   log(`  Codex          installed -> ${PLUGIN_DIR}`);
 }
 function uninstallCodex() {
-  if (existsSync3(HOOKS_PATH)) {
+  if (existsSync2(HOOKS_PATH)) {
     let existing = {};
     try {
-      const raw = JSON.parse(readFileSync4(HOOKS_PATH, "utf-8"));
+      const raw = JSON.parse(readFileSync3(HOOKS_PATH, "utf-8"));
       if (raw && typeof raw === "object")
         existing = raw;
     } catch {
@@ -480,7 +400,7 @@ function uninstallCodex() {
       }
     }
   }
-  if (existsSync3(SKILL_LINK)) {
+  if (existsSync2(SKILL_LINK)) {
     unlinkSync2(SKILL_LINK);
     log(`  Codex          removed ${SKILL_LINK}`);
   }
@@ -490,6 +410,90 @@ function uninstallCodex() {
 // dist/src/cli/install-openclaw.js
 import { existsSync as existsSync4, copyFileSync, rmSync } from "node:fs";
 import { join as join5 } from "node:path";
+
+// dist/openclaw/src/setup-config.js
+import { existsSync as existsSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync2, renameSync } from "node:fs";
+import { homedir as homedir2 } from "node:os";
+import { join as join4 } from "node:path";
+var HIVEMIND_TOOL_NAMES = ["hivemind_search", "hivemind_read", "hivemind_index"];
+function getOpenclawConfigPath() {
+  return join4(homedir2(), ".openclaw", "openclaw.json");
+}
+function isAllowlistCoveringHivemind(alsoAllow) {
+  if (!Array.isArray(alsoAllow))
+    return false;
+  for (const entry of alsoAllow) {
+    if (typeof entry !== "string")
+      continue;
+    const normalized = entry.trim().toLowerCase();
+    if (normalized === "hivemind")
+      return true;
+    if (normalized === "group:plugins")
+      return true;
+    if (HIVEMIND_TOOL_NAMES.includes(normalized))
+      return true;
+  }
+  return false;
+}
+function isPluginsAllowMissingHivemind(allow) {
+  return Array.isArray(allow) && allow.length > 0 && !allow.includes("hivemind");
+}
+function ensureHivemindAllowlisted() {
+  const configPath = getOpenclawConfigPath();
+  if (!existsSync3(configPath)) {
+    return { status: "error", configPath, error: "openclaw config file not found" };
+  }
+  let parsed;
+  try {
+    const raw = readFileSync4(configPath, "utf-8");
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { status: "error", configPath, error: `could not read/parse config: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  const plugins = parsed.plugins ?? {};
+  const pluginsAllowRaw = plugins.allow;
+  const tools = parsed.tools ?? {};
+  const alsoAllowRaw = Array.isArray(tools.alsoAllow) ? tools.alsoAllow : [];
+  const pluginsAllowNeedsPatch = isPluginsAllowMissingHivemind(pluginsAllowRaw);
+  const toolsAlsoAllowNeedsPatch = !isAllowlistCoveringHivemind(alsoAllowRaw);
+  if (!pluginsAllowNeedsPatch && !toolsAlsoAllowNeedsPatch) {
+    return { status: "already-set", configPath };
+  }
+  const updated = { ...parsed };
+  if (pluginsAllowNeedsPatch) {
+    updated.plugins = {
+      ...plugins,
+      // Cast safe — isPluginsAllowMissingHivemind guarantees Array.
+      allow: [...pluginsAllowRaw, "hivemind"]
+    };
+  }
+  if (toolsAlsoAllowNeedsPatch) {
+    updated.tools = {
+      ...tools,
+      alsoAllow: [...alsoAllowRaw, "hivemind"]
+    };
+  }
+  const backupPath = `${configPath}.bak-hivemind-${Date.now()}`;
+  const tmpPath = `${configPath}.tmp-hivemind-${process.pid}`;
+  try {
+    writeFileSync2(backupPath, readFileSync4(configPath, "utf-8"));
+    writeFileSync2(tmpPath, JSON.stringify(updated, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
+  } catch (e) {
+    return { status: "error", configPath, error: `could not write config: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  return {
+    status: "added",
+    configPath,
+    backupPath,
+    delta: {
+      pluginsAllow: pluginsAllowNeedsPatch,
+      toolsAlsoAllow: toolsAlsoAllowNeedsPatch
+    }
+  };
+}
+
+// dist/src/cli/install-openclaw.js
 var PLUGIN_DIR2 = join5(HOME, ".openclaw", "extensions", "hivemind");
 function installOpenclaw() {
   const srcDist = join5(pkgRoot(), "openclaw", "dist");
@@ -500,7 +504,6 @@ function installOpenclaw() {
     throw new Error(`OpenClaw bundle missing at ${srcDist}. Run 'npm run build' first.`);
   }
   ensureDir(PLUGIN_DIR2);
-  rmSync(join5(PLUGIN_DIR2, "dist"), { recursive: true, force: true });
   copyDir(srcDist, join5(PLUGIN_DIR2, "dist"));
   if (existsSync4(srcManifest))
     copyFileSync(srcManifest, join5(PLUGIN_DIR2, "openclaw.plugin.json"));
@@ -510,6 +513,20 @@ function installOpenclaw() {
     copyDir(srcSkills, join5(PLUGIN_DIR2, "skills"));
   writeVersionStamp(PLUGIN_DIR2, getVersion());
   log(`  OpenClaw       installed -> ${PLUGIN_DIR2}`);
+  const result = ensureHivemindAllowlisted();
+  if (result.status === "added") {
+    const touched = [];
+    if (result.delta.pluginsAllow)
+      touched.push("plugins.allow");
+    if (result.delta.toolsAlsoAllow)
+      touched.push("tools.alsoAllow");
+    log(`  OpenClaw       patched ${touched.join(" + ")} in ${result.configPath}`);
+    log(`  OpenClaw       backup: ${result.backupPath}`);
+    log(`  OpenClaw       restart the gateway to activate: systemctl --user restart openclaw-gateway.service`);
+    log(`  OpenClaw       capture starts on the NEXT turn \u2014 earlier turns are NOT backfilled`);
+  } else if (result.status === "already-set") {
+    log(`  OpenClaw       allowlist already covers hivemind in ${result.configPath}`);
+  }
 }
 function uninstallOpenclaw() {
   if (existsSync4(PLUGIN_DIR2)) {
@@ -4039,12 +4056,10 @@ import { randomUUID } from "node:crypto";
 import { appendFileSync } from "node:fs";
 import { join as join14 } from "node:path";
 import { homedir as homedir5 } from "node:os";
+var DEBUG = process.env.HIVEMIND_DEBUG === "1";
 var LOG = join14(homedir5(), ".deeplake", "hook-debug.log");
-function isDebug() {
-  return process.env.HIVEMIND_DEBUG === "1";
-}
 function log2(tag, msg) {
-  if (!isDebug())
+  if (!DEBUG)
     return;
   appendFileSync(LOG, `${(/* @__PURE__ */ new Date()).toISOString()} [${tag}] ${msg}
 `);
@@ -4090,9 +4105,7 @@ var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
 var BASE_DELAY_MS = 500;
 var MAX_CONCURRENCY = 5;
-function getQueryTimeoutMs() {
-  return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
-}
+var QUERY_TIMEOUT_MS = Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -4173,9 +4186,8 @@ var DeeplakeApi = class {
     let lastError;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       let resp;
-      const timeoutMs = getQueryTimeoutMs();
       try {
-        const signal = AbortSignal.timeout(timeoutMs);
+        const signal = AbortSignal.timeout(QUERY_TIMEOUT_MS);
         resp = await fetch(`${this.apiUrl}/workspaces/${this.workspaceId}/tables/query`, {
           method: "POST",
           headers: {
@@ -4189,7 +4201,7 @@ var DeeplakeApi = class {
         });
       } catch (e) {
         if (isTimeoutError(e)) {
-          lastError = new Error(`Query timeout after ${timeoutMs}ms`);
+          lastError = new Error(`Query timeout after ${QUERY_TIMEOUT_MS}ms`);
           throw lastError;
         }
         lastError = e instanceof Error ? e : new Error(String(e));
@@ -4430,14 +4442,13 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
       log3(`table "${tbl}" not found, creating`);
-      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
+      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
       log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
     await this.ensureEmbeddingColumn(tbl, SUMMARY_EMBEDDING_COL);
     await this.ensureColumn(tbl, "agent", "TEXT NOT NULL DEFAULT ''");
-    await this.ensureColumn(tbl, "plugin_version", "TEXT NOT NULL DEFAULT ''");
   }
   /** Create the sessions table (uses JSONB for message since every row is a JSON event). */
   async ensureSessionsTable(name) {
@@ -4445,14 +4456,13 @@ var DeeplakeApi = class {
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
       log3(`table "${safe}" not found, creating`);
-      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
+      await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
       log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
     await this.ensureEmbeddingColumn(safe, MESSAGE_EMBEDDING_COL);
     await this.ensureColumn(safe, "agent", "TEXT NOT NULL DEFAULT ''");
-    await this.ensureColumn(safe, "plugin_version", "TEXT NOT NULL DEFAULT ''");
     await this.ensureLookupIndex(safe, "path_creation_date", `("path", "creation_date")`);
   }
   /**
@@ -4807,9 +4817,9 @@ if (process.argv[1] && process.argv[1].endsWith("auth-login.js")) {
 }
 
 // dist/src/commands/skillify.js
-import { readdirSync as readdirSync5, existsSync as existsSync24, readFileSync as readFileSync17, mkdirSync as mkdirSync10, renameSync as renameSync4 } from "node:fs";
-import { homedir as homedir17 } from "node:os";
-import { dirname as dirname6, join as join27 } from "node:path";
+import { readdirSync as readdirSync4, existsSync as existsSync20, readFileSync as readFileSync14, mkdirSync as mkdirSync8, renameSync as renameSync5 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { dirname as dirname4, join as join23 } from "node:path";
 
 // dist/src/skillify/scope-config.js
 import { existsSync as existsSync14, mkdirSync as mkdirSync4, readFileSync as readFileSync10, writeFileSync as writeFileSync7 } from "node:fs";
@@ -4817,7 +4827,7 @@ import { homedir as homedir7 } from "node:os";
 import { join as join17 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync13, renameSync } from "node:fs";
+import { existsSync as existsSync13, renameSync as renameSync2 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { join as join16 } from "node:path";
 var dlog = (msg) => log2("skillify-migrate", msg);
@@ -4834,7 +4844,7 @@ function migrateLegacyStateDir() {
   if (existsSync13(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -4856,7 +4866,7 @@ function loadScopeConfig() {
     return DEFAULT;
   try {
     const raw = JSON.parse(readFileSync10(CONFIG_PATH2, "utf-8"));
-    const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
+    const scope = raw.scope === "team" || raw.scope === "org" ? raw.scope : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
     return { scope, team, install };
@@ -4871,7 +4881,7 @@ function saveScopeConfig(cfg) {
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync18, readFileSync as readFileSync13, writeFileSync as writeFileSync10, mkdirSync as mkdirSync7, renameSync as renameSync3, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync8 } from "node:fs";
+import { existsSync as existsSync18, readFileSync as readFileSync13, writeFileSync as writeFileSync10, mkdirSync as mkdirSync7, renameSync as renameSync4, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync8 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
 import { dirname as dirname3, join as join21 } from "node:path";
 
@@ -4893,35 +4903,6 @@ function assertValidSkillName(name) {
     throw new Error(`invalid skill name: must be kebab-case (lowercase a-z, 0-9, hyphen): ${name}`);
   }
 }
-function skillDir(skillsRoot, name) {
-  return join18(skillsRoot, name);
-}
-function skillPath(skillsRoot, name) {
-  return join18(skillDir(skillsRoot, name), "SKILL.md");
-}
-function renderFrontmatter(fm) {
-  const lines = ["---"];
-  lines.push(`name: ${fm.name}`);
-  lines.push(`description: ${JSON.stringify(fm.description)}`);
-  if (fm.trigger)
-    lines.push(`trigger: ${JSON.stringify(fm.trigger)}`);
-  if (fm.author)
-    lines.push(`author: ${fm.author}`);
-  lines.push(`source_sessions:`);
-  for (const s of fm.source_sessions)
-    lines.push(`  - ${s}`);
-  if (fm.contributors && fm.contributors.length > 0) {
-    lines.push(`contributors:`);
-    for (const c of fm.contributors)
-      lines.push(`  - ${c}`);
-  }
-  lines.push(`version: ${fm.version}`);
-  lines.push(`created_by_agent: ${fm.created_by_agent}`);
-  lines.push(`created_at: ${fm.created_at}`);
-  lines.push(`updated_at: ${fm.updated_at}`);
-  lines.push("---");
-  return lines.join("\n");
-}
 function parseFrontmatter(text) {
   if (!text.startsWith("---\n") && !text.startsWith("---\r\n"))
     return null;
@@ -4931,25 +4912,18 @@ function parseFrontmatter(text) {
   const head = text.slice(4, end).trim();
   const body = text.slice(end + 4).replace(/^\r?\n/, "");
   const fm = { source_sessions: [] };
-  let arrayKey = null;
+  let mode = "kv";
   for (const raw of head.split(/\r?\n/)) {
-    if (arrayKey) {
+    if (mode === "sources") {
       const m2 = raw.match(/^\s+-\s+(.+)$/);
       if (m2) {
-        const arr = fm[arrayKey] ?? [];
-        arr.push(m2[1].trim());
-        fm[arrayKey] = arr;
+        fm.source_sessions.push(m2[1].trim());
         continue;
       }
-      arrayKey = null;
+      mode = "kv";
     }
     if (raw.startsWith("source_sessions:")) {
-      arrayKey = "source_sessions";
-      continue;
-    }
-    if (raw.startsWith("contributors:")) {
-      arrayKey = "contributors";
-      fm.contributors = [];
+      mode = "sources";
       continue;
     }
     const m = raw.match(/^([a-zA-Z_]+):\s*(.*)$/);
@@ -4971,65 +4945,9 @@ function parseFrontmatter(text) {
   }
   return { fm, body };
 }
-function writeNewSkill(args) {
-  assertValidSkillName(args.name);
-  const dir = skillDir(args.skillsRoot, args.name);
-  const path = skillPath(args.skillsRoot, args.name);
-  if (existsSync15(path)) {
-    throw new Error(`skill already exists at ${path}; use mergeSkill`);
-  }
-  mkdirSync5(dir, { recursive: true });
-  const now = (/* @__PURE__ */ new Date()).toISOString();
-  const author = args.author && args.author.length > 0 ? args.author : void 0;
-  const contributors = author ? [author] : [];
-  const fm = {
-    name: args.name,
-    description: args.description,
-    trigger: args.trigger,
-    author,
-    source_sessions: args.sourceSessions,
-    contributors,
-    version: 1,
-    created_by_agent: args.agent,
-    created_at: now,
-    updated_at: now
-  };
-  const text = `${renderFrontmatter(fm)}
-
-${args.body.trim()}
-`;
-  writeFileSync8(path, text);
-  return {
-    path,
-    action: "created",
-    version: 1,
-    createdAt: now,
-    updatedAt: now,
-    author,
-    contributors
-  };
-}
-function listSkills(skillsRoot) {
-  if (!existsSync15(skillsRoot))
-    return [];
-  const out = [];
-  for (const name of readdirSync2(skillsRoot)) {
-    const skillFile = join18(skillsRoot, name, "SKILL.md");
-    if (existsSync15(skillFile) && statSync2(skillFile).isFile()) {
-      out.push({ name, body: readFileSync11(skillFile, "utf-8") });
-    }
-  }
-  return out;
-}
-function resolveSkillsRoot(install, cwd) {
-  if (install === "global") {
-    return join18(homedir8(), ".claude", "skills");
-  }
-  return join18(cwd, ".claude", "skills");
-}
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync16, lstatSync as lstatSync3, mkdirSync as mkdirSync6, readFileSync as readFileSync12, renameSync as renameSync2, unlinkSync as unlinkSync7, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync16, lstatSync as lstatSync3, mkdirSync as mkdirSync6, readFileSync as readFileSync12, renameSync as renameSync3, unlinkSync as unlinkSync7, writeFileSync as writeFileSync9 } from "node:fs";
 import { homedir as homedir9 } from "node:os";
 import { dirname as dirname2, join as join19 } from "node:path";
 function emptyManifest() {
@@ -5094,7 +5012,7 @@ function saveManifest(m, path = manifestPath()) {
   mkdirSync6(dirname2(path), { recursive: true });
   const tmp = `${path}.tmp`;
   writeFileSync9(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -5195,18 +5113,10 @@ function buildPullSql(args) {
     where.push(`name = '${esc(args.skillName)}'`);
   }
   const whereClause = where.length > 0 ? ` WHERE ${where.join(" AND ")}` : "";
-  const contributorsCol = args.includeContributors === false ? "" : "contributors, ";
-  return `SELECT name, project, project_key, body, version, source_agent, scope, author, ${contributorsCol}description, trigger_text, source_sessions, install, created_at, updated_at FROM "${args.tableName}"${whereClause} ORDER BY project_key ASC, name ASC, version DESC`;
-}
-function isMissingContributorsColumnError(message) {
-  if (!message)
-    return false;
-  return /contributors.*(?:does not exist|not found|unknown)/i.test(message) || /(?:does not exist|unknown column).*contributors/i.test(message);
+  return `SELECT name, project, project_key, body, version, source_agent, scope, author, description, trigger_text, source_sessions, install, created_at, updated_at FROM "${args.tableName}"${whereClause} ORDER BY project_key ASC, name ASC, version DESC`;
 }
 function isMissingTableError(message) {
   if (!message)
-    return false;
-  if (/\bcolumn\b/i.test(message))
     return false;
   return /Table does not exist|relation .* does not exist|no such table/i.test(message);
 }
@@ -5303,23 +5213,18 @@ function selectLatestPerName(rows) {
 }
 function renderSkillFile(row) {
   const sources = parseSourceSessions(row.source_sessions);
-  const author = typeof row.author === "string" && row.author.length > 0 ? row.author : void 0;
-  const contributors = parseContributors(row.contributors);
-  const renderedContributors = contributors.length > 0 ? contributors : author ? [author] : [];
   const fm = {
     name: String(row.name ?? ""),
     description: String(row.description ?? ""),
     trigger: typeof row.trigger_text === "string" && row.trigger_text.length > 0 ? String(row.trigger_text) : void 0,
-    author,
     source_sessions: sources,
-    contributors: renderedContributors,
     version: Number(row.version ?? 1),
     created_by_agent: String(row.source_agent ?? "unknown"),
     created_at: String(row.created_at ?? (/* @__PURE__ */ new Date()).toISOString()),
     updated_at: String(row.updated_at ?? (/* @__PURE__ */ new Date()).toISOString())
   };
   const body = String(row.body ?? "").trim();
-  return `${renderFrontmatter2(fm)}
+  return `${renderFrontmatter(fm)}
 
 ${body}
 `;
@@ -5337,35 +5242,15 @@ function parseSourceSessions(v) {
   }
   return [];
 }
-function parseContributors(v) {
-  if (Array.isArray(v))
-    return v.map(String);
-  if (typeof v === "string") {
-    try {
-      const parsed = JSON.parse(v);
-      if (Array.isArray(parsed))
-        return parsed.map(String);
-    } catch {
-    }
-  }
-  return [];
-}
-function renderFrontmatter2(fm) {
+function renderFrontmatter(fm) {
   const lines = ["---"];
   lines.push(`name: ${fm.name}`);
   lines.push(`description: ${JSON.stringify(fm.description)}`);
   if (fm.trigger)
     lines.push(`trigger: ${JSON.stringify(fm.trigger)}`);
-  if (fm.author)
-    lines.push(`author: ${fm.author}`);
   lines.push(`source_sessions:`);
   for (const s of fm.source_sessions)
     lines.push(`  - ${s}`);
-  if (fm.contributors && fm.contributors.length > 0) {
-    lines.push(`contributors:`);
-    for (const c of fm.contributors)
-      lines.push(`  - ${c}`);
-  }
   lines.push(`version: ${fm.version}`);
   lines.push(`created_by_agent: ${fm.created_by_agent}`);
   lines.push(`created_at: ${fm.created_at}`);
@@ -5405,19 +5290,10 @@ async function runPull(opts) {
   try {
     rows = await opts.query(sql);
   } catch (e) {
-    if (isMissingTableError(e?.message)) {
+    if (isMissingTableError(e?.message))
       rows = [];
-    } else if (isMissingContributorsColumnError(e?.message)) {
-      const legacySql = buildPullSql({
-        tableName: opts.tableName,
-        users: opts.users,
-        skillName: opts.skillName,
-        includeContributors: false
-      });
-      rows = await opts.query(legacySql);
-    } else {
+    else
       throw e;
-    }
   }
   const latest = selectLatestPerName(rows);
   const root = resolvePullDestination(opts.install, opts.cwd);
@@ -5472,8 +5348,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir2 = join21(root, dirName);
-    const skillFile = join21(skillDir2, "SKILL.md");
+    const skillDir = join21(root, dirName);
+    const skillFile = join21(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -5484,15 +5360,15 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync7(skillDir2, { recursive: true });
+      mkdirSync7(skillDir, { recursive: true });
       if (existsSync18(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
       writeFileSync10(skillFile, renderSkillFile(row));
-      const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir2, dirName, detectAgentSkillsRoots(root)) : [];
+      const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
           dirName,
@@ -5700,949 +5576,9 @@ function decideTargetForManifestEntry(entry, opts, userFilter, haveUserFilter) {
   return { shouldRemove: true };
 }
 
-// dist/src/commands/mine-local.js
-import { spawn } from "node:child_process";
-import { existsSync as existsSync23, mkdirSync as mkdirSync9, readFileSync as readFileSync16, writeFileSync as writeFileSync12 } from "node:fs";
-import { homedir as homedir16 } from "node:os";
-import { basename, dirname as dirname5, join as join26 } from "node:path";
-
-// dist/src/skillify/local-source.js
-import { readdirSync as readdirSync4, readFileSync as readFileSync14, existsSync as existsSync20, statSync as statSync4 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { join as join23 } from "node:path";
-var HOME2 = homedir13();
-function encodeCwdClaudeCode(cwd) {
-  return cwd.replace(/[/_]/g, "-");
-}
-function detectInstalledAgents() {
-  const installs = [];
-  const claudeRoot = join23(HOME2, ".claude", "projects");
-  if (existsSync20(claudeRoot)) {
-    installs.push({
-      agent: "claude_code",
-      sessionRoot: claudeRoot,
-      encodeCwd: encodeCwdClaudeCode
-    });
-  }
-  const codexRoot = join23(HOME2, ".codex", "sessions");
-  if (existsSync20(codexRoot)) {
-    installs.push({
-      agent: "codex",
-      sessionRoot: codexRoot,
-      encodeCwd: () => "__cwd_unknown__"
-    });
-  }
-  return installs;
-}
-function detectHostAgent() {
-  if (process.env.CLAUDECODE === "1" || process.env.CLAUDE_CODE_ENTRYPOINT)
-    return "claude_code";
-  if (process.env.CODEX_HOME || process.env.CODEX_SESSION_ID)
-    return "codex";
-  return null;
-}
-function listLocalSessions(installs, cwd) {
-  const out = [];
-  for (const install of installs) {
-    const cwdEncoded = install.encodeCwd(cwd);
-    let subdirs = [];
-    try {
-      subdirs = readdirSync4(install.sessionRoot);
-    } catch {
-      continue;
-    }
-    for (const sub of subdirs) {
-      const subdirPath = join23(install.sessionRoot, sub);
-      try {
-        if (!statSync4(subdirPath).isDirectory())
-          continue;
-      } catch {
-        continue;
-      }
-      const inCwd = sub === cwdEncoded;
-      let files = [];
-      try {
-        files = readdirSync4(subdirPath);
-      } catch {
-        continue;
-      }
-      for (const f of files) {
-        if (!f.endsWith(".jsonl"))
-          continue;
-        const fullPath = join23(subdirPath, f);
-        let stats;
-        try {
-          stats = statSync4(fullPath);
-        } catch {
-          continue;
-        }
-        if (!stats.isFile())
-          continue;
-        const sessionId = f.replace(/\.jsonl$/, "");
-        out.push({
-          agent: install.agent,
-          path: fullPath,
-          mtime: stats.mtimeMs,
-          inCwd,
-          sessionId
-        });
-      }
-    }
-  }
-  return out;
-}
-function pickSessions(candidates, opts) {
-  const { n, epsilon } = opts;
-  if (n <= 0 || candidates.length === 0)
-    return [];
-  const sorted = [...candidates].sort((a, b) => b.mtime - a.mtime);
-  const cwdQuota = Math.ceil((1 - epsilon) * n);
-  const globalQuota = Math.floor(epsilon * n);
-  const picked = [];
-  const taken = /* @__PURE__ */ new Set();
-  for (const s of sorted) {
-    if (picked.length >= cwdQuota)
-      break;
-    if (s.inCwd && !taken.has(s.path)) {
-      picked.push(s);
-      taken.add(s.path);
-    }
-  }
-  const cap2 = picked.length + globalQuota;
-  for (const s of sorted) {
-    if (picked.length >= cap2)
-      break;
-    if (!taken.has(s.path)) {
-      picked.push(s);
-      taken.add(s.path);
-    }
-  }
-  for (const s of sorted) {
-    if (picked.length >= n)
-      break;
-    if (!taken.has(s.path)) {
-      picked.push(s);
-      taken.add(s.path);
-    }
-  }
-  return picked;
-}
-function nativeJsonlToRows(filePath, sessionId, agent) {
-  let raw;
-  try {
-    raw = readFileSync14(filePath, "utf-8");
-  } catch {
-    return [];
-  }
-  const rows = [];
-  let pendingAsstText;
-  let pendingAsstTs;
-  const flushAssistant = () => {
-    if (pendingAsstText && pendingAsstText.trim().length > 0) {
-      rows.push({
-        type: "assistant_message",
-        content: pendingAsstText,
-        creation_date: pendingAsstTs,
-        session_id: sessionId,
-        agent
-      });
-    }
-    pendingAsstText = void 0;
-    pendingAsstTs = void 0;
-  };
-  for (const line of raw.split(/\n/)) {
-    if (!line)
-      continue;
-    let obj;
-    try {
-      obj = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    const t = obj?.type;
-    const ts = obj?.timestamp ?? obj?.created_at;
-    if (t === "user") {
-      const c = obj?.message?.content;
-      if (typeof c === "string" && c.trim().length > 0) {
-        flushAssistant();
-        rows.push({
-          type: "user_message",
-          content: c,
-          creation_date: ts,
-          session_id: sessionId,
-          agent
-        });
-      }
-    } else if (t === "assistant") {
-      const c = obj?.message?.content;
-      if (Array.isArray(c)) {
-        const text = c.filter((b) => b?.type === "text" && typeof b.text === "string").map((b) => b.text).join("\n\n");
-        if (text.trim().length > 0) {
-          pendingAsstText = text;
-          pendingAsstTs = ts;
-        }
-      }
-    }
-  }
-  flushAssistant();
-  return rows;
-}
-
-// dist/src/skillify/extractors/index.js
-function extractPairs(rows) {
-  const pairs2 = [];
-  let pendingPrompt = null;
-  let pendingAnswer = [];
-  function flush() {
-    if (pendingPrompt && pendingAnswer.length > 0) {
-      pairs2.push({
-        sessionId: pendingPrompt.row.session_id ?? "",
-        agent: pendingPrompt.row.agent ?? null,
-        date: pendingPrompt.row.creation_date ?? null,
-        prompt: pendingPrompt.content,
-        answer: pendingAnswer.join("\n\n")
-      });
-    }
-    pendingPrompt = null;
-    pendingAnswer = [];
-  }
-  for (const r of rows) {
-    if (r.type === "user_message" && typeof r.content === "string") {
-      flush();
-      pendingPrompt = { content: r.content, row: r };
-    } else if (r.type === "assistant_message" && typeof r.content === "string" && pendingPrompt) {
-      if (r.content.trim().length > 0)
-        pendingAnswer.push(r.content);
-    }
-  }
-  flush();
-  return pairs2;
-}
-
-// dist/src/skillify/gate-runner.js
-import { existsSync as existsSync21 } from "node:fs";
-import { createRequire } from "node:module";
-import { homedir as homedir14 } from "node:os";
-import { join as join24 } from "node:path";
-var requireForCp = createRequire(import.meta.url);
-var { execFileSync: runChildProcess } = requireForCp("node:child_process");
-var inheritedEnv = process;
-function firstExistingPath(candidates) {
-  for (const c of candidates) {
-    if (existsSync21(c))
-      return c;
-  }
-  return null;
-}
-function findAgentBin(agent) {
-  const home = homedir14();
-  switch (agent) {
-    // /usr/bin/<name> is included in every candidate list — that's the
-    // common Linux package-manager install path (apt, dnf, pacman). Old
-    // code used `which` which always checked it; the static-scan fix
-    // dropped `which`, so /usr/bin needs to be explicit. CodeRabbit on
-    // #170 caught the gap.
-    case "claude_code":
-      return firstExistingPath([
-        join24(home, ".claude", "local", "claude"),
-        "/usr/local/bin/claude",
-        "/usr/bin/claude",
-        join24(home, ".npm-global", "bin", "claude"),
-        join24(home, ".local", "bin", "claude"),
-        "/opt/homebrew/bin/claude"
-      ]) ?? join24(home, ".claude", "local", "claude");
-    case "codex":
-      return firstExistingPath([
-        "/usr/local/bin/codex",
-        "/usr/bin/codex",
-        join24(home, ".npm-global", "bin", "codex"),
-        join24(home, ".local", "bin", "codex"),
-        "/opt/homebrew/bin/codex"
-      ]) ?? "/usr/local/bin/codex";
-    case "cursor":
-      return firstExistingPath([
-        "/usr/local/bin/cursor-agent",
-        "/usr/bin/cursor-agent",
-        join24(home, ".npm-global", "bin", "cursor-agent"),
-        join24(home, ".local", "bin", "cursor-agent"),
-        "/opt/homebrew/bin/cursor-agent"
-      ]) ?? "/usr/local/bin/cursor-agent";
-    case "hermes":
-      return firstExistingPath([
-        join24(home, ".local", "bin", "hermes"),
-        "/usr/local/bin/hermes",
-        "/usr/bin/hermes",
-        join24(home, ".npm-global", "bin", "hermes"),
-        "/opt/homebrew/bin/hermes"
-      ]) ?? join24(home, ".local", "bin", "hermes");
-    case "pi":
-      return firstExistingPath([
-        join24(home, ".local", "bin", "pi"),
-        "/usr/local/bin/pi",
-        "/usr/bin/pi",
-        join24(home, ".npm-global", "bin", "pi"),
-        "/opt/homebrew/bin/pi"
-      ]) ?? join24(home, ".local", "bin", "pi");
-  }
-}
-
-// dist/src/skillify/gate-parser.js
-function extractJsonBlock(s) {
-  const trimmed = s.trim();
-  if (!trimmed)
-    return null;
-  const fenced = trimmed.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
-  if (fenced)
-    return fenced[1].trim();
-  const start = trimmed.indexOf("{");
-  if (start < 0)
-    return null;
-  let depth = 0;
-  for (let i = start; i < trimmed.length; i++) {
-    const c = trimmed[i];
-    if (c === "{")
-      depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0)
-        return trimmed.slice(start, i + 1);
-    }
-  }
-  return null;
-}
-
-// dist/src/skillify/local-manifest.js
-import { existsSync as existsSync22, mkdirSync as mkdirSync8, readFileSync as readFileSync15, writeFileSync as writeFileSync11 } from "node:fs";
-import { homedir as homedir15 } from "node:os";
-import { dirname as dirname4, join as join25 } from "node:path";
-var LOCAL_MANIFEST_PATH = join25(homedir15(), ".claude", "hivemind", "local-mined.json");
-var LOCAL_MINE_LOCK_PATH = join25(homedir15(), ".claude", "hivemind", "local-mined.lock");
-function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
-  if (!existsSync22(path))
-    return null;
-  try {
-    return JSON.parse(readFileSync15(path, "utf-8"));
-  } catch {
-    return null;
-  }
-}
-function writeLocalManifest(m, path = LOCAL_MANIFEST_PATH) {
-  mkdirSync8(dirname4(path), { recursive: true });
-  writeFileSync11(path, JSON.stringify(m, null, 2));
-}
-
-// dist/src/commands/mine-local.js
-import { unlinkSync as unlinkSync9 } from "node:fs";
-var EPSILON = 0.3;
-var DEFAULT_N = 8;
-var PAIR_CHAR_CAP = 4e3;
-var PER_SESSION_PAIR_CAP = 30;
-var PER_SESSION_PROMPT_CAP = 12e4;
-var GATE_CONCURRENCY = 4;
-var IN_FLIGHT_MAX_AGE_MS = 6e4;
-var GATE_TIMEOUT_MS = 24e4;
-var MANIFEST_PATH = LOCAL_MANIFEST_PATH;
-function runGateViaStdin(opts) {
-  return new Promise((resolve) => {
-    if (opts.agent !== "claude_code") {
-      resolve({
-        stdout: "",
-        stderr: "",
-        errored: true,
-        errorMessage: `stdin gate runner only supports claude_code (got ${opts.agent}); for other agents the prompt must fit in argv`
-      });
-      return;
-    }
-    if (!existsSync23(opts.bin)) {
-      resolve({
-        stdout: "",
-        stderr: "",
-        errored: true,
-        errorMessage: `agent binary not found at ${opts.bin}`
-      });
-      return;
-    }
-    const args = [
-      "-p",
-      "--no-session-persistence",
-      "--model",
-      "haiku",
-      "--permission-mode",
-      "bypassPermissions"
-    ];
-    const child = spawn(opts.bin, args, {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" }
-    });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    const finish = (r) => {
-      if (settled)
-        return;
-      settled = true;
-      resolve(r);
-    };
-    const timer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-      }
-      finish({
-        stdout,
-        stderr,
-        errored: true,
-        errorMessage: `gate timed out after ${opts.timeoutMs}ms`
-      });
-    }, opts.timeoutMs);
-    child.stdout.on("data", (b) => {
-      stdout += b.toString("utf-8");
-    });
-    child.stderr.on("data", (b) => {
-      stderr += b.toString("utf-8");
-    });
-    child.on("error", (e) => {
-      clearTimeout(timer);
-      finish({ stdout, stderr, errored: true, errorMessage: e.message });
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      finish({
-        stdout,
-        stderr,
-        errored: code !== 0,
-        errorMessage: code !== 0 ? `claude_code CLI exited with code ${code}` : void 0
-      });
-    });
-    child.stdin.on("error", (e) => {
-      clearTimeout(timer);
-      finish({ stdout, stderr, errored: true, errorMessage: `stdin write failed: ${e.message}` });
-    });
-    child.stdin.end(opts.prompt);
-  });
-}
-var loadManifest2 = readLocalManifest;
-var saveManifest2 = writeLocalManifest;
-function truncate(s, max) {
-  if (s.length <= max)
-    return s;
-  return s.slice(0, max) + `
-[\u2026truncated ${s.length - max} chars]`;
-}
-function renderPairsBlock(pairs2) {
-  let total = 0;
-  const out = [];
-  for (const [i, p] of pairs2.entries()) {
-    const block = `--- exchange ${i + 1} ---
-USER:
-${truncate(p.prompt, PAIR_CHAR_CAP)}
-
-ASSISTANT:
-${truncate(p.answer, PAIR_CHAR_CAP)}
-`;
-    if (total + block.length > PER_SESSION_PROMPT_CAP) {
-      out.push(`[\u2026${pairs2.length - i} more exchanges omitted to stay under budget]`);
-      break;
-    }
-    out.push(block);
-    total += block.length;
-  }
-  return out.join("\n");
-}
-function buildSessionPrompt(pairs2, session, verdictPath) {
-  return [
-    `You are a skill curator examining ONE session of recent agent activity.`,
-    `Your job: identify up to 3 distinct, non-overlapping reusable skills hiding in this session.`,
-    `Distinct = different problem domains. Empty list is fine if nothing qualifies.`,
-    ``,
-    `Session: ${session.sessionId} (agent: ${session.agent})`,
-    ``,
-    `RULES:`,
-    `- A skill qualifies if it captures a concrete, repeatable workflow OR a non-obvious`,
-    `  constraint/gotcha a future engineer would benefit from knowing. Intra-session is fine \u2014`,
-    `  one deep dive yielding a generalizable takeaway counts.`,
-    `- Skip patterns that are obvious from reading the codebase or already in CLAUDE.md.`,
-    `- Each body uses short sections (When to use, Workflow, Anti-patterns), concrete commands`,
-    `  / paths / snippets drawn from the exchanges below, no marketing, no emojis.`,
-    `- Each body under ~3000 characters.`,
-    `- Skill names are kebab-case slugs (lowercase letters/digits/hyphens only).`,
-    ``,
-    `=== EXCHANGES (user prompts + assistant final answers, tool calls stripped) ===`,
-    renderPairsBlock(pairs2),
-    ``,
-    `=== YOUR TASK ===`,
-    `Output a single JSON object. You may either:`,
-    `  (a) Write the JSON to this exact path using the Write tool: ${verdictPath}`,
-    `  (b) Print the JSON object to stdout as your final message, nothing else.`,
-    `Pick whichever you prefer. Do not do both.`,
-    ``,
-    `Required shape:`,
-    `{`,
-    `  "reason": "<one-line justification>",`,
-    `  "skills": [`,
-    `    {`,
-    `      "name": "<kebab-case>",`,
-    `      "description": "<one-line>",`,
-    `      "trigger": "<short trigger>",`,
-    `      "body": "<full SKILL.md body without frontmatter>"`,
-    `    },`,
-    `    ... up to 3 entries, or [] if nothing qualifies`,
-    `  ]`,
-    `}`,
-    ``,
-    `If you print to stdout, do not include any prose before or after the JSON.`
-  ].join("\n");
-}
-function parseMultiVerdict(raw) {
-  const block = extractJsonBlock(raw);
-  if (!block)
-    return null;
-  let parsed;
-  try {
-    parsed = JSON.parse(block);
-  } catch {
-    return null;
-  }
-  if (!parsed || typeof parsed !== "object")
-    return null;
-  const skills = parsed.skills;
-  if (!Array.isArray(skills))
-    return null;
-  const out = [];
-  for (const s of skills) {
-    if (!s || typeof s !== "object")
-      continue;
-    const name = typeof s.name === "string" ? s.name.trim() : "";
-    const description = typeof s.description === "string" ? s.description.trim() : "";
-    const body = typeof s.body === "string" ? s.body.trim() : "";
-    const trigger = typeof s.trigger === "string" ? s.trigger.trim() : void 0;
-    if (!name || !body)
-      continue;
-    out.push({ name, description, body, trigger });
-  }
-  return { reason: typeof parsed.reason === "string" ? parsed.reason : void 0, skills: out };
-}
-function gateAgentFor(host, fallback, installs) {
-  const installed = new Set(installs.map((i) => i.agent));
-  if (installed.has("claude_code"))
-    return "claude_code";
-  return host ?? fallback;
-}
-async function parallelMap(items, concurrency, fn) {
-  const results = new Array(items.length);
-  let cursor = 0;
-  const workers = [];
-  for (let w = 0; w < Math.min(concurrency, items.length); w++) {
-    workers.push((async () => {
-      while (true) {
-        const i = cursor++;
-        if (i >= items.length)
-          return;
-        results[i] = await fn(items[i], i);
-      }
-    })());
-  }
-  await Promise.all(workers);
-  return results;
-}
-var SUMMARY_STOPWORDS = /* @__PURE__ */ new Set([
-  "the",
-  "and",
-  "for",
-  "with",
-  "from",
-  "into",
-  "via",
-  "this",
-  "that",
-  "your",
-  "you",
-  "are",
-  "was",
-  "were",
-  "use",
-  "using",
-  "uses",
-  "used",
-  "skill",
-  "when",
-  "what",
-  "where",
-  "which",
-  "while",
-  "how",
-  "non",
-  "any",
-  "all",
-  "code",
-  "file",
-  "files",
-  "way",
-  "ways",
-  "via"
-]);
-function summaryTokens(s) {
-  return new Set(s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 3 && !SUMMARY_STOPWORDS.has(t)));
-}
-function jaccard(a, b) {
-  if (a.size === 0 || b.size === 0)
-    return 0;
-  let intersection = 0;
-  for (const t of a)
-    if (b.has(t))
-      intersection++;
-  return intersection / (a.size + b.size - intersection);
-}
-var OVERLAP_THRESHOLD = 0.4;
-function findOverlap(candidateDesc, others) {
-  const ct = summaryTokens(candidateDesc);
-  let best = null;
-  for (const e of others) {
-    const score = jaccard(ct, summaryTokens(e.desc));
-    if (score >= OVERLAP_THRESHOLD && (!best || score > best.score)) {
-      best = { name: e.name, score };
-    }
-  }
-  return best;
-}
-function loadExistingSummaries(skillsRoot) {
-  const out = [];
-  for (const s of listSkills(skillsRoot)) {
-    const parsed = parseFrontmatter(s.body);
-    const desc = parsed?.fm.description ?? "";
-    if (desc)
-      out.push({ name: s.name, desc });
-  }
-  return out;
-}
-function takeFlagValue(args, flag) {
-  const idx = args.indexOf(flag);
-  if (idx < 0)
-    return null;
-  const v = args[idx + 1];
-  if (v === void 0 || v.startsWith("--")) {
-    console.error(`${flag} requires a value`);
-    process.exit(1);
-  }
-  args.splice(idx, 2);
-  return v;
-}
-function takeBoolFlag(args, flag) {
-  const idx = args.indexOf(flag);
-  if (idx < 0)
-    return false;
-  args.splice(idx, 1);
-  return true;
-}
-async function runMineLocal(args) {
-  let lockReleased = false;
-  const releaseLock = () => {
-    if (lockReleased)
-      return;
-    lockReleased = true;
-    try {
-      unlinkSync9(LOCAL_MINE_LOCK_PATH);
-    } catch {
-    }
-  };
-  process.on("exit", releaseLock);
-  try {
-    return await runMineLocalImpl(args);
-  } finally {
-    releaseLock();
-  }
-}
-async function runMineLocalImpl(args) {
-  const work = [...args];
-  const force = takeBoolFlag(work, "--force");
-  const dryRun = takeBoolFlag(work, "--dry-run");
-  const nRaw = takeFlagValue(work, "--n");
-  if (loadManifest2() && !force) {
-    console.error(`Local skills have already been mined on this machine.`);
-    console.error(`Manifest: ${MANIFEST_PATH}`);
-    console.error(`Pass --force to re-mine.`);
-    process.exit(1);
-  }
-  const installs = detectInstalledAgents();
-  if (installs.length === 0) {
-    console.error(`No agent session directories detected. Run a session first.`);
-    process.exit(1);
-  }
-  console.log(`Detected installed agents: ${installs.map((i) => i.agent).join(", ")}`);
-  const host = detectHostAgent();
-  const fallback = installs[0].agent;
-  const gateAgent = gateAgentFor(host, fallback, installs);
-  if (gateAgent !== "claude_code") {
-    console.error(`mine-local v1 requires the Claude Code CLI as its LLM gate.`);
-    console.error(`Detected gate agent: ${gateAgent} (no claude_code session dir found at ~/.claude/projects/).`);
-    console.error(`Install Claude Code, or run a Claude Code session once, then re-run.`);
-    process.exit(1);
-  }
-  const gateBin = findAgentBin(gateAgent);
-  console.log(`Gate CLI: ${gateAgent} (${gateBin})${host ? " \u2014 host-agent detected" : ""}`);
-  const cwd = process.cwd();
-  const rawSessions = listLocalSessions(installs, cwd);
-  const now = Date.now();
-  const allSessions = rawSessions.filter((s) => now - s.mtime >= IN_FLIGHT_MAX_AGE_MS);
-  const dropped = rawSessions.length - allSessions.length;
-  const cwdCount = allSessions.filter((s) => s.inCwd).length;
-  console.log(`Found ${allSessions.length} local session(s) (${cwdCount} in cwd${dropped > 0 ? `, ${dropped} in-flight skipped` : ""})`);
-  if (allSessions.length === 0) {
-    console.error(`No mineable session files (all were modified within the last ${IN_FLIGHT_MAX_AGE_MS / 1e3}s).`);
-    process.exit(1);
-  }
-  const n = nRaw === "all" ? allSessions.length : nRaw ? Math.max(1, parseInt(nRaw, 10) || DEFAULT_N) : DEFAULT_N;
-  const picked = pickSessions(allSessions, { n, epsilon: EPSILON });
-  console.log(`Picking ${picked.length} session(s) (\u03B5=${EPSILON}, N=${n}): ${picked.map((s) => s.sessionId.slice(0, 8)).join(", ")}`);
-  if (dryRun) {
-    console.log(`Dry-run: would invoke ${gateAgent} gate on ${picked.length} session(s) in parallel (concurrency=${GATE_CONCURRENCY}).`);
-    return;
-  }
-  const tmpDir = join26(homedir16(), ".claude", "hivemind", `mine-local-${Date.now()}`);
-  mkdirSync9(tmpDir, { recursive: true });
-  console.log(`Running ${picked.length} gate call(s) in parallel (concurrency=${GATE_CONCURRENCY}, timeout=${GATE_TIMEOUT_MS / 1e3}s each)...`);
-  const results = await parallelMap(picked, GATE_CONCURRENCY, async (s) => {
-    const shortId = s.sessionId.slice(0, 8);
-    const rows = nativeJsonlToRows(s.path, s.sessionId, s.agent);
-    const pairs2 = extractPairs(rows);
-    if (pairs2.length === 0) {
-      console.log(`  [${shortId}] no usable pairs \u2014 skipped`);
-      return { session: s, skills: [], reason: "no pairs", error: null };
-    }
-    const tail = pairs2.slice(-PER_SESSION_PAIR_CAP);
-    const sessionTmp = join26(tmpDir, `s-${shortId}`);
-    mkdirSync9(sessionTmp, { recursive: true });
-    const verdictPath = join26(sessionTmp, "verdict.json");
-    const prompt = buildSessionPrompt(tail, s, verdictPath);
-    writeFileSync12(join26(sessionTmp, "prompt.txt"), prompt);
-    const gate = await runGateViaStdin({ agent: gateAgent, bin: gateBin, prompt, timeoutMs: GATE_TIMEOUT_MS });
-    try {
-      writeFileSync12(join26(sessionTmp, "gate-stdout.txt"), gate.stdout);
-      if (gate.stderr)
-        writeFileSync12(join26(sessionTmp, "gate-stderr.txt"), gate.stderr);
-    } catch {
-    }
-    if (gate.errored) {
-      console.log(`  [${shortId}] gate failed: ${gate.errorMessage}`);
-      return { session: s, skills: [], reason: null, error: gate.errorMessage ?? "gate failed" };
-    }
-    const verdictText = existsSync23(verdictPath) ? readFileSync16(verdictPath, "utf-8") : gate.stdout;
-    const mv = parseMultiVerdict(verdictText);
-    if (!mv) {
-      console.log(`  [${shortId}] unparseable verdict (kept at ${sessionTmp})`);
-      return { session: s, skills: [], reason: null, error: "unparseable verdict" };
-    }
-    console.log(`  [${shortId}] ${mv.skills.length} skill candidate(s) \u2014 ${mv.reason ?? "no reason given"}`);
-    return { session: s, skills: mv.skills, reason: mv.reason ?? null, error: null };
-  });
-  const skillsRoot = resolveSkillsRoot("global", cwd);
-  const totalCandidates = results.reduce((sum, r) => sum + r.skills.length, 0);
-  const existingSummaries = loadExistingSummaries(skillsRoot);
-  console.log("");
-  console.log(`Got ${totalCandidates} candidate(s) across ${picked.length} session(s). Checking overlap against ${existingSummaries.length} installed skill(s) + each new write.`);
-  if (totalCandidates === 0) {
-    const existing = loadManifest2();
-    saveManifest2({
-      created_at: existing?.created_at ?? (/* @__PURE__ */ new Date()).toISOString(),
-      entries: existing?.entries ?? []
-    });
-    console.log(`No skills to write.`);
-    console.log(`tmp dir kept for inspection: ${tmpDir}`);
-    return;
-  }
-  const flat = [];
-  for (const r of results) {
-    for (const sk of r.skills)
-      flat.push({ skill: sk, session: r.session });
-  }
-  flat.sort((a, b) => b.session.mtime - a.session.mtime);
-  const fanOutRoots = detectAgentSkillsRoots(skillsRoot);
-  if (fanOutRoots.length > 0) {
-    console.log(`Fan-out targets: ${fanOutRoots.join(", ")}`);
-  }
-  const written = [];
-  const knownSummaries = [...existingSummaries];
-  for (const { skill, session } of flat) {
-    const overlap = findOverlap(skill.description, knownSummaries);
-    if (overlap) {
-      console.log(`  skipped ${skill.name} \u2190 session ${session.sessionId.slice(0, 8)} (description overlaps "${overlap.name}", Jaccard=${overlap.score.toFixed(2)})`);
-      continue;
-    }
-    try {
-      const result = writeNewSkill({
-        skillsRoot,
-        name: skill.name,
-        description: skill.description,
-        trigger: skill.trigger,
-        body: skill.body,
-        sourceSessions: [session.sessionId],
-        agent: gateAgent
-      });
-      const canonicalDir = dirname5(result.path);
-      const symlinks = fanOutRoots.length > 0 ? fanOutSymlinks(canonicalDir, basename(canonicalDir), fanOutRoots) : [];
-      const symlinkSuffix = symlinks.length > 0 ? `, fan-out \u2192 ${symlinks.length} root(s)` : "";
-      console.log(`  wrote ${skill.name} \u2190 session ${session.sessionId.slice(0, 8)} (${session.agent}${symlinkSuffix})`);
-      written.push({ skill, session, result, symlinks });
-      knownSummaries.push({ name: skill.name, desc: skill.description });
-    } catch (e) {
-      if (/already exists/i.test(e.message ?? "")) {
-        console.log(`  skipped ${skill.name} (file already exists at ${skillsRoot})`);
-      } else {
-        console.log(`  failed ${skill.name}: ${e.message}`);
-      }
-    }
-  }
-  if (written.length > 0) {
-    const existing = loadManifest2();
-    const newEntries = written.map(({ skill, session, result, symlinks }) => ({
-      skill_name: skill.name,
-      canonical_path: result.path,
-      symlinks,
-      source_session_ids: [session.sessionId],
-      source_session_paths: [session.path],
-      source_agent: session.agent,
-      gate_agent: gateAgent,
-      created_at: result.createdAt,
-      uploaded: false
-    }));
-    saveManifest2({
-      created_at: existing?.created_at ?? (/* @__PURE__ */ new Date()).toISOString(),
-      entries: [...existing?.entries ?? [], ...newEntries]
-    });
-  }
-  console.log("");
-  console.log(`Mined ${written.length} skill(s) from ${picked.length} session(s) (${results.filter((r) => r.skills.length > 0).length} session(s) contributed candidate(s)).`);
-  console.log(`Installed to ${skillsRoot}/ \u2014 local-only, not shared.`);
-  console.log(`Sign in with 'hivemind login' to share with your team later.`);
-}
-
-// dist/src/cli/skillify-spec.js
-var SKILLIFY_SPEC = [
-  {
-    cmd: "hivemind skillify",
-    desc: "show scope, team, install, per-project state"
-  },
-  {
-    cmd: "hivemind skillify pull",
-    desc: "sync project skills from the org table to local FS",
-    options: [
-      { flag: "--user <email>", desc: "only skills authored by that user" },
-      { flag: "--users <a,b,c>", desc: "only skills from those authors" },
-      { flag: "--all-users", desc: 'explicit "no author filter" (default)' },
-      { flag: "--to <project|global>", desc: "install location (project=cwd/.claude/skills, global=~/.claude/skills)" },
-      { flag: "--dry-run", desc: "preview without touching disk" },
-      { flag: "--force", desc: "overwrite local files even if up-to-date (creates .bak)" },
-      { flag: "<skill-name>", desc: "pull only that one skill (combines with --user)" }
-    ],
-    note: "every agent's SessionStart hook auto-runs 'pull --all-users --to global' on every session. File writes are idempotent (skipped when local is at-or-newer than remote). Disable via HIVEMIND_AUTOPULL_DISABLED=1."
-  },
-  {
-    cmd: "hivemind skillify unpull",
-    desc: "remove every skill previously installed by pull",
-    options: [
-      { flag: "--user <email>", desc: "remove only that author's pulls" },
-      { flag: "--not-mine", desc: "remove all pulls except your own" },
-      { flag: "--dry-run", desc: "preview without touching disk" }
-    ]
-  },
-  {
-    cmd: "hivemind skillify scope",
-    args: "<me|team|org>",
-    desc: "sharing scope for newly mined skills"
-  },
-  {
-    cmd: "hivemind skillify install",
-    args: "<project|global>",
-    desc: "default install location for new skills"
-  },
-  {
-    cmd: "hivemind skillify promote",
-    args: "<skill-name>",
-    desc: "move a project skill to the global location"
-  },
-  {
-    cmd: "hivemind skillify team add|remove|list",
-    args: "<name>",
-    desc: "manage team member list"
-  },
-  {
-    cmd: "hivemind skillify mine-local",
-    desc: "one-shot: mine skills from local sessions (no auth needed)",
-    options: [
-      { flag: "--n <num|all>", desc: "how many sessions to mine (default: 8)" },
-      { flag: "--force", desc: "re-run even if the manifest sentinel exists" },
-      { flag: "--dry-run", desc: "stop before calling the LLM gate" }
-    ]
-  }
-];
-function renderCliHelpBlock() {
-  const INDENT = "  ";
-  const CMD_COL_WIDTH = 42;
-  const lines = [];
-  for (const sub of SKILLIFY_SPEC) {
-    const left = sub.args ? `${sub.cmd} ${sub.args}` : sub.cmd;
-    const padded = left.length >= CMD_COL_WIDTH ? `${left}  ` : left.padEnd(CMD_COL_WIDTH);
-    lines.push(`${INDENT}${padded}${capitalize(sub.desc)}.`);
-    if (sub.options && sub.options.length > 0) {
-      const optsList = sub.options.map((o) => o.flag).join(", ");
-      lines.push(`${INDENT}${" ".repeat(CMD_COL_WIDTH)}Options: ${optsList}.`);
-    }
-    if (sub.note) {
-      const noteWrapped = wrapAt(`Note: ${sub.note}`, 72);
-      for (const noteLine of noteWrapped) {
-        lines.push(`${INDENT}${" ".repeat(CMD_COL_WIDTH)}${noteLine}`);
-      }
-    }
-  }
-  return lines.join("\n");
-}
-function renderSubcommandUsageBlock() {
-  const INDENT = "  ";
-  const SUB_INDENT = "    ";
-  const FLAG_INDENT = "      ";
-  const CMD_COL_WIDTH = 44;
-  const FLAG_COL_WIDTH = 26;
-  const lines = [];
-  for (const sub of SKILLIFY_SPEC) {
-    const left = sub.args ? `${sub.cmd} ${sub.args}` : sub.cmd;
-    const padded = left.length >= CMD_COL_WIDTH ? `${left}  ` : left.padEnd(CMD_COL_WIDTH);
-    lines.push(`${INDENT}${padded}${sub.desc}`);
-    if (sub.options && sub.options.length > 0) {
-      const tail = sub.cmd.split(" ").slice(-1)[0];
-      lines.push(`${SUB_INDENT}Options for ${tail}:`);
-      for (const opt of sub.options) {
-        const flagPadded = opt.flag.length >= FLAG_COL_WIDTH ? `${opt.flag}  ` : opt.flag.padEnd(FLAG_COL_WIDTH);
-        lines.push(`${FLAG_INDENT}${flagPadded}${opt.desc}`);
-      }
-    }
-  }
-  return lines.join("\n");
-}
-function capitalize(s) {
-  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
-}
-function wrapAt(s, max) {
-  const words = s.split(/\s+/);
-  const out = [];
-  let cur = "";
-  for (const w of words) {
-    if (cur.length === 0) {
-      cur = w;
-    } else if (cur.length + 1 + w.length > max) {
-      out.push(cur);
-      cur = w;
-    } else {
-      cur += " " + w;
-    }
-  }
-  if (cur)
-    out.push(cur);
-  return out;
-}
-
 // dist/src/commands/skillify.js
 function stateDir() {
-  return join27(homedir17(), ".deeplake", "state", "skillify");
+  return join23(homedir13(), ".deeplake", "state", "skillify");
 }
 function showStatus() {
   const cfg = loadScopeConfig();
@@ -6650,11 +5586,11 @@ function showStatus() {
   console.log(`team:    ${cfg.team.length === 0 ? "(empty)" : cfg.team.join(", ")}`);
   console.log(`install: ${cfg.install}  (${cfg.install === "global" ? "~/.claude/skills/" : "<project>/.claude/skills/"})`);
   const dir = stateDir();
-  if (!existsSync24(dir)) {
+  if (!existsSync20(dir)) {
     console.log(`state: (no projects tracked yet)`);
     return;
   }
-  const files = readdirSync5(dir).filter((f) => f.endsWith(".json") && f !== "config.json" && f !== "pulled.json" && f !== "autopull-last-run.json");
+  const files = readdirSync4(dir).filter((f) => f.endsWith(".json") && f !== "config.json" && f !== "pulled.json" && f !== "autopull-last-run.json");
   if (files.length === 0) {
     console.log(`state: (no projects tracked yet)`);
     return;
@@ -6662,7 +5598,7 @@ function showStatus() {
   console.log(`state: ${files.length} project(s) tracked`);
   for (const f of files) {
     try {
-      const s = JSON.parse(readFileSync17(join27(dir, f), "utf-8"));
+      const s = JSON.parse(readFileSync14(join23(dir, f), "utf-8"));
       const last = typeof s.updatedAt === "number" ? new Date(s.updatedAt).toISOString() : s.lastDate ?? "never";
       const skills = Array.isArray(s.skillsGenerated) && s.skillsGenerated.length > 0 ? s.skillsGenerated.join(", ") : "none";
       console.log(`  - ${s.project} (counter=${s.counter}, last=${last}, skills=${skills})`);
@@ -6671,8 +5607,8 @@ function showStatus() {
   }
 }
 function setScope(scope) {
-  if (scope !== "me" && scope !== "team") {
-    console.error(`Invalid scope '${scope}'. Use one of: me, team`);
+  if (scope !== "me" && scope !== "team" && scope !== "org") {
+    console.error(`Invalid scope '${scope}'. Use one of: me, team, org`);
     process.exit(1);
   }
   const cfg = loadScopeConfig();
@@ -6689,7 +5625,7 @@ function setInstall(loc) {
   }
   const cfg = loadScopeConfig();
   saveScopeConfig({ ...cfg, install: loc });
-  const path = loc === "global" ? join27(homedir17(), ".claude", "skills") : "<cwd>/.claude/skills";
+  const path = loc === "global" ? join23(homedir13(), ".claude", "skills") : "<cwd>/.claude/skills";
   console.log(`Install location set to '${loc}'. New skills will be written to ${path}/<name>/SKILL.md.`);
 }
 function promoteSkill(name, cwd) {
@@ -6697,18 +5633,18 @@ function promoteSkill(name, cwd) {
     console.error("Usage: hivemind skillify promote <skill-name>");
     process.exit(1);
   }
-  const projectPath = join27(cwd, ".claude", "skills", name);
-  const globalPath = join27(homedir17(), ".claude", "skills", name);
-  if (!existsSync24(join27(projectPath, "SKILL.md"))) {
+  const projectPath = join23(cwd, ".claude", "skills", name);
+  const globalPath = join23(homedir13(), ".claude", "skills", name);
+  if (!existsSync20(join23(projectPath, "SKILL.md"))) {
     console.error(`Skill '${name}' not found at ${projectPath}/SKILL.md`);
     process.exit(1);
   }
-  if (existsSync24(join27(globalPath, "SKILL.md"))) {
+  if (existsSync20(join23(globalPath, "SKILL.md"))) {
     console.error(`Skill '${name}' already exists at ${globalPath}/SKILL.md \u2014 refusing to overwrite. Remove it first or rename the project skill.`);
     process.exit(1);
   }
-  mkdirSync10(dirname6(globalPath), { recursive: true });
-  renameSync4(projectPath, globalPath);
+  mkdirSync8(dirname4(globalPath), { recursive: true });
+  renameSync5(projectPath, globalPath);
   console.log(`Promoted '${name}' from ${projectPath} \u2192 ${globalPath}.`);
 }
 function teamAdd(name) {
@@ -6750,9 +5686,33 @@ function teamList() {
 }
 function usage() {
   console.log("Usage:");
-  console.log(renderSubcommandUsageBlock());
+  console.log("  hivemind skillify                            show current scope, team, install, and per-project state");
+  console.log("  hivemind skillify scope <me|team|org>        set the mining scope");
+  console.log("  hivemind skillify install <project|global>   set where new skills are written");
+  console.log("  hivemind skillify promote <skill-name>       move a project skill to the global location");
+  console.log("  hivemind skillify team add <username>        add a username to the team list");
+  console.log("  hivemind skillify team remove <username>     remove a username from the team list");
+  console.log("  hivemind skillify team list                  list current team members");
+  console.log("  hivemind skillify pull [skill-name] [opts]   fetch skills from Deeplake to local FS");
+  console.log("    Options for pull:");
+  console.log("      --to <project|global>     destination (default: global)");
+  console.log("      --user <name>             only skills authored by this user");
+  console.log("      --users <a,b,c>           only skills authored by these users");
+  console.log("      --all-users               all authors (default \u2014 equivalent to no filter)");
+  console.log("      --dry-run                 show what would be written, don't touch disk");
+  console.log("      --force                   overwrite even when local version >= remote");
+  console.log("  hivemind skillify unpull [opts]              remove skills previously installed by pull");
+  console.log("    Options for unpull:");
+  console.log("      --to <project|global>     where to scan (default: global)");
+  console.log("      --user <name>             only entries authored by this user");
+  console.log("      --users <a,b,c>           only entries authored by these users");
+  console.log("      --not-mine                remove all pulled entries except your own");
+  console.log("      --dry-run                 show what would be removed");
+  console.log("      --all                     also remove flat-layout (locally-mined) entries");
+  console.log("      --legacy-cleanup          also remove pre-`--author`-layout legacy `<projectKey>/` dirs");
+  console.log("  hivemind skillify status                     show per-project state");
 }
-function takeFlagValue2(args, flag) {
+function takeFlagValue(args, flag) {
   const idx = args.indexOf(flag);
   if (idx < 0)
     return null;
@@ -6773,9 +5733,9 @@ function takeBooleanFlag(args, flag) {
 }
 async function pullSkills(args) {
   const work = [...args];
-  const toRaw = takeFlagValue2(work, "--to") ?? "global";
-  const userOne = takeFlagValue2(work, "--user");
-  const usersMany = takeFlagValue2(work, "--users");
+  const toRaw = takeFlagValue(work, "--to") ?? "global";
+  const userOne = takeFlagValue(work, "--user");
+  const usersMany = takeFlagValue(work, "--users");
   const allUsers = takeBooleanFlag(work, "--all-users");
   const dryRun = takeBooleanFlag(work, "--dry-run");
   const force = takeBooleanFlag(work, "--force");
@@ -6814,7 +5774,7 @@ async function pullSkills(args) {
     console.error(`pull failed: ${e?.message ?? e}`);
     process.exit(1);
   }
-  const dest = toRaw === "global" ? join27(homedir17(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join23(homedir13(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterDesc = users.length === 0 ? "all users" : users.join(", ");
   console.log(`Destination: ${dest}`);
   console.log(`Filter:      ${filterDesc}${skillName ? ` \xB7 skill='${skillName}'` : ""}${dryRun ? " \xB7 dry-run" : ""}${force ? " \xB7 force" : ""}`);
@@ -6831,9 +5791,9 @@ async function pullSkills(args) {
 }
 async function unpullSkills(args) {
   const work = [...args];
-  const toRaw = takeFlagValue2(work, "--to") ?? "global";
-  const userOne = takeFlagValue2(work, "--user");
-  const usersMany = takeFlagValue2(work, "--users");
+  const toRaw = takeFlagValue(work, "--to") ?? "global";
+  const userOne = takeFlagValue(work, "--user");
+  const usersMany = takeFlagValue(work, "--users");
   const notMine = takeBooleanFlag(work, "--not-mine");
   const dryRun = takeBooleanFlag(work, "--dry-run");
   const all = takeBooleanFlag(work, "--all");
@@ -6864,7 +5824,7 @@ async function unpullSkills(args) {
     all,
     legacyCleanup
   });
-  const dest = toRaw === "global" ? join27(homedir17(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join23(homedir13(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterParts = [];
   if (users.length > 0)
     filterParts.push(`users=${users.join(",")}`);
@@ -6939,13 +5899,6 @@ function runSkillifyCommand(args) {
     console.error("Usage: hivemind skillify team <add|remove|list> [name]");
     process.exit(1);
   }
-  if (sub === "mine-local") {
-    runMineLocal(args.slice(1)).catch((e) => {
-      console.error(`mine-local error: ${e?.message ?? e}`);
-      process.exit(1);
-    });
-    return;
-  }
   if (sub === "--help" || sub === "-h" || sub === "help") {
     usage();
     return;
@@ -6960,13 +5913,13 @@ if (process.argv[1] && process.argv[1].endsWith("skillify.js")) {
 
 // dist/src/cli/update.js
 import { execFileSync as execFileSync4 } from "node:child_process";
-import { existsSync as existsSync25, readFileSync as readFileSync19, realpathSync } from "node:fs";
-import { dirname as dirname8, sep } from "node:path";
+import { existsSync as existsSync21, readFileSync as readFileSync16, realpathSync } from "node:fs";
+import { dirname as dirname6, sep } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync18 } from "node:fs";
-import { dirname as dirname7, join as join28 } from "node:path";
+import { readFileSync as readFileSync15 } from "node:fs";
+import { dirname as dirname5, join as join24 } from "node:path";
 function isNewer(latest, current) {
   const parse = (v) => v.split(".").map(Number);
   const [la, lb, lc] = parse(latest);
@@ -6985,24 +5938,24 @@ function detectInstallKind(argv1) {
       return argv1 ?? process.argv[1] ?? fileURLToPath2(import.meta.url);
     }
   })();
-  let dir = dirname8(realArgv1);
+  let dir = dirname6(realArgv1);
   let installDir = null;
   for (let i = 0; i < 10; i++) {
     const pkgPath = `${dir}${sep}package.json`;
     try {
-      const pkg = JSON.parse(readFileSync19(pkgPath, "utf-8"));
+      const pkg = JSON.parse(readFileSync16(pkgPath, "utf-8"));
       if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
         installDir = dir;
         break;
       }
     } catch {
     }
-    const parent = dirname8(dir);
+    const parent = dirname6(dir);
     if (parent === dir)
       break;
     dir = parent;
   }
-  installDir ??= dirname8(realArgv1);
+  installDir ??= dirname6(realArgv1);
   if (realArgv1.includes(`${sep}_npx${sep}`) || realArgv1.includes(`${sep}.npx${sep}`)) {
     return { kind: "npx", installDir };
   }
@@ -7011,10 +5964,10 @@ function detectInstallKind(argv1) {
   }
   let gitDir = installDir;
   for (let i = 0; i < 6; i++) {
-    if (existsSync25(`${gitDir}${sep}.git`)) {
+    if (existsSync21(`${gitDir}${sep}.git`)) {
       return { kind: "local-dev", installDir };
     }
-    const parent = dirname8(gitDir);
+    const parent = dirname6(gitDir);
     if (parent === gitDir)
       break;
     gitDir = parent;
@@ -7049,7 +6002,7 @@ async function runUpdate(opts = {}) {
   }
   log(`Update available: ${current} \u2192 ${latest}`);
   const detected = opts.installKindOverride ?? detectInstallKind();
-  const spawn2 = opts.spawn ?? defaultSpawn;
+  const spawn = opts.spawn ?? defaultSpawn;
   switch (detected.kind) {
     case "npm-global": {
       if (opts.dryRun) {
@@ -7059,7 +6012,7 @@ async function runUpdate(opts = {}) {
       }
       log(`Upgrading via npm\u2026`);
       try {
-        spawn2("npm", ["install", "-g", `${PKG_NAME}@latest`]);
+        spawn("npm", ["install", "-g", `${PKG_NAME}@latest`]);
       } catch (e) {
         warn(`npm install failed: ${e.message}`);
         warn(`Try running it manually: npm install -g ${PKG_NAME}@latest`);
@@ -7068,7 +6021,7 @@ async function runUpdate(opts = {}) {
       log(``);
       log(`Refreshing agent bundles\u2026`);
       try {
-        spawn2("hivemind", ["install", "--skip-auth"]);
+        spawn("hivemind", ["install", "--skip-auth"]);
       } catch (e) {
         warn(`Agent refresh failed: ${e.message}`);
         warn(`Run manually: hivemind install`);
@@ -7168,7 +6121,28 @@ Semantic search (embeddings):
   to run "embeddings install" automatically after installing the agent(s).
 
 Skill management (mine + share reusable Claude skills across the org):
-${renderCliHelpBlock()}
+  hivemind skillify                         Show scope, team, install, and per-project state.
+  hivemind skillify pull [skill-name]       Sync skills from the org table to local FS.
+                                           Options: --user <email>, --users a,b,c,
+                                           --all-users, --to <project|global>,
+                                           --dry-run, --force.
+                                           Note: every agent's SessionStart hook
+                                           auto-runs 'pull --all-users --to global'
+                                           on every session. File writes are
+                                           idempotent (skipped when local is
+                                           at-or-newer than remote). Disable via
+                                           HIVEMIND_AUTOPULL_DISABLED=1.
+  hivemind skillify unpull                  Remove skills previously installed by pull.
+                                           Options: --user, --users, --not-mine,
+                                           --to <project|global>, --dry-run,
+                                           --all (also locally-mined),
+                                           --legacy-cleanup (pre-suffix-author dirs).
+  hivemind skillify scope <me|team|org>     Set the sharing scope for newly mined skills.
+  hivemind skillify install <project|global>  Set where new skills are written.
+  hivemind skillify promote <name>          Move a project skill to the global location.
+  hivemind skillify team add <username>     Add a username to the team list.
+  hivemind skillify team remove <username>  Remove a username from the team list.
+  hivemind skillify team list               List current team members.
 
 Account / org / workspace:
   hivemind whoami                          Show current user, org, workspace.

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -833,7 +833,7 @@ export default definePluginEntry({
             if (result.delta.toolsAlsoAllow) touched.push(`"hivemind" → tools.alsoAllow`);
             return { text: `✅ Added:\n  • ${touched.join("\n  • ")}\n\nOpenclaw will detect the config change and restart. On the next turn, the agent will have access to hivemind_search, hivemind_read, and hivemind_index. **Capture starts on the next turn — earlier turns are NOT backfilled.**\n\nBackup of previous config: ${result.backupPath}${skillifyHint}` };
           }
-          return { text: `⚠️ Could not update allowlist: ${result.error}\n\nManual fix: open ${result.configPath} and add "hivemind" to BOTH the "allow" array under "plugins" AND the "alsoAllow" array under "tools".` };
+          return { text: `⚠️ Could not update allowlist: ${result.error}\n\nManual fix: open ${result.configPath}. If \`plugins.allow\` exists as a non-empty array, add "hivemind" to it. If \`tools.alsoAllow\` exists as a non-empty array, add "hivemind" to it. If either is absent or empty, leave it as-is (openclaw treats that as default-allow).` };
         },
       });
 
@@ -1183,30 +1183,33 @@ export default definePluginEntry({
     // the SKILL.md body in the system prompt directing it to call them
     // first. See issue #121 for the original report (plugins.allow gating
     // also fixed in the same PR).
-    if (config.autoRecall !== false) {
-      hook("before_agent_start", async (event: { prompt?: string }) => {
-        if (!event.prompt || event.prompt.length < 5) return;
-        try {
-          const dl = await getApi();
+    // No `config.autoRecall` gate here: the hook body no longer does any
+    // recall (CodeRabbit on #124 caught this). Both remaining paths — the
+    // login URL nudge and the post-auth welcome banner — must run for
+    // every user, including those who set autoRecall=false. Gating the
+    // whole hook registration would silently break their auth flow.
+    hook("before_agent_start", async (event: { prompt?: string }) => {
+      if (!event.prompt || event.prompt.length < 5) return;
+      try {
+        const dl = await getApi();
 
-          if (!dl && authUrl) {
-            return {
-              prependContext: `\n\nIMPORTANT: The user needs to authenticate with Hivemind. Include this link in your reply: ${authUrl}\nTell them to click it and sign in, then send another message.\n`,
-            };
-          }
-          if (!dl) return;
-
-          if (justAuthenticated) {
-            justAuthenticated = false;
-            const creds = await loadCredentials();
-            const orgName = creds?.orgName ?? creds?.orgId ?? "unknown";
-            return { prependContext: `\n\n🐝 Welcome to Hivemind!\n\nCurrent org: ${orgName}\n\nYour agents now share memory across sessions, teammates, and machines.\n\nGet started:\n1. Verify sync: spin up multiple sessions and confirm agents share context\n2. Invite a teammate: ask the agent to add them over email\n3. Switch orgs: ask the agent to list or switch your organizations\n\nOne brain for every agent on your team.\n` };
-          }
-        } catch (err) {
-          logger.error(`before_agent_start failed: ${err instanceof Error ? err.message : String(err)}`);
+        if (!dl && authUrl) {
+          return {
+            prependContext: `\n\nIMPORTANT: The user needs to authenticate with Hivemind. Include this link in your reply: ${authUrl}\nTell them to click it and sign in, then send another message.\n`,
+          };
         }
-      });
-    }
+        if (!dl) return;
+
+        if (justAuthenticated) {
+          justAuthenticated = false;
+          const creds = await loadCredentials();
+          const orgName = creds?.orgName ?? creds?.orgId ?? "unknown";
+          return { prependContext: `\n\n🐝 Welcome to Hivemind!\n\nCurrent org: ${orgName}\n\nYour agents now share memory across sessions, teammates, and machines.\n\nGet started:\n1. Verify sync: spin up multiple sessions and confirm agents share context\n2. Invite a teammate: ask the agent to add them over email\n3. Switch orgs: ask the agent to list or switch your organizations\n\nOne brain for every agent on your team.\n` };
+        }
+      } catch (err) {
+        logger.error(`before_agent_start failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
 
     // Auto-capture: store new messages in sessions table (same format as CC capture.ts)
     if (config.autoCapture !== false) {

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -636,29 +636,6 @@ function buildSessionPath(config: { userName: string; orgName: string; workspace
   return `/sessions/${config.userName}/${config.userName}_${config.orgName}_${config.workspaceId}_${sessionId}.jsonl`;
 }
 
-const RECALL_STOPWORDS = new Set([
-  "the","and","for","are","but","not","you","all","can","had","her","was","one",
-  "our","out","has","have","what","does","like","with","this","that","from","they",
-  "been","will","more","when","who","how","its","into","some","than","them","these",
-  "then","your","just","about","would","could","should","where","which","there",
-  "their","being","each","other",
-]);
-
-/**
- * Extract the signal-bearing tokens from a natural-language prompt so we can
- * feed them into `searchDeeplakeTables` as a multi-word ILIKE. Mirrors the
- * pattern used by claude-code/codex grep intercepts — lowercase, strip
- * non-alphanumeric, drop short words + stopwords, cap at 4 so the SQL doesn't
- * turn into a 20-way OR.
- */
-function extractKeywords(prompt: string): string[] {
-  return prompt.toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .filter(w => w.length >= 3 && !RECALL_STOPWORDS.has(w))
-    .slice(0, 4);
-}
-
 /** Trim a path filter down to a safe virtual prefix. `/` ⇒ unfiltered. */
 function normalizeVirtualPath(p: string | undefined | null): string {
   if (!p || typeof p !== "string") return "/";
@@ -851,9 +828,12 @@ export default definePluginEntry({
             return { text: `✅ Hivemind tools are already enabled in your allowlist.\n\nNo changes needed — memory tools are available to the agent.${skillifyHint}` };
           }
           if (result.status === "added") {
-            return { text: `✅ Added "hivemind" to your tool allowlist.\n\nOpenclaw will detect the config change and restart. On the next turn, the agent will have access to hivemind_search, hivemind_read, and hivemind_index.\n\nBackup of previous config: ${result.backupPath}${skillifyHint}` };
+            const touched: string[] = [];
+            if (result.delta.pluginsAllow) touched.push(`"hivemind" → plugins.allow`);
+            if (result.delta.toolsAlsoAllow) touched.push(`"hivemind" → tools.alsoAllow`);
+            return { text: `✅ Added:\n  • ${touched.join("\n  • ")}\n\nOpenclaw will detect the config change and restart. On the next turn, the agent will have access to hivemind_search, hivemind_read, and hivemind_index. **Capture starts on the next turn — earlier turns are NOT backfilled.**\n\nBackup of previous config: ${result.backupPath}${skillifyHint}` };
           }
-          return { text: `⚠️ Could not update allowlist: ${result.error}\n\nManual fix: open ${result.configPath} and add "hivemind" to the "alsoAllow" array under "tools".` };
+          return { text: `⚠️ Could not update allowlist: ${result.error}\n\nManual fix: open ${result.configPath} and add "hivemind" to BOTH the "allow" array under "plugins" AND the "alsoAllow" array under "tools".` };
         },
       });
 
@@ -1185,7 +1165,24 @@ export default definePluginEntry({
       });
     }
 
-    // Auto-recall: search memory before each turn
+    // before_agent_start handles two narrow paths that legitimately fire
+    // before the agent starts:
+    //   1. Login nudge — when the user isn't authenticated yet, drop the
+    //      device-flow URL into the agent's context so it can show it.
+    //   2. Welcome banner — once after a successful device-flow auth.
+    //
+    // The previous version of this hook also did a proactive recall query
+    // across the memory + sessions tables on every turn. That made every
+    // openclaw turn pay Deeplake's `sessions`-table latency (200ms–10s+)
+    // even when the prompt needed no memory at all, and a slow Deeplake
+    // would block the agent for the full timeout before it could reply.
+    // Other agents (claude-code, codex, cursor, hermes, pi) don't do
+    // this — they let the agent decide when to search by intercepting its
+    // Grep tool calls. Openclaw now matches that pattern: the agent gets
+    // memory via the registered tools (hivemind_search/_read/_index), with
+    // the SKILL.md body in the system prompt directing it to call them
+    // first. See issue #121 for the original report (plugins.allow gating
+    // also fixed in the same PR).
     if (config.autoRecall !== false) {
       hook("before_agent_start", async (event: { prompt?: string }) => {
         if (!event.prompt || event.prompt.length < 5) return;
@@ -1205,53 +1202,8 @@ export default definePluginEntry({
             const orgName = creds?.orgName ?? creds?.orgId ?? "unknown";
             return { prependContext: `\n\n🐝 Welcome to Hivemind!\n\nCurrent org: ${orgName}\n\nYour agents now share memory across sessions, teammates, and machines.\n\nGet started:\n1. Verify sync: spin up multiple sessions and confirm agents share context\n2. Invite a teammate: ask the agent to add them over email\n3. Switch orgs: ask the agent to list or switch your organizations\n\nOne brain for every agent on your team.\n` };
           }
-
-          // Multi-keyword search across BOTH the memory (summaries) and
-          // sessions (raw turns) tables. Uses the same `searchDeeplakeTables`
-          // primitive that claude-code and codex agents reach via their
-          // PreToolUse-intercepted Grep, so recall quality is model-agnostic
-          // (no more first-keyword-only ILIKE on sessions alone).
-          const keywords = extractKeywords(event.prompt);
-          if (!keywords.length) return;
-
-          const grepParams: GrepMatchParams = {
-            pattern: keywords.join(" "),
-            ignoreCase: true,
-            wordMatch: false,
-            filesOnly: false,
-            countOnly: false,
-            lineNumber: false,
-            invertMatch: false,
-            fixedString: true,
-          };
-          const searchOpts = buildGrepSearchOptions(grepParams, "/");
-          searchOpts.limit = 10;
-          const rows = await searchDeeplakeTables(dl, memoryTable, sessionsTable, searchOpts);
-          if (!rows.length) return;
-
-          const recalled = rows
-            .map(r => {
-              const body = normalizeContent(r.path, r.content);
-              return `[${r.path}] ${body.slice(0, 400)}`;
-            })
-            .join("\n\n");
-
-          logger.info?.(`Auto-recalled ${rows.length} memories`);
-          const instruction =
-            "These are raw Hivemind search hits from prior sessions. Each hit is prefixed with its path " +
-            "(e.g. `/summaries/<username>/...`). Different usernames are different people — do NOT merge, " +
-            "alias, or conflate them. If you need more detail, call `hivemind_search` with a more specific " +
-            "query or `hivemind_read` on a specific path. If these hits don't answer the question, say so " +
-            "rather than guessing.";
-          return {
-            prependContext:
-              "\n\n<recalled-memories>\n" +
-              instruction + "\n\n" +
-              recalled +
-              "\n</recalled-memories>\n",
-          };
         } catch (err) {
-          logger.error(`Auto-recall failed: ${err instanceof Error ? err.message : String(err)}`);
+          logger.error(`before_agent_start failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       });
     }

--- a/openclaw/src/setup-config.ts
+++ b/openclaw/src/setup-config.ts
@@ -1,7 +1,8 @@
 // Helpers that read and write ~/.openclaw/openclaw.json on behalf of the
-// /hivemind_setup and /hivemind_autoupdate slash commands. Kept in its own
-// module so the config-IO code stays separate from the network code in
-// index.ts and has a narrow public surface (four exports).
+// /hivemind_setup and /hivemind_autoupdate slash commands AND the CLI
+// installer at src/cli/install-openclaw.ts. Kept in its own module so the
+// config-IO code stays separate from the network code in index.ts and has
+// a narrow public surface.
 
 import { existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
@@ -25,11 +26,40 @@ export function isAllowlistCoveringHivemind(alsoAllow: unknown): boolean {
   return false;
 }
 
+/**
+ * True when plugins.allow is an explicit non-empty array that doesn't yet
+ * include "hivemind". Mirrors openclaw's own `ensurePluginAllowlisted`
+ * semantics (ext/openclaw/src/config/plugins-allowlist.ts): only patch
+ * when the user has opted into an explicit allowlist. If it's absent or
+ * empty, openclaw treats that as default-allow, and we must not silently
+ * flip the user into explicit-allowlist mode — that would disable every
+ * other plugin they have installed.
+ */
+export function isPluginsAllowMissingHivemind(allow: unknown): boolean {
+  return Array.isArray(allow) && allow.length > 0 && !allow.includes("hivemind");
+}
+
+export type AllowlistDelta = {
+  pluginsAllow: boolean;
+  toolsAlsoAllow: boolean;
+};
+
 export type SetupResult =
   | { status: "already-set"; configPath: string }
-  | { status: "added"; configPath: string; backupPath: string }
+  | { status: "added"; configPath: string; backupPath: string; delta: AllowlistDelta }
   | { status: "error"; configPath: string; error: string };
 
+/**
+ * Patch ~/.openclaw/openclaw.json so the hivemind plugin can both load
+ * (plugins.allow) and expose its tools (tools.alsoAllow). Atomic write
+ * via tmp+rename with a timestamped backup. Idempotent across re-runs.
+ *
+ * Called from the /hivemind_setup slash command AND from the CLI installer
+ * — both surfaces need exactly the same config-patch semantics, so they
+ * share this one entry point. The slash command only becomes reachable
+ * AFTER plugins.allow already accepts hivemind, so the CLI installer is
+ * the one path that can fix that case end-to-end (issue #121).
+ */
 export function ensureHivemindAllowlisted(): SetupResult {
   const configPath = getOpenclawConfigPath();
   if (!existsSync(configPath)) {
@@ -42,18 +72,36 @@ export function ensureHivemindAllowlisted(): SetupResult {
   } catch (e) {
     return { status: "error", configPath, error: `could not read/parse config: ${e instanceof Error ? e.message : String(e)}` };
   }
+
+  const plugins = (parsed.plugins ?? {}) as Record<string, unknown>;
+  const pluginsAllowRaw = plugins.allow;
   const tools = (parsed.tools ?? {}) as Record<string, unknown>;
-  const alsoAllow = Array.isArray(tools.alsoAllow) ? (tools.alsoAllow as unknown[]) : [];
-  if (isAllowlistCoveringHivemind(alsoAllow)) {
+  const alsoAllowRaw = Array.isArray(tools.alsoAllow) ? (tools.alsoAllow as unknown[]) : [];
+
+  const pluginsAllowNeedsPatch = isPluginsAllowMissingHivemind(pluginsAllowRaw);
+  const toolsAlsoAllowNeedsPatch = !isAllowlistCoveringHivemind(alsoAllowRaw);
+
+  if (!pluginsAllowNeedsPatch && !toolsAlsoAllowNeedsPatch) {
     return { status: "already-set", configPath };
   }
-  const updated: Record<string, unknown> = {
-    ...parsed,
-    tools: {
+
+  const updated: Record<string, unknown> = { ...parsed };
+
+  if (pluginsAllowNeedsPatch) {
+    updated.plugins = {
+      ...plugins,
+      // Cast safe — isPluginsAllowMissingHivemind guarantees Array.
+      allow: [...(pluginsAllowRaw as unknown[]), "hivemind"],
+    };
+  }
+
+  if (toolsAlsoAllowNeedsPatch) {
+    updated.tools = {
       ...tools,
-      alsoAllow: [...alsoAllow, "hivemind"],
-    },
-  };
+      alsoAllow: [...alsoAllowRaw, "hivemind"],
+    };
+  }
+
   const backupPath = `${configPath}.bak-hivemind-${Date.now()}`;
   const tmpPath = `${configPath}.tmp-hivemind-${process.pid}`;
   try {
@@ -63,7 +111,15 @@ export function ensureHivemindAllowlisted(): SetupResult {
   } catch (e) {
     return { status: "error", configPath, error: `could not write config: ${e instanceof Error ? e.message : String(e)}` };
   }
-  return { status: "added", configPath, backupPath };
+  return {
+    status: "added",
+    configPath,
+    backupPath,
+    delta: {
+      pluginsAllow: pluginsAllowNeedsPatch,
+      toolsAlsoAllow: toolsAlsoAllowNeedsPatch,
+    },
+  };
 }
 
 export type AutoUpdateToggleResult =
@@ -120,19 +176,26 @@ export function toggleAutoUpdateConfig(setTo?: boolean): AutoUpdateToggleResult 
 }
 
 /**
- * True if the openclaw config exists but its tool allowlist doesn't admit
- * hivemind's agent tools. Used by index.ts at plugin-register time to decide
- * whether to inject the "run /hivemind_setup" nudge into the system prompt.
- * Returns false on any error so unusual host environments don't produce
- * spurious nudges.
+ * True if the openclaw config exists but EITHER plugins.allow or
+ * tools.alsoAllow is missing hivemind. Used by index.ts at plugin-
+ * register time to decide whether to inject the "run /hivemind_setup"
+ * nudge into the system prompt. Returns false on any error so unusual
+ * host environments don't produce spurious nudges.
+ *
+ * Note: when plugins.allow is the one that's missing hivemind, the
+ * plugin won't have registered in the first place and this function
+ * is moot for that path — but the same check still covers the case
+ * where a user manually adds hivemind to plugins.allow + restarts but
+ * forgets to also update tools.alsoAllow.
  */
 export function detectAllowlistMissing(): boolean {
   const configPath = getOpenclawConfigPath();
   if (!existsSync(configPath)) return false;
   try {
     const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    const plugins = (parsed.plugins ?? {}) as Record<string, unknown>;
     const tools = (parsed.tools ?? {}) as Record<string, unknown>;
-    return !isAllowlistCoveringHivemind(tools.alsoAllow);
+    return isPluginsAllowMissingHivemind(plugins.allow) || !isAllowlistCoveringHivemind(tools.alsoAllow);
   } catch {
     return false;
   }

--- a/openclaw/src/setup-config.ts
+++ b/openclaw/src/setup-config.ts
@@ -72,14 +72,25 @@ export function ensureHivemindAllowlisted(): SetupResult {
   } catch (e) {
     return { status: "error", configPath, error: `could not read/parse config: ${e instanceof Error ? e.message : String(e)}` };
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { status: "error", configPath, error: "openclaw config is not a JSON object" };
+  }
 
   const plugins = (parsed.plugins ?? {}) as Record<string, unknown>;
   const pluginsAllowRaw = plugins.allow;
   const tools = (parsed.tools ?? {}) as Record<string, unknown>;
-  const alsoAllowRaw = Array.isArray(tools.alsoAllow) ? (tools.alsoAllow as unknown[]) : [];
+  const alsoAllowRaw = tools.alsoAllow;
 
   const pluginsAllowNeedsPatch = isPluginsAllowMissingHivemind(pluginsAllowRaw);
-  const toolsAlsoAllowNeedsPatch = !isAllowlistCoveringHivemind(alsoAllowRaw);
+  // Match the same explicit-non-empty-only contract used for plugins.allow:
+  // only patch when the user has opted into an explicit array. Absent or
+  // empty → leave alone, so we don't flip default-allow setups into
+  // restrictive explicit-allowlist mode (CodeRabbit on #124). The
+  // reporter's broken-state config in #121 already had this as an
+  // explicit array, so the original bug-fix path is unchanged.
+  const toolsAlsoAllowNeedsPatch =
+    Array.isArray(alsoAllowRaw) && alsoAllowRaw.length > 0 &&
+    !isAllowlistCoveringHivemind(alsoAllowRaw);
 
   if (!pluginsAllowNeedsPatch && !toolsAlsoAllowNeedsPatch) {
     return { status: "already-set", configPath };
@@ -98,7 +109,8 @@ export function ensureHivemindAllowlisted(): SetupResult {
   if (toolsAlsoAllowNeedsPatch) {
     updated.tools = {
       ...tools,
-      alsoAllow: [...alsoAllowRaw, "hivemind"],
+      // Cast safe — the needs-patch check above guarantees Array.
+      alsoAllow: [...(alsoAllowRaw as unknown[]), "hivemind"],
     };
   }
 
@@ -193,9 +205,17 @@ export function detectAllowlistMissing(): boolean {
   if (!existsSync(configPath)) return false;
   try {
     const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
     const plugins = (parsed.plugins ?? {}) as Record<string, unknown>;
     const tools = (parsed.tools ?? {}) as Record<string, unknown>;
-    return isPluginsAllowMissingHivemind(plugins.allow) || !isAllowlistCoveringHivemind(tools.alsoAllow);
+    const alsoAllow = tools.alsoAllow;
+    // Same explicit-non-empty-only contract as `ensureHivemindAllowlisted`:
+    // an absent/empty `tools.alsoAllow` is default-allow, not "missing
+    // hivemind" — so don't trigger the nudge for those users.
+    const toolsMissing =
+      Array.isArray(alsoAllow) && alsoAllow.length > 0 &&
+      !isAllowlistCoveringHivemind(alsoAllow);
+    return isPluginsAllowMissingHivemind(plugins.allow) || toolsMissing;
   } catch {
     return false;
   }

--- a/src/cli/install-openclaw.ts
+++ b/src/cli/install-openclaw.ts
@@ -2,6 +2,7 @@ import { existsSync, copyFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { HOME, pkgRoot, ensureDir, copyDir, writeVersionStamp, log } from "./util.js";
 import { getVersion } from "./version.js";
+import { ensureHivemindAllowlisted } from "../../openclaw/src/setup-config.js";
 
 const PLUGIN_DIR = join(HOME, ".openclaw", "extensions", "hivemind");
 
@@ -39,6 +40,34 @@ export function installOpenclaw(): void {
 
   writeVersionStamp(PLUGIN_DIR, getVersion());
   log(`  OpenClaw       installed -> ${PLUGIN_DIR}`);
+
+  // Patch ~/.openclaw/openclaw.json so the gateway actually loads us.
+  // Without this, plugins.allow gates the plugin out — the files land
+  // on disk but the loader never registers them, so `/hivemind_setup`
+  // is unreachable from inside the agent (chicken-and-egg). The same
+  // helper is shared with the slash command, so behavior stays
+  // identical across both surfaces. See issue #121.
+  //
+  // Safe-by-default: if openclaw.json doesn't exist (gateway never
+  // started) or is malformed, we skip silently. If plugins.allow is
+  // absent/empty (default-allow), we leave it alone — only patch
+  // explicit allowlists so we never flip the user into restrictive
+  // mode and break their other plugins.
+  const result = ensureHivemindAllowlisted();
+  if (result.status === "added") {
+    const touched: string[] = [];
+    if (result.delta.pluginsAllow) touched.push("plugins.allow");
+    if (result.delta.toolsAlsoAllow) touched.push("tools.alsoAllow");
+    log(`  OpenClaw       patched ${touched.join(" + ")} in ${result.configPath}`);
+    log(`  OpenClaw       backup: ${result.backupPath}`);
+    log(`  OpenClaw       restart the gateway to activate: systemctl --user restart openclaw-gateway.service`);
+    log(`  OpenClaw       capture starts on the NEXT turn — earlier turns are NOT backfilled`);
+  } else if (result.status === "already-set") {
+    log(`  OpenClaw       allowlist already covers hivemind in ${result.configPath}`);
+  }
+  // status === "error" (config missing / malformed): stay quiet. Most
+  // common cause is "openclaw not run yet" — not actionable here, and
+  // /hivemind_setup will fix it the first time the user runs openclaw.
 }
 
 export function uninstallOpenclaw(): void {

--- a/src/cli/install-openclaw.ts
+++ b/src/cli/install-openclaw.ts
@@ -1,6 +1,6 @@
 import { existsSync, copyFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { HOME, pkgRoot, ensureDir, copyDir, writeVersionStamp, log } from "./util.js";
+import { HOME, pkgRoot, ensureDir, copyDir, writeVersionStamp, log, warn } from "./util.js";
 import { getVersion } from "./version.js";
 import { ensureHivemindAllowlisted } from "../../openclaw/src/setup-config.js";
 
@@ -64,10 +64,19 @@ export function installOpenclaw(): void {
     log(`  OpenClaw       capture starts on the NEXT turn — earlier turns are NOT backfilled`);
   } else if (result.status === "already-set") {
     log(`  OpenClaw       allowlist already covers hivemind in ${result.configPath}`);
+  } else if (result.status === "error") {
+    // "openclaw config file not found" is the common no-op case (gateway
+    // never started). Log it at info-level — installer is non-fatal, the
+    // /hivemind_setup slash command will patch on first openclaw run.
+    // Other errors (malformed JSON, write failure) are user-actionable
+    // and get a warn so they're visible. CodeRabbit on #124 caught the
+    // previous silent-error path.
+    if (result.error === "openclaw config file not found") {
+      log(`  OpenClaw       openclaw.json not present at ${result.configPath} — run openclaw once, then \`hivemind claw install\` again`);
+    } else {
+      warn(`  OpenClaw       could not patch allowlist in ${result.configPath}: ${result.error}`);
+    }
   }
-  // status === "error" (config missing / malformed): stay quiet. Most
-  // common cause is "openclaw not run yet" — not actionable here, and
-  // /hivemind_setup will fix it the first time the user runs openclaw.
 }
 
 export function uninstallOpenclaw(): void {

--- a/tests/openclaw/auto-recall.test.ts
+++ b/tests/openclaw/auto-recall.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /**
- * Auto-recall regression tests for the openclaw hivemind plugin's
- * `before_agent_start` hook. This used to do a single-keyword ILIKE on the
- * sessions table only; after the Phase-1 fix it calls `searchDeeplakeTables`
- * with multi-word patterns across BOTH the memory (summaries) and sessions
- * tables, exactly what CC/Codex agents see via their PreToolUse grep path.
+ * Regression tests for the openclaw `before_agent_start` hook.
+ *
+ * Design history: the hook used to do a proactive blocking recall query
+ * across the memory + sessions tables on every user turn. That made every
+ * openclaw turn pay Deeplake's `sessions`-table latency (200ms–10s+) even
+ * for prompts that needed no memory at all. Other agents (claude-code,
+ * codex, cursor, hermes, pi) don't do this — they let the agent decide
+ * when to search by intercepting its Grep tool calls.
+ *
+ * The hook now mirrors that lazy/agent-initiated pattern: recall is only
+ * available via the registered tools (`hivemind_search`, `hivemind_read`,
+ * `hivemind_index`), and the SKILL.md body in the system prompt tells the
+ * agent to use them. The hook itself still handles two narrow paths that
+ * legitimately need to fire before the agent starts:
+ *   1. Login nudge — when the user isn't authenticated yet, drop the
+ *      device-flow URL into the agent's context so it can show it.
+ *   2. Welcome banner — once after a successful device-flow auth.
  */
 
 const queryMock = vi.fn();
@@ -36,12 +48,21 @@ vi.mock("../../src/deeplake-api.js", () => ({
 
 type HookHandler = (event: Record<string, unknown>) => Promise<unknown>;
 
-async function loadPluginWithHooks() {
+async function loadPluginWithHooks(): Promise<{
+  hooks: Map<string, HookHandler>;
+  mockApi: ReturnType<typeof buildMockApi>;
+}> {
   vi.resetModules();
   const mod = await import("../../openclaw/src/index.js");
-  const plugin = mod.default as { register: (api: any) => void };
+  const plugin = mod.default as { register: (api: ReturnType<typeof buildMockApi>) => void };
   const hooks = new Map<string, HookHandler>();
-  const mockApi = {
+  const mockApi = buildMockApi(hooks);
+  plugin.register(mockApi);
+  return { hooks, mockApi };
+}
+
+function buildMockApi(hooks: Map<string, HookHandler>) {
+  return {
     logger: { info: vi.fn(), error: vi.fn() },
     on: (event: string, handler: HookHandler) => { hooks.set(event, handler); },
     registerCommand: vi.fn(),
@@ -49,8 +70,6 @@ async function loadPluginWithHooks() {
     registerMemoryCorpusSupplement: vi.fn(),
     pluginConfig: {},
   };
-  plugin.register(mockApi);
-  return { hooks, mockApi };
 }
 
 beforeEach(() => {
@@ -73,61 +92,69 @@ beforeEach(() => {
   });
 });
 
-describe("openclaw auto-recall (before_agent_start)", () => {
-  it("skips when the prompt is too short", async () => {
+describe("openclaw before_agent_start (post-blocking-recall removal)", () => {
+  it("does NOT call Deeplake on a normal turn — recall is now tool-initiated", async () => {
+    // The whole point of removing the proactive recall: a plain turn must
+    // not pay Deeplake latency. If this regresses, every openclaw turn
+    // will block on `sessions`-table query latency again.
     const { hooks } = await loadPluginWithHooks();
-    const before = hooks.get("before_agent_start")!;
-    const result = await before({ prompt: "hi" });
-    expect(result).toBeUndefined();
-    expect(queryMock).not.toHaveBeenCalled();
-  });
-
-  it("runs a multi-word UNION ALL search across memory and sessions", async () => {
-    queryMock.mockResolvedValue([
-      { path: "/summaries/alice/abc.md", content: "Levon is driving the LoCoMo accuracy work", source_order: 0, creation_date: "" },
-      { path: "/sessions/bob/xyz.jsonl", content: "chatted with Levon about accuracy metrics", source_order: 1, creation_date: "2026-04-22" },
-    ]);
-    const { hooks, mockApi } = await loadPluginWithHooks();
     const before = hooks.get("before_agent_start")!;
     const result = await before({ prompt: "what is Levon doing on accuracy" });
 
-    expect(queryMock).toHaveBeenCalled();
-    const sql = queryMock.mock.calls[0][0];
-    expect(sql).toContain('FROM "memory"');
-    expect(sql).toContain('FROM "sessions"');
-    expect(sql).toContain("UNION ALL");
-    // Multi-keyword match — at least "levon" and "accuracy" both appear as OR filters
-    expect(sql).toMatch(/summary::text ILIKE '%levon%'/i);
-    expect(sql).toMatch(/summary::text ILIKE '%accuracy%'/i);
-    expect(sql).toMatch(/message::text ILIKE '%levon%'/i);
-    expect(sql).toMatch(/message::text ILIKE '%accuracy%'/i);
-
-    const ctx = (result as { prependContext: string }).prependContext;
-    expect(ctx).toContain("<recalled-memories>");
-    expect(ctx).toContain("/summaries/alice/abc.md");
-    expect(ctx).toContain("/sessions/bob/xyz.jsonl");
-    expect(ctx).toContain("</recalled-memories>");
-    expect(mockApi.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("Auto-recalled 2 memories"),
-    );
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 
-  it("returns undefined when no rows match", async () => {
-    queryMock.mockResolvedValue([]);
+  it("does NOT inject <recalled-memories> context — the agent must call hivemind_search instead", async () => {
+    // Even if Deeplake were queried, the old prependContext shape must not
+    // be reintroduced. Belt-and-braces: assert the marker text is absent
+    // from any return value the hook might emit on a normal turn.
+    queryMock.mockResolvedValue([
+      { path: "/summaries/alice/abc.md", content: "anything", source_order: 0 },
+    ]);
     const { hooks } = await loadPluginWithHooks();
     const before = hooks.get("before_agent_start")!;
-    const result = await before({ prompt: "what is nobody-ever-mentioned doing" });
-    expect(result).toBeUndefined();
+    const result = await before({ prompt: "anything that previously triggered recall" });
+
+    const ctx = (result as { prependContext?: string } | undefined)?.prependContext ?? "";
+    expect(ctx).not.toContain("<recalled-memories>");
   });
 
-  it("logs and returns undefined when the DeeplakeApi throws", async () => {
-    queryMock.mockRejectedValue(new Error("deeplake down"));
-    const { hooks, mockApi } = await loadPluginWithHooks();
+  it("still skips when the prompt is empty or too short", async () => {
+    const { hooks } = await loadPluginWithHooks();
     const before = hooks.get("before_agent_start")!;
-    const result = await before({ prompt: "what is levon doing" });
-    expect(result).toBeUndefined();
-    expect(mockApi.logger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Auto-recall failed"),
+    expect(await before({ prompt: "" })).toBeUndefined();
+    expect(await before({ prompt: "hi" })).toBeUndefined();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("registers hivemind_search / hivemind_read / hivemind_index tools — recall surface for the agent", async () => {
+    // The hook no longer auto-recalls, so the only way the agent gets at
+    // memory is the tools. Assert they're still registered; if a future
+    // refactor drops them by accident, recall disappears entirely.
+    const { mockApi } = await loadPluginWithHooks();
+    const registered = (mockApi.registerTool as ReturnType<typeof vi.fn>).mock.calls.map(
+      ([tool]) => (tool as { name: string }).name,
     );
+    expect(registered).toEqual(expect.arrayContaining([
+      "hivemind_search", "hivemind_read", "hivemind_index",
+    ]));
+  });
+
+  it("still surfaces the login URL when the user isn't authenticated yet", async () => {
+    // No credentials → getApi() returns null → the hook should prepend the
+    // device-flow URL so the agent shows it. This path predates the
+    // proactive recall and must survive its removal.
+    loadCredsMock.mockReturnValue(null);
+    loadConfigMock.mockReturnValue(null);
+    const { hooks } = await loadPluginWithHooks();
+    // before_agent_start fires asynchronously after register(); requestAuth
+    // is kicked off by the post-register login-prompt path with a real URL.
+    // We can't easily seed `authUrl` without doing the device flow, so the
+    // assertion here is conservative: the hook must NOT call query, and
+    // must NOT throw, when no creds exist.
+    const before = hooks.get("before_agent_start")!;
+    await expect(before({ prompt: "anything that triggered the path before" })).resolves.not.toThrow();
+    expect(queryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/openclaw/auto-recall.test.ts
+++ b/tests/openclaw/auto-recall.test.ts
@@ -154,7 +154,11 @@ describe("openclaw before_agent_start (post-blocking-recall removal)", () => {
     // assertion here is conservative: the hook must NOT call query, and
     // must NOT throw, when no creds exist.
     const before = hooks.get("before_agent_start")!;
-    await expect(before({ prompt: "anything that triggered the path before" })).resolves.not.toThrow();
+    // `.resolves.not.toThrow()` is invalid when the promise resolves to
+    // `undefined` (not a function) — see CodeRabbit on #124. Switch to
+    // `.resolves.toBeUndefined()` which actually asserts the resolved
+    // value and surfaces any thrown rejection naturally.
+    await expect(before({ prompt: "anything that triggered the path before" })).resolves.toBeUndefined();
     expect(queryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/openclaw/install-openclaw.test.ts
+++ b/tests/openclaw/install-openclaw.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Tests for installOpenclaw() — the CLI installer that copies the openclaw
+ * plugin bundle to ~/.openclaw/extensions/hivemind/ AND patches
+ * ~/.openclaw/openclaw.json to include "hivemind" in both plugins.allow and
+ * tools.alsoAllow (when each is an explicit array). See issue #121.
+ *
+ * The chicken-and-egg problem this fixes: OpenClaw's plugin loader gates on
+ * plugins.allow before any of the plugin's registered slash commands become
+ * reachable, so a freshly-installed plugin that's missing from plugins.allow
+ * cannot fix its own visibility via /hivemind_setup — the slash command
+ * isn't reachable. The installer has to patch out-of-band.
+ *
+ * homedir() is mocked via vi.mock("node:os") so the installer targets a
+ * temp dir we control, mirroring the pattern in setup-command.test.ts.
+ */
+
+let TEMP_HOME = "";
+
+vi.mock("node:os", async (orig) => {
+  const actual = await orig<typeof import("node:os")>();
+  return { ...actual, homedir: () => TEMP_HOME };
+});
+
+beforeEach(() => {
+  TEMP_HOME = mkdtempSync(join(tmpdir(), "hivemind-install-openclaw-test-"));
+});
+
+afterEach(() => {
+  if (TEMP_HOME && existsSync(TEMP_HOME)) {
+    rmSync(TEMP_HOME, { recursive: true, force: true });
+  }
+});
+
+function writeConfig(body: Record<string, unknown>): string {
+  const dir = join(TEMP_HOME, ".openclaw");
+  const path = join(dir, "openclaw.json");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(body, null, 2));
+  return path;
+}
+
+async function loadInstaller(): Promise<{ installOpenclaw: () => unknown }> {
+  vi.resetModules();
+  return await import("../../src/cli/install-openclaw.js") as { installOpenclaw: () => unknown };
+}
+
+describe("installOpenclaw()", () => {
+  it("copies the plugin bundle to ~/.openclaw/extensions/hivemind/", async () => {
+    writeConfig({ tools: { alsoAllow: ["hivemind"] } });
+    const { installOpenclaw } = await loadInstaller();
+    installOpenclaw();
+
+    const pluginDir = join(TEMP_HOME, ".openclaw", "extensions", "hivemind");
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(existsSync(join(pluginDir, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(pluginDir, ".hivemind_version"))).toBe(true);
+  });
+
+  describe("openclaw.json patching (issue #121)", () => {
+    it("adds 'hivemind' to plugins.allow when it's an explicit array missing hivemind", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki", "browser"] },
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toEqual(["memory-wiki", "browser", "hivemind"]);
+    });
+
+    it("adds 'hivemind' to tools.alsoAllow when missing", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki", "hivemind"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.tools.alsoAllow).toEqual(["memory_store", "hivemind"]);
+    });
+
+    it("patches BOTH arrays in a single run when both miss hivemind", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toContain("hivemind");
+      expect(updated.tools.alsoAllow).toContain("hivemind");
+    });
+
+    it("is idempotent — no patch when both arrays already include hivemind", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki", "hivemind"] },
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      const before = readFileSync(configPath, "utf-8");
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const after = readFileSync(configPath, "utf-8");
+      expect(after).toBe(before);
+      // And: no backup file written when nothing changed.
+      const backups = readdirSync(join(TEMP_HOME, ".openclaw")).filter(n => n.startsWith("openclaw.json.bak-hivemind-"));
+      expect(backups).toEqual([]);
+    });
+
+    it("leaves plugins.allow ABSENT when it isn't already present (default-allow semantics)", async () => {
+      const configPath = writeConfig({
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      // plugins.allow must NOT be created — that would silently flip the
+      // user from default-allow to explicit-allowlist mode and break
+      // every other plugin they have installed.
+      expect(updated.plugins).toBeUndefined();
+      // tools.alsoAllow is still patched.
+      expect(updated.tools.alsoAllow).toContain("hivemind");
+    });
+
+    it("leaves plugins.allow ALONE when it's an empty array (default-allow semantics)", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: [] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toEqual([]);
+    });
+
+    it("writes a timestamped backup before patching", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const before = readFileSync(configPath, "utf-8");
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+
+      const backups = readdirSync(join(TEMP_HOME, ".openclaw")).filter(n => n.startsWith("openclaw.json.bak-hivemind-"));
+      expect(backups.length).toBe(1);
+      const backupBody = readFileSync(join(TEMP_HOME, ".openclaw", backups[0]), "utf-8");
+      expect(backupBody).toBe(before);
+    });
+
+    it("doesn't crash when openclaw.json is absent (openclaw never run)", async () => {
+      // No .openclaw/ dir at all.
+      const { installOpenclaw } = await loadInstaller();
+      expect(() => installOpenclaw()).not.toThrow();
+
+      const pluginDir = join(TEMP_HOME, ".openclaw", "extensions", "hivemind");
+      expect(existsSync(pluginDir)).toBe(true);
+    });
+
+    it("doesn't crash when openclaw.json is malformed JSON", async () => {
+      const dir = join(TEMP_HOME, ".openclaw");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "openclaw.json"), "{ this is not json");
+      const { installOpenclaw } = await loadInstaller();
+      expect(() => installOpenclaw()).not.toThrow();
+    });
+
+    it("does not duplicate 'hivemind' if it sneaks in twice", async () => {
+      // Real-world configs sometimes have duplicate entries from manual
+      // edits + automated edits. Adding once should leave a single entry.
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const { installOpenclaw } = await loadInstaller();
+      installOpenclaw();
+      // Run a second time — must remain idempotent.
+      installOpenclaw();
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      const allow = updated.plugins.allow as string[];
+      const also = updated.tools.alsoAllow as string[];
+      expect(allow.filter(x => x === "hivemind").length).toBe(1);
+      expect(also.filter(x => x === "hivemind").length).toBe(1);
+    });
+
+    it("prints a restart hint when the config was patched", async () => {
+      writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const logs: string[] = [];
+      const origWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = ((chunk: string | Uint8Array) => {
+        logs.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+        return true;
+      }) as typeof process.stdout.write;
+      try {
+        const { installOpenclaw } = await loadInstaller();
+        installOpenclaw();
+      } finally {
+        process.stdout.write = origWrite;
+      }
+      const out = logs.join("");
+      expect(out).toMatch(/restart/i);
+      // No-backfill caveat must also surface so users don't expect old turns to land.
+      expect(out).toMatch(/next turn|no backfill/i);
+    });
+  });
+});

--- a/tests/openclaw/setup-command.test.ts
+++ b/tests/openclaw/setup-command.test.ts
@@ -174,4 +174,119 @@ describe("/hivemind_setup", () => {
     expect(updated.tools.profile).toBe("coding");
     expect(updated.tools.alsoAllow).toContain("hivemind");
   });
+
+  // plugins.allow gating — issue #121. OpenClaw refuses to load the
+  // hivemind plugin at all when plugins.allow is an explicit non-empty
+  // array missing "hivemind", so the slash command was previously
+  // unreachable on a freshly-installed plugin. /hivemind_setup must
+  // patch both arrays (where each exists as an explicit list) so a
+  // single run fully unblocks the plugin once it has been registered
+  // out-of-band.
+  describe("plugins.allow gating (issue #121)", () => {
+    it("adds 'hivemind' to plugins.allow when it's an explicit array missing hivemind", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki", "browser"] },
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      const setup = await loadSetupCommand();
+      const result = await setup.handler({}) as { text: string };
+      expect(result.text).toContain("Added");
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toEqual(["memory-wiki", "browser", "hivemind"]);
+    });
+
+    it("patches BOTH plugins.allow and tools.alsoAllow in a single run when both miss hivemind", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const setup = await loadSetupCommand();
+      const result = await setup.handler({}) as { text: string };
+      expect(result.text).toContain("Added");
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toEqual(["memory-wiki", "hivemind"]);
+      expect(updated.tools.alsoAllow).toEqual(["memory_store", "hivemind"]);
+    });
+
+    it("does NOT create plugins.allow when it's absent (default-allow semantics)", async () => {
+      const configPath = writeConfig({
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const setup = await loadSetupCommand();
+      await setup.handler({});
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins).toBeUndefined();
+    });
+
+    it("does NOT touch plugins.allow when it's an empty array (default-allow semantics)", async () => {
+      const configPath = writeConfig({
+        plugins: { allow: [] },
+        tools: { profile: "coding", alsoAllow: ["memory_store"] },
+      });
+      const setup = await loadSetupCommand();
+      await setup.handler({});
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toEqual([]);
+    });
+
+    it("is idempotent when 'hivemind' is already in plugins.allow AND tools.alsoAllow", async () => {
+      writeConfig({
+        plugins: { allow: ["memory-wiki", "hivemind"] },
+        tools: { profile: "coding", alsoAllow: ["memory_store", "hivemind"] },
+      });
+      const setup = await loadSetupCommand();
+      const result = await setup.handler({}) as { text: string };
+      expect(result.text).toContain("already enabled");
+    });
+
+    it("reports 'Added' even when only plugins.allow needs patching (tools.alsoAllow already covers hivemind)", async () => {
+      // group:plugins wildcard covers tools.alsoAllow, but plugins.allow
+      // still needs an explicit "hivemind" entry.
+      const configPath = writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["group:plugins"] },
+      });
+      const setup = await loadSetupCommand();
+      const result = await setup.handler({}) as { text: string };
+      expect(result.text).toContain("Added");
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(updated.plugins.allow).toContain("hivemind");
+      // tools.alsoAllow was already covered by the wildcard — left as-is.
+      expect(updated.tools.alsoAllow).toEqual(["group:plugins"]);
+    });
+
+    it("detectAllowlistMissing returns true when only plugins.allow is missing hivemind", async () => {
+      writeConfig({
+        plugins: { allow: ["memory-wiki"] },
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      vi.resetModules();
+      const { detectAllowlistMissing } = await import("../../openclaw/src/setup-config.js");
+      expect(detectAllowlistMissing()).toBe(true);
+    });
+
+    it("detectAllowlistMissing returns false when both allowlists cover hivemind", async () => {
+      writeConfig({
+        plugins: { allow: ["memory-wiki", "hivemind"] },
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      vi.resetModules();
+      const { detectAllowlistMissing } = await import("../../openclaw/src/setup-config.js");
+      expect(detectAllowlistMissing()).toBe(false);
+    });
+
+    it("detectAllowlistMissing returns false when plugins.allow is absent (default-allow)", async () => {
+      writeConfig({
+        tools: { profile: "coding", alsoAllow: ["hivemind"] },
+      });
+      vi.resetModules();
+      const { detectAllowlistMissing } = await import("../../openclaw/src/setup-config.js");
+      expect(detectAllowlistMissing()).toBe(false);
+    });
+  });
 });

--- a/tests/openclaw/setup-command.test.ts
+++ b/tests/openclaw/setup-command.test.ts
@@ -138,16 +138,43 @@ describe("/hivemind_setup", () => {
     expect(result.text).toContain("already enabled");
   });
 
-  it("handles config where alsoAllow is missing entirely", async () => {
+  it("does NOT create alsoAllow when it's missing entirely (default-allow semantics)", async () => {
+    // CodeRabbit on #124 caught this: my original code coerced an absent
+    // tools.alsoAllow to [] then patched it to ["hivemind"], flipping the
+    // user from default-allow into explicit-allowlist mode and potentially
+    // disabling tools from other plugins. Match the same explicit-only
+    // contract used for plugins.allow.
     const configPath = writeConfig({
       tools: { profile: "coding" },
     });
     const setup = await loadSetupCommand();
     const result = await setup.handler({}) as { text: string };
-    expect(result.text).toContain("Added");
+    // No change → already-set
+    expect(result.text).toContain("already enabled");
 
     const updated = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(updated.tools.alsoAllow).toEqual(["hivemind"]);
+    expect(updated.tools.alsoAllow).toBeUndefined();
+  });
+
+  it("does NOT touch alsoAllow when it's an empty array (default-allow semantics)", async () => {
+    const configPath = writeConfig({
+      tools: { profile: "coding", alsoAllow: [] },
+    });
+    const setup = await loadSetupCommand();
+    const result = await setup.handler({}) as { text: string };
+    expect(result.text).toContain("already enabled");
+
+    const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(updated.tools.alsoAllow).toEqual([]);
+  });
+
+  it("reports a parse error when openclaw.json is not valid JSON", async () => {
+    const dir = join(TEMP_HOME, ".openclaw");
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "openclaw.json"), "{ broken json");
+    const setup = await loadSetupCommand();
+    const result = await setup.handler({}) as { text: string };
+    expect(result.text).toContain("Could not update allowlist");
   });
 
   it("reports error when openclaw.json doesn't exist", async () => {


### PR DESCRIPTION
Fixes #121.

## Why

Two related bugs surfaced in a user report (the original symptom: "openclaw plugin installed but auto-capture silently does nothing"):

1. **`plugins.allow` gating** — the installer copies files into `~/.openclaw/extensions/hivemind/` but never patches `~/.openclaw/openclaw.json`. If the gateway's `plugins.allow` is an explicit array missing `"hivemind"`, the plugin never registers, `agent_end` never fires, and `/hivemind_setup` is unreachable from inside the agent (chicken-and-egg: the slash command needs the plugin to load first).
2. **Blocking auto-recall** — `before_agent_start` ran a Deeplake `sessions`-table search on **every** user turn. Sessions queries currently take **11.7s / 10.8s / 11.2s** (three sequential probes) against a 10s SDK timeout, so every turn paid the full timeout before the agent could read the message. Other agents (claude-code/codex/cursor/hermes/pi) don't do this — they intercept the agent's `Grep` tool and let the agent decide when to search.

## What changed

### `plugins.allow` patch in the installer

- `src/cli/install-openclaw.ts` now calls the same `ensureHivemindAllowlisted` helper that `/hivemind_setup` uses
- Mirrors openclaw's own `ensurePluginAllowlisted` semantics (`ext/openclaw/src/config/plugins-allowlist.ts:7`): only patches `plugins.allow` when it's an explicit non-empty array. Absent / empty → left alone (default-allow stays default-allow; we don't flip the user into restrictive mode and break their other plugins)
- Same logic for `tools.alsoAllow`
- Atomic write (tmp + rename) with timestamped backup
- Installer prints: which arrays were patched, restart hint, and a **"capture starts on the next turn — no backfill"** caveat so users aren't confused when older turns don't appear

### Blocking auto-recall removed

- `openclaw/src/index.ts:before_agent_start` no longer runs `searchDeeplakeTables`
- Recall flows exclusively through the agent-callable `hivemind_search` / `hivemind_read` / `hivemind_index` tools (already registered), with the `SKILL.md` body in the system prompt directing the agent to use them
- Side-effect win: the recursive `<recalled-memories>` capture bug (old recall context was getting captured as part of the user's prompt and stored) is gone too
- The hook still handles the login nudge and post-auth welcome banner — those don't touch Deeplake
- `extractKeywords` + `RECALL_STOPWORDS` removed as dead code

## Tests

- `openclaw/tests/setup-command.test.ts` — **+9 cases** for `plugins.allow` patching: idempotency, default-allow semantics, both-arrays patched, `detectAllowlistMissing` extension
- `openclaw/tests/install-openclaw.test.ts` (**new, 12 cases**) — drives the real installer against tmpdir fixtures: file copy, both patches, idempotency, default-allow preservation, malformed config tolerance, restart hint, no-duplicate
- `openclaw/tests/auto-recall.test.ts` — **rewritten**: asserts no Deeplake call on a normal turn, no `<recalled-memories>` injection, tools still registered, login-nudge path preserved

All 2214 hivemind tests pass.

## Real-world E2E on a live openclaw gateway (2026.4.21)

- Bundle installed → `Hivemind plugin registered` in gateway log
- Idempotency: re-running installer logs `allowlist already covers hivemind`, no extra backup
- **Zero `Auto-recall failed` log lines** after the restart with the new bundle (previous bundle emitted them on every turn that hit Deeplake slowness)
- `hivemind_search` / `hivemind_read` / `hivemind_index` tools confirmed registered in `before_prompt_build`

## Caveats

- **Capture (write path)** still hits the same Deeplake timeout intermittently — `Auto-capture failed: Query timeout after 10000ms` lines appear in the gateway log. `agent_end` runs *after* the agent responds, so this doesn't block the user, but it does drop some turns from memory until Deeplake's `sessions`-table query latency improves. **Separate issue, not addressed here.**
- The exact host state the original reporter hit (where adding `"hivemind"` to `plugins.allow` was needed even though tools were allowlisted) can't be reproduced on openclaw 2026.4.21 — that version has an "auto-promote plugins when their tools are in `alsoAllow`" feature that masks the gating. Older openclaw versions without that feature are the broken-state case the installer's `plugins.allow` patch is for.

## Confidence

`Confidence: high`, because the unit tests cover every edge case of the new config-patching logic, the local fixture E2E drove the real installer end-to-end against multiple fixture shapes, and the live gateway confirms the bundle loads + the recall hook no longer fires.

`Untested: openclaw versions older than 2026.4.21` (no host available; the installer's plugins.allow patch is the right fix for them but unverified end-to-end on those versions).

## Test plan

- [ ] CI green on this branch
- [ ] Reviewer reads through `openclaw/src/setup-config.ts` semantics (esp. `isPluginsAllowMissingHivemind` only-patch-explicit-arrays rule)
- [ ] Reviewer skims `openclaw/tests/install-openclaw.test.ts` and confirms test coverage matches the design intent in the description
- [ ] After merge: cut a release and verify users on default-restrictive openclaw configs see the plugin register after a fresh install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw installation now validates and patches configuration to ensure the hivemind plugin is properly allowlisted, with backup creation before changes.
  * Setup command displays which allowlist fields were updated during configuration patching.

* **Changes**
  * Removed automatic memory recall that occurred on every turn; recall is now available only through direct tool invocation.
  * Improved installation and cleanup processes for extension management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->