### PR TITLE
openclaw: name message_embedding in auto-capture INSERT to avoid deeplake vector::at

### DIFF
--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -1258,9 +1258,19 @@ export default definePluginEntry({
             // For JSONB: only escape single quotes, keep JSON structure intact
             const jsonForSql = line.replace(/'/g, "''");
 
+            // Include `message_embedding` with explicit NULL even though
+            // openclaw can't generate embeddings (the bundle stubs
+            // node:child_process, so we can't spawn the embed daemon).
+            // Omitting the column entirely makes deeplake-api's storage
+            // layer hit an internal `vector::at out of range` on the
+            // FLOAT4[] column — pre-PR-#168 claude-code captured NULL
+            // embeddings successfully because its INSERT NAMED the column
+            // with a NULL value (see embeddingSqlLiteral → "NULL"). The
+            // delta is "missing column" vs "named column with NULL value"
+            // — column-store backends treat these differently.
             const insertSql =
-              `INSERT INTO "${sessionsTable}" (id, path, filename, message, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-              `VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, '${sqlStr(cfg.userName)}', ` +
+              `INSERT INTO "${sessionsTable}" (id, path, filename, message, message_embedding, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
+              `VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, NULL, '${sqlStr(cfg.userName)}', ` +
               `${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', '${sqlStr(msg.role)}', 'openclaw', '${sqlStr(getInstalledVersion() ?? "")}', '${ts}', '${ts}')`;
 
             try {

--- a/tests/claude-code/skillify-session-start-injection.test.ts
+++ b/tests/claude-code/skillify-session-start-injection.test.ts
@@ -289,10 +289,12 @@ describe("OpenClaw skillify worker (mining) wiring", () => {
     expect(src).toMatch(/const skillifySpawnedFor = new Set<string>\(\)/);
     expect(src).toMatch(/if \(!skillifySpawnedFor\.has\(sid\)\)/);
     expect(src).toMatch(/skillifySpawnedFor\.add\(sid\)/);
-    // agent_end hook calls it after the capture loop. Distance bumped
-    // from 500→1500 to accommodate the per-runtime spawn-dedup comment
-    // block landed for #100 between `Auto-captured` and the spawn site.
-    expect(src).toMatch(/agent_end[\s\S]{0,3500}Auto-captured[\s\S]{0,1500}spawnOpenclawSkillifyWorker/);
+    // agent_end hook calls it after the capture loop. Window 1: from
+    // agent_end to `Auto-captured` covers the INSERT loop including
+    // its column-shape comment. Window 2: from `Auto-captured` to the
+    // spawn site covers the dedup + spawn-handling block. Both have
+    // grown over time as documentation accreted; resize when it trips.
+    expect(src).toMatch(/agent_end[\s\S]{0,4500}Auto-captured[\s\S]{0,2500}spawnOpenclawSkillifyWorker/);
     // install: "global" — no per-project cwd, skills land under ~/.claude/skills/
     expect(src).toMatch(/install:\s*"global"/);
   });


### PR DESCRIPTION
## Summary

Auto-capture has been failing in production with `Auto-capture failed: Query failed: 500: {"error":"Database error: Failed to insert tuple: vector::at out of range"}` on every openclaw turn. Diagnosed during the live E2E test of #170/#171/#172/#124 against `@deeplake/hivemind@0.7.32`.

## Root cause

The openclaw auto-capture INSERT omits the `message_embedding` column entirely. The bundle stubs `node:child_process` so it can't spawn the embed daemon; the prior assumption was that an unmentioned `FLOAT4[]` column would default to NULL. It doesn't — deeplake-api's tuple-builder hits an internal C++ bounds check on the missing column.

Side-by-side:

```sql
-- openclaw (current, fails with vector::at):
INSERT INTO "sessions" (id, path, filename, message,                     author, ...)
                                                    ^ column OMITTED
VALUES                  (uuid, ..., jsonb,                              author, ...)

-- claude-code (works, even with NULL embedding):
INSERT INTO "sessions" (id, path, filename, message, message_embedding, author, ...)
                                                     ^^^^^^^^^^^^^^^^^
VALUES                  (uuid, ..., jsonb,           NULL,              author, ...)
```

## Decisive evidence this is fixable on our side

PR #168's body explicitly states pre-fix claude-code wrote rows with `message_embedding = NULL` successfully ("writes through as `NULL` forever after"). Those rows weren't rejected — they just had NULL embeddings. So deeplake-api **does** accept a NULL FLOAT4[] when the column is **named** in the INSERT. The literal difference between "writes succeed with NULL" and "vector::at out of range" is whether the column appears in the INSERT column list.

## Fix

Name `message_embedding` in the openclaw INSERT and pass `NULL` in the values tuple — mirroring the working claude-code-with-NULL-embedding shape. One semantic delta at the call site (`openclaw/src/index.ts`).

Plus a regex window bump in `tests/claude-code/skillify-session-start-injection.test.ts` (the inline comment documenting why we need the explicit NULL pushed past the previous 3500-char window between `agent_end` and `Auto-captured`).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` produces the openclaw bundle with the new INSERT
- [x] `npm test` — 2708/2709 pass; the 1 failure is `deeplake-fs.test.ts > batches and flushes on BATCH_SIZE writes` which also fails on `origin/main` (pre-existing flake, unrelated)
- [x] `npm run audit:openclaw -- --criticals-only` — 0 critical
- [ ] **Live verification once merged**: install `0.7.33` (or whatever the bump-bot produces), restart openclaw gateway, send a Telegram message, confirm `Auto-captured N messages` log line appears instead of `vector::at`

## Out of scope (separate)

- The `Query timeout after 10000ms` failures — once `vector::at` stops, we'll know whether the timeouts also stop (most are likely the slow-failure path of the same bug) or are a real deeplake-side write-latency issue that warrants a separate report.
- The pre-existing structural bug where the skillify spawn lives inside the auto-capture try/catch (so when capture fails, mining also gets skipped) — separate small PR.
- A nice-to-have feedback for the deeplake team: `vector::at out of range` is a C++ assertion leak that's hard to debug from the plugin side; a clearer "INSERT missing required column for column-store table" message would have saved hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session data capture to explicitly include all required fields with consistent handling
* **Tests**
  * Updated test assertions to validate improved session capture behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->