### PR TITLE
openclaw: bump checkForUpdate timeout 5s/3s → 10s (#105 + #109)

### DIFF
--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -189,7 +189,13 @@ async function checkForUpdate(logger: PluginLogger): Promise<void> {
   try {
     const current = getInstalledVersion();
     if (!current) return;
-    const res = await fetch(VERSION_URL, { signal: AbortSignal.timeout(5000) });
+    // 10s timeout: cold gateway init runs this concurrently with plugin
+    // discovery + Bonjour watchdogs + TLS warm-up. Steady-state npm
+    // registry latency is ~170ms, but 3s and 5s have both been observed
+    // to abort during cold start (see #105, #109). Fire-and-forget call
+    // path (see register() bottom), so a longer budget doesn't block
+    // anything user-visible.
+    const res = await fetch(VERSION_URL, { signal: AbortSignal.timeout(10000) });
     if (!res.ok) return;
     const latest = extractLatestVersion(await res.json());
     if (latest && isNewer(latest, current)) {
@@ -691,7 +697,11 @@ export default definePluginEntry({
           const current = getInstalledVersion();
           if (!current) return { text: "Could not determine installed version." };
           try {
-            const res = await fetch(VERSION_URL, { signal: AbortSignal.timeout(3000) });
+            // 10s timeout matches checkForUpdate (see #105, #109). The 3s
+            // budget here was too aggressive even off cold start, since
+            // /hivemind_version is often the first command after a fresh
+            // login and runs while other plugins are still initializing.
+            const res = await fetch(VERSION_URL, { signal: AbortSignal.timeout(10000) });
             if (!res.ok) return { text: `Current version: ${current}. Could not check for updates.` };
             const latest = extractLatestVersion(await res.json());
             if (!latest) return { text: `Current version: ${current}. Could not parse latest version.` };


### PR DESCRIPTION
Fixes #105 and #109.

## Why

Two `AbortSignal.timeout` budgets in `openclaw/src/index.ts` are aggressive enough to abort the npm-registry fetch on cold gateway init:

- Line 192 — `checkForUpdate` at startup (5s)
- Line 694 — `/hivemind_version` slash command (3s)

Steady-state response time from `registry.npmjs.org/@deeplake/hivemind/latest` is ~170ms. The aborts happen during cold start when this fetch runs concurrently with plugin discovery, Bonjour watchdogs, and TLS warm-up. Both issues track this same root cause.

Observed live on the user's gateway 2026-05-12T20:49:48 right after a `systemctl --user restart openclaw-gateway`:

```
[plugins] Auto-update check failed: The operation was aborted due to timeout
```

The expected `⬆️ Hivemind update available: <current> → <latest>. Run: hivemind update` notice never renders for that gateway run, so users miss the upgrade prompt until the next restart hits a warm cache.

## What changed

Bumped both timeouts to 10s (~60x headroom over observed steady-state latency).

- The startup site is fire-and-forget (`checkForUpdate(logger).catch(() => {})` at the bottom of `register()`), so a longer budget does **not** add session-start latency. Per the team's "no session-start latency" rule, the network call is intentionally unawaited; the only effect of a longer timeout is "the abort message no longer races a slow-but-eventually-succeeding fetch."
- The `/hivemind_version` site is a user-invoked command — 10s is well below user-patience threshold and matches the worst cold-start latency we want to cover.

## Tests

- `npm run typecheck` — clean
- `npm test` — 2380/2380 passing
- Source-only change; CI regenerates `openclaw/dist/`.

## Test plan

- [ ] After this lands and a release publishes, on a cold openclaw gateway: `journalctl --user -u openclaw-gateway -e | grep 'Auto-update check'` should show no "operation was aborted due to timeout" lines.
- [ ] Run `/hivemind_version` from inside the agent. Should return the `Update available / up to date` message, not "Could not check for updates."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of version checks and auto-update detection to better handle varying network conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->