### PR TITLE
embeddings: drop user-visible 'deps missing' banner, keep recycle

### DIFF
--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4475,13 +4475,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log4(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log4(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -4480,11 +4480,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log4(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/bundle/cli.js
+++ b/bundle/cli.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync14, mkdirSync as mkdirSync4, readFileSync as readFileSync12, writeFileSync as writeFileSync8 } from "node:fs";
-import { join as join17 } from "node:path";
+import { existsSync as existsSync14, mkdirSync as mkdirSync5, readFileSync as readFileSync13, writeFileSync as writeFileSync9 } from "node:fs";
+import { join as join18 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join17(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join18(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join17(getIndexMarkerDir(), `${markerKey}.json`);
+  return join18(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync14(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync12(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync13(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync4(getIndexMarkerDir(), { recursive: true });
-  writeFileSync8(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync5(getIndexMarkerDir(), { recursive: true });
+  writeFileSync9(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -4343,6 +4343,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync12, writeFileSync as writeFileSync8, renameSync as renameSync3, mkdirSync as mkdirSync4, openSync, closeSync, unlinkSync as unlinkSync7, statSync as statSync2 } from "node:fs";
+import { join as join17, resolve } from "node:path";
+import { homedir as homedir8 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log3 = (msg) => log2("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join17(homedir8(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync12(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log3(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir8());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync4(join17(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync8(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync3(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync4(join17(homedir8(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync2(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync7(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync7(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -4350,7 +4451,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log3 = (msg) => log2("sdk", msg);
+var log4 = (msg) => log2("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -4362,7 +4463,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log3(msg);
+    log4(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log4(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log4(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -4371,8 +4493,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -4402,7 +4524,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -4473,8 +4595,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log4(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -4490,10 +4612,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log4(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -4514,7 +4637,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log3(`commit: ${rows.length} rows`);
+    log4(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -4570,7 +4693,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log3(`index "${indexName}" skipped: ${e.message}`);
+      log4(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -4660,13 +4783,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -4694,9 +4817,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log4(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -4707,9 +4830,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log3(`table "${tbl}" not found, creating`);
+      log4(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log3(`table "${tbl}" created`);
+      log4(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -4722,9 +4845,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log3(`table "${safe}" not found, creating`);
+      log4(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log3(`table "${safe}" created`);
+      log4(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -4747,9 +4870,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log3(`table "${safe}" not found, creating`);
+      log4(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log3(`table "${safe}" created`);
+      log4(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -4780,10 +4903,10 @@ function parseArgs(argv) {
 }
 function confirm(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     rl.question(`${message} [y/N] `, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
+      resolve2(answer.trim().toLowerCase() === "y");
     });
   });
 }
@@ -5085,34 +5208,34 @@ if (process.argv[1] && process.argv[1].endsWith("auth-login.js")) {
 }
 
 // dist/src/commands/skillify.js
-import { readdirSync as readdirSync5, existsSync as existsSync26, readFileSync as readFileSync20, mkdirSync as mkdirSync11, renameSync as renameSync6 } from "node:fs";
-import { homedir as homedir19 } from "node:os";
-import { dirname as dirname7, join as join29 } from "node:path";
+import { readdirSync as readdirSync5, existsSync as existsSync26, readFileSync as readFileSync21, mkdirSync as mkdirSync12, renameSync as renameSync7 } from "node:fs";
+import { homedir as homedir20 } from "node:os";
+import { dirname as dirname7, join as join30 } from "node:path";
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync16, mkdirSync as mkdirSync5, readFileSync as readFileSync13, writeFileSync as writeFileSync9 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join19 } from "node:path";
+import { existsSync as existsSync16, mkdirSync as mkdirSync6, readFileSync as readFileSync14, writeFileSync as writeFileSync10 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join20 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync15, renameSync as renameSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join18 } from "node:path";
+import { existsSync as existsSync15, renameSync as renameSync4 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join19 } from "node:path";
 var dlog = (msg) => log2("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join18(homedir8(), ".deeplake", "state");
-  const legacy = join18(root, "skilify");
-  const current = join18(root, "skillify");
+  const root = join19(homedir9(), ".deeplake", "state");
+  const legacy = join19(root, "skilify");
+  const current = join19(root, "skillify");
   if (!existsSync15(legacy))
     return;
   if (existsSync15(current))
     return;
   try {
-    renameSync3(legacy, current);
+    renameSync4(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -5125,15 +5248,15 @@ function migrateLegacyStateDir() {
 }
 
 // dist/src/skillify/scope-config.js
-var STATE_DIR = join19(homedir9(), ".deeplake", "state", "skillify");
-var CONFIG_PATH2 = join19(STATE_DIR, "config.json");
+var STATE_DIR = join20(homedir10(), ".deeplake", "state", "skillify");
+var CONFIG_PATH2 = join20(STATE_DIR, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync16(CONFIG_PATH2))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync13(CONFIG_PATH2, "utf-8"));
+    const raw = JSON.parse(readFileSync14(CONFIG_PATH2, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -5144,19 +5267,19 @@ function loadScopeConfig() {
 }
 function saveScopeConfig(cfg) {
   migrateLegacyStateDir();
-  mkdirSync5(STATE_DIR, { recursive: true });
-  writeFileSync9(CONFIG_PATH2, JSON.stringify(cfg, null, 2));
+  mkdirSync6(STATE_DIR, { recursive: true });
+  writeFileSync10(CONFIG_PATH2, JSON.stringify(cfg, null, 2));
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync20, readFileSync as readFileSync16, writeFileSync as writeFileSync12, mkdirSync as mkdirSync8, renameSync as renameSync5, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync8 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { dirname as dirname4, join as join23 } from "node:path";
+import { existsSync as existsSync20, readFileSync as readFileSync17, writeFileSync as writeFileSync13, mkdirSync as mkdirSync9, renameSync as renameSync6, lstatSync as lstatSync4, readlinkSync as readlinkSync2, symlinkSync as symlinkSync2, unlinkSync as unlinkSync9 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { dirname as dirname4, join as join24 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync17, mkdirSync as mkdirSync6, readFileSync as readFileSync14, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync10 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join20 } from "node:path";
+import { existsSync as existsSync17, mkdirSync as mkdirSync7, readFileSync as readFileSync15, readdirSync as readdirSync2, statSync as statSync3, writeFileSync as writeFileSync11 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join21 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -5172,10 +5295,10 @@ function assertValidSkillName(name) {
   }
 }
 function skillDir(skillsRoot, name) {
-  return join20(skillsRoot, name);
+  return join21(skillsRoot, name);
 }
 function skillPath(skillsRoot, name) {
-  return join20(skillDir(skillsRoot, name), "SKILL.md");
+  return join21(skillDir(skillsRoot, name), "SKILL.md");
 }
 function renderFrontmatter(fm) {
   const lines = ["---"];
@@ -5256,7 +5379,7 @@ function writeNewSkill(args) {
   if (existsSync17(path)) {
     throw new Error(`skill already exists at ${path}; use mergeSkill`);
   }
-  mkdirSync6(dir, { recursive: true });
+  mkdirSync7(dir, { recursive: true });
   const now = (/* @__PURE__ */ new Date()).toISOString();
   const author = args.author && args.author.length > 0 ? args.author : void 0;
   const contributors = author ? [author] : [];
@@ -5276,7 +5399,7 @@ function writeNewSkill(args) {
 
 ${args.body.trim()}
 `;
-  writeFileSync10(path, text);
+  writeFileSync11(path, text);
   return {
     path,
     action: "created",
@@ -5292,29 +5415,29 @@ function listSkills(skillsRoot) {
     return [];
   const out = [];
   for (const name of readdirSync2(skillsRoot)) {
-    const skillFile = join20(skillsRoot, name, "SKILL.md");
-    if (existsSync17(skillFile) && statSync2(skillFile).isFile()) {
-      out.push({ name, body: readFileSync14(skillFile, "utf-8") });
+    const skillFile = join21(skillsRoot, name, "SKILL.md");
+    if (existsSync17(skillFile) && statSync3(skillFile).isFile()) {
+      out.push({ name, body: readFileSync15(skillFile, "utf-8") });
     }
   }
   return out;
 }
 function resolveSkillsRoot(install, cwd) {
   if (install === "global") {
-    return join20(homedir10(), ".claude", "skills");
+    return join21(homedir11(), ".claude", "skills");
   }
-  return join20(cwd, ".claude", "skills");
+  return join21(cwd, ".claude", "skills");
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync18, lstatSync as lstatSync3, mkdirSync as mkdirSync7, readFileSync as readFileSync15, renameSync as renameSync4, unlinkSync as unlinkSync7, writeFileSync as writeFileSync11 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { dirname as dirname3, join as join21 } from "node:path";
+import { existsSync as existsSync18, lstatSync as lstatSync3, mkdirSync as mkdirSync8, readFileSync as readFileSync16, renameSync as renameSync5, unlinkSync as unlinkSync8, writeFileSync as writeFileSync12 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { dirname as dirname3, join as join22 } from "node:path";
 function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join21(homedir11(), ".deeplake", "state", "skillify", "pulled.json");
+  return join22(homedir12(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -5322,7 +5445,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync15(path, "utf-8");
+    raw = readFileSync16(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -5369,10 +5492,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync7(dirname3(path), { recursive: true });
+  mkdirSync8(dirname3(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync11(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync4(tmp, path);
+  writeFileSync12(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync5(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -5404,7 +5527,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync7(path);
+      unlinkSync8(path);
     } catch {
     }
   }
@@ -5414,7 +5537,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync18(join21(e.installRoot, e.dirName))) {
+    if (existsSync18(join22(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -5428,25 +5551,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync19 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join22 } from "node:path";
+import { homedir as homedir13 } from "node:os";
+import { join as join23 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync19(join22(home, ".codex"));
-  const piInstalled = existsSync19(join22(home, ".pi", "agent"));
-  const hermesInstalled = existsSync19(join22(home, ".hermes"));
+  const codexInstalled = existsSync19(join23(home, ".codex"));
+  const piInstalled = existsSync19(join23(home, ".pi", "agent"));
+  const hermesInstalled = existsSync19(join23(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join22(home, ".agents", "skills"));
+    out.push(join23(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join22(home, ".hermes", "skills"));
+    out.push(join23(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join22(home, ".pi", "agent", "skills"));
+    out.push(join23(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir12()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir13()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -5490,15 +5613,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join23(homedir13(), ".claude", "skills");
+    return join24(homedir14(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join23(cwd, ".claude", "skills");
+  return join24(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join23(root, dirName);
+    const link = join24(root, dirName);
     let existing;
     try {
       existing = lstatSync4(link);
@@ -5520,13 +5643,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync8(link);
+        unlinkSync9(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync8(dirname4(link), { recursive: true });
+      mkdirSync9(dirname4(link), { recursive: true });
       symlinkSync2(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -5541,7 +5664,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join23(entry.installRoot, entry.dirName);
+    const canonical = join24(entry.installRoot, entry.dirName);
     if (!existsSync20(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -5655,7 +5778,7 @@ function readLocalVersion(path) {
   if (!existsSync20(path))
     return null;
   try {
-    const text = readFileSync16(path, "utf-8");
+    const text = readFileSync17(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -5750,8 +5873,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir2 = join23(root, dirName);
-    const skillFile = join23(skillDir2, "SKILL.md");
+    const skillDir2 = join24(root, dirName);
+    const skillFile = join24(skillDir2, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -5762,14 +5885,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync8(skillDir2, { recursive: true });
+      mkdirSync9(skillDir2, { recursive: true });
       if (existsSync20(skillFile)) {
         try {
-          renameSync5(skillFile, `${skillFile}.bak`);
+          renameSync6(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync12(skillFile, renderSkillFile(row));
+      writeFileSync13(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir2, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -5811,15 +5934,15 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/unpull.js
-import { existsSync as existsSync21, readdirSync as readdirSync3, rmSync as rmSync5, statSync as statSync3 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { join as join24 } from "node:path";
+import { existsSync as existsSync21, readdirSync as readdirSync3, rmSync as rmSync5, statSync as statSync4 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { join as join25 } from "node:path";
 function resolveUnpullRoot(install, cwd) {
   if (install === "global")
-    return join24(homedir14(), ".claude", "skills");
+    return join25(homedir15(), ".claude", "skills");
   if (!cwd)
     throw new Error("cwd required when install === 'project'");
-  return join24(cwd, ".claude", "skills");
+  return join25(cwd, ".claude", "skills");
 }
 function runUnpull(opts) {
   const root = resolveUnpullRoot(opts.install, opts.cwd);
@@ -5842,7 +5965,7 @@ function runUnpull(opts) {
   const entries = entriesForRoot(manifest, opts.install, root);
   for (const entry of entries) {
     summary.scanned++;
-    const path = join24(root, entry.dirName);
+    const path = join25(root, entry.dirName);
     if (!existsSync21(path)) {
       if (!opts.dryRun) {
         unlinkSymlinks(entry.symlinks);
@@ -5901,10 +6024,10 @@ function runUnpull(opts) {
     for (const dirName of readdirSync3(root)) {
       if (manifestDirNames.has(dirName))
         continue;
-      const path = join24(root, dirName);
+      const path = join25(root, dirName);
       let st;
       try {
-        st = statSync3(path);
+        st = statSync4(path);
       } catch {
         continue;
       }
@@ -5980,21 +6103,21 @@ function decideTargetForManifestEntry(entry, opts, userFilter, haveUserFilter) {
 
 // dist/src/commands/mine-local.js
 import { spawn } from "node:child_process";
-import { existsSync as existsSync25, mkdirSync as mkdirSync10, readFileSync as readFileSync19, writeFileSync as writeFileSync14 } from "node:fs";
-import { homedir as homedir18 } from "node:os";
-import { basename, dirname as dirname6, join as join28 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync11, readFileSync as readFileSync20, writeFileSync as writeFileSync15 } from "node:fs";
+import { homedir as homedir19 } from "node:os";
+import { basename, dirname as dirname6, join as join29 } from "node:path";
 
 // dist/src/skillify/local-source.js
-import { readdirSync as readdirSync4, readFileSync as readFileSync17, existsSync as existsSync22, statSync as statSync4 } from "node:fs";
-import { homedir as homedir15 } from "node:os";
-import { join as join25 } from "node:path";
-var HOME2 = homedir15();
+import { readdirSync as readdirSync4, readFileSync as readFileSync18, existsSync as existsSync22, statSync as statSync5 } from "node:fs";
+import { homedir as homedir16 } from "node:os";
+import { join as join26 } from "node:path";
+var HOME2 = homedir16();
 function encodeCwdClaudeCode(cwd) {
   return cwd.replace(/[/_]/g, "-");
 }
 function detectInstalledAgents() {
   const installs = [];
-  const claudeRoot = join25(HOME2, ".claude", "projects");
+  const claudeRoot = join26(HOME2, ".claude", "projects");
   if (existsSync22(claudeRoot)) {
     installs.push({
       agent: "claude_code",
@@ -6002,7 +6125,7 @@ function detectInstalledAgents() {
       encodeCwd: encodeCwdClaudeCode
     });
   }
-  const codexRoot = join25(HOME2, ".codex", "sessions");
+  const codexRoot = join26(HOME2, ".codex", "sessions");
   if (existsSync22(codexRoot)) {
     installs.push({
       agent: "codex",
@@ -6030,9 +6153,9 @@ function listLocalSessions(installs, cwd) {
       continue;
     }
     for (const sub of subdirs) {
-      const subdirPath = join25(install.sessionRoot, sub);
+      const subdirPath = join26(install.sessionRoot, sub);
       try {
-        if (!statSync4(subdirPath).isDirectory())
+        if (!statSync5(subdirPath).isDirectory())
           continue;
       } catch {
         continue;
@@ -6047,10 +6170,10 @@ function listLocalSessions(installs, cwd) {
       for (const f of files) {
         if (!f.endsWith(".jsonl"))
           continue;
-        const fullPath = join25(subdirPath, f);
+        const fullPath = join26(subdirPath, f);
         let stats;
         try {
-          stats = statSync4(fullPath);
+          stats = statSync5(fullPath);
         } catch {
           continue;
         }
@@ -6108,7 +6231,7 @@ function pickSessions(candidates, opts) {
 function nativeJsonlToRows(filePath, sessionId, agent) {
   let raw;
   try {
-    raw = readFileSync17(filePath, "utf-8");
+    raw = readFileSync18(filePath, "utf-8");
   } catch {
     return [];
   }
@@ -6200,8 +6323,8 @@ function extractPairs(rows) {
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync23 } from "node:fs";
 import { createRequire } from "node:module";
-import { homedir as homedir16 } from "node:os";
-import { join as join26 } from "node:path";
+import { homedir as homedir17 } from "node:os";
+import { join as join27 } from "node:path";
 var requireForCp = createRequire(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -6213,7 +6336,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir16();
+  const home = homedir17();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -6222,45 +6345,45 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join26(home, ".claude", "local", "claude"),
+        join27(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join26(home, ".npm-global", "bin", "claude"),
-        join26(home, ".local", "bin", "claude"),
+        join27(home, ".npm-global", "bin", "claude"),
+        join27(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join26(home, ".claude", "local", "claude");
+      ]) ?? join27(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join26(home, ".npm-global", "bin", "codex"),
-        join26(home, ".local", "bin", "codex"),
+        join27(home, ".npm-global", "bin", "codex"),
+        join27(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join26(home, ".npm-global", "bin", "cursor-agent"),
-        join26(home, ".local", "bin", "cursor-agent"),
+        join27(home, ".npm-global", "bin", "cursor-agent"),
+        join27(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join26(home, ".local", "bin", "hermes"),
+        join27(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join26(home, ".npm-global", "bin", "hermes"),
+        join27(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join26(home, ".local", "bin", "hermes");
+      ]) ?? join27(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join26(home, ".local", "bin", "pi"),
+        join27(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join26(home, ".npm-global", "bin", "pi"),
+        join27(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join26(home, ".local", "bin", "pi");
+      ]) ?? join27(home, ".local", "bin", "pi");
   }
 }
 
@@ -6290,27 +6413,27 @@ function extractJsonBlock(s) {
 }
 
 // dist/src/skillify/local-manifest.js
-import { existsSync as existsSync24, mkdirSync as mkdirSync9, readFileSync as readFileSync18, writeFileSync as writeFileSync13 } from "node:fs";
-import { homedir as homedir17 } from "node:os";
-import { dirname as dirname5, join as join27 } from "node:path";
-var LOCAL_MANIFEST_PATH = join27(homedir17(), ".claude", "hivemind", "local-mined.json");
-var LOCAL_MINE_LOCK_PATH = join27(homedir17(), ".claude", "hivemind", "local-mined.lock");
+import { existsSync as existsSync24, mkdirSync as mkdirSync10, readFileSync as readFileSync19, writeFileSync as writeFileSync14 } from "node:fs";
+import { homedir as homedir18 } from "node:os";
+import { dirname as dirname5, join as join28 } from "node:path";
+var LOCAL_MANIFEST_PATH = join28(homedir18(), ".claude", "hivemind", "local-mined.json");
+var LOCAL_MINE_LOCK_PATH = join28(homedir18(), ".claude", "hivemind", "local-mined.lock");
 function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
   if (!existsSync24(path))
     return null;
   try {
-    return JSON.parse(readFileSync18(path, "utf-8"));
+    return JSON.parse(readFileSync19(path, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeLocalManifest(m, path = LOCAL_MANIFEST_PATH) {
-  mkdirSync9(dirname5(path), { recursive: true });
-  writeFileSync13(path, JSON.stringify(m, null, 2));
+  mkdirSync10(dirname5(path), { recursive: true });
+  writeFileSync14(path, JSON.stringify(m, null, 2));
 }
 
 // dist/src/commands/mine-local.js
-import { unlinkSync as unlinkSync9 } from "node:fs";
+import { unlinkSync as unlinkSync10 } from "node:fs";
 var EPSILON = 0.3;
 var DEFAULT_N = 8;
 var PAIR_CHAR_CAP = 4e3;
@@ -6321,9 +6444,9 @@ var IN_FLIGHT_MAX_AGE_MS = 6e4;
 var GATE_TIMEOUT_MS = 24e4;
 var MANIFEST_PATH = LOCAL_MANIFEST_PATH;
 function runGateViaStdin(opts) {
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     if (opts.agent !== "claude_code") {
-      resolve({
+      resolve2({
         stdout: "",
         stderr: "",
         errored: true,
@@ -6332,7 +6455,7 @@ function runGateViaStdin(opts) {
       return;
     }
     if (!existsSync25(opts.bin)) {
-      resolve({
+      resolve2({
         stdout: "",
         stderr: "",
         errored: true,
@@ -6359,7 +6482,7 @@ function runGateViaStdin(opts) {
       if (settled)
         return;
       settled = true;
-      resolve(r);
+      resolve2(r);
     };
     const timer = setTimeout(() => {
       try {
@@ -6619,7 +6742,7 @@ async function runMineLocal(args) {
       return;
     lockReleased = true;
     try {
-      unlinkSync9(LOCAL_MINE_LOCK_PATH);
+      unlinkSync10(LOCAL_MINE_LOCK_PATH);
     } catch {
     }
   };
@@ -6676,8 +6799,8 @@ async function runMineLocalImpl(args) {
     console.log(`Dry-run: would invoke ${gateAgent} gate on ${picked.length} session(s) in parallel (concurrency=${GATE_CONCURRENCY}).`);
     return;
   }
-  const tmpDir = join28(homedir18(), ".claude", "hivemind", `mine-local-${Date.now()}`);
-  mkdirSync10(tmpDir, { recursive: true });
+  const tmpDir = join29(homedir19(), ".claude", "hivemind", `mine-local-${Date.now()}`);
+  mkdirSync11(tmpDir, { recursive: true });
   console.log(`Running ${picked.length} gate call(s) in parallel (concurrency=${GATE_CONCURRENCY}, timeout=${GATE_TIMEOUT_MS / 1e3}s each)...`);
   const results = await parallelMap(picked, GATE_CONCURRENCY, async (s) => {
     const shortId = s.sessionId.slice(0, 8);
@@ -6688,23 +6811,23 @@ async function runMineLocalImpl(args) {
       return { session: s, skills: [], reason: "no pairs", error: null };
     }
     const tail = pairs2.slice(-PER_SESSION_PAIR_CAP);
-    const sessionTmp = join28(tmpDir, `s-${shortId}`);
-    mkdirSync10(sessionTmp, { recursive: true });
-    const verdictPath = join28(sessionTmp, "verdict.json");
+    const sessionTmp = join29(tmpDir, `s-${shortId}`);
+    mkdirSync11(sessionTmp, { recursive: true });
+    const verdictPath = join29(sessionTmp, "verdict.json");
     const prompt = buildSessionPrompt(tail, s, verdictPath);
-    writeFileSync14(join28(sessionTmp, "prompt.txt"), prompt);
+    writeFileSync15(join29(sessionTmp, "prompt.txt"), prompt);
     const gate = await runGateViaStdin({ agent: gateAgent, bin: gateBin, prompt, timeoutMs: GATE_TIMEOUT_MS });
     try {
-      writeFileSync14(join28(sessionTmp, "gate-stdout.txt"), gate.stdout);
+      writeFileSync15(join29(sessionTmp, "gate-stdout.txt"), gate.stdout);
       if (gate.stderr)
-        writeFileSync14(join28(sessionTmp, "gate-stderr.txt"), gate.stderr);
+        writeFileSync15(join29(sessionTmp, "gate-stderr.txt"), gate.stderr);
     } catch {
     }
     if (gate.errored) {
       console.log(`  [${shortId}] gate failed: ${gate.errorMessage}`);
       return { session: s, skills: [], reason: null, error: gate.errorMessage ?? "gate failed" };
     }
-    const verdictText = existsSync25(verdictPath) ? readFileSync19(verdictPath, "utf-8") : gate.stdout;
+    const verdictText = existsSync25(verdictPath) ? readFileSync20(verdictPath, "utf-8") : gate.stdout;
     const mv = parseMultiVerdict(verdictText);
     if (!mv) {
       console.log(`  [${shortId}] unparseable verdict (kept at ${sessionTmp})`);
@@ -6920,7 +7043,7 @@ function wrapAt(s, max) {
 
 // dist/src/commands/skillify.js
 function stateDir() {
-  return join29(homedir19(), ".deeplake", "state", "skillify");
+  return join30(homedir20(), ".deeplake", "state", "skillify");
 }
 function showStatus() {
   const cfg = loadScopeConfig();
@@ -6940,7 +7063,7 @@ function showStatus() {
   console.log(`state: ${files.length} project(s) tracked`);
   for (const f of files) {
     try {
-      const s = JSON.parse(readFileSync20(join29(dir, f), "utf-8"));
+      const s = JSON.parse(readFileSync21(join30(dir, f), "utf-8"));
       const last = typeof s.updatedAt === "number" ? new Date(s.updatedAt).toISOString() : s.lastDate ?? "never";
       const skills = Array.isArray(s.skillsGenerated) && s.skillsGenerated.length > 0 ? s.skillsGenerated.join(", ") : "none";
       console.log(`  - ${s.project} (counter=${s.counter}, last=${last}, skills=${skills})`);
@@ -6967,7 +7090,7 @@ function setInstall(loc) {
   }
   const cfg = loadScopeConfig();
   saveScopeConfig({ ...cfg, install: loc });
-  const path = loc === "global" ? join29(homedir19(), ".claude", "skills") : "<cwd>/.claude/skills";
+  const path = loc === "global" ? join30(homedir20(), ".claude", "skills") : "<cwd>/.claude/skills";
   console.log(`Install location set to '${loc}'. New skills will be written to ${path}/<name>/SKILL.md.`);
 }
 function promoteSkill(name, cwd) {
@@ -6975,18 +7098,18 @@ function promoteSkill(name, cwd) {
     console.error("Usage: hivemind skillify promote <skill-name>");
     process.exit(1);
   }
-  const projectPath = join29(cwd, ".claude", "skills", name);
-  const globalPath = join29(homedir19(), ".claude", "skills", name);
-  if (!existsSync26(join29(projectPath, "SKILL.md"))) {
+  const projectPath = join30(cwd, ".claude", "skills", name);
+  const globalPath = join30(homedir20(), ".claude", "skills", name);
+  if (!existsSync26(join30(projectPath, "SKILL.md"))) {
     console.error(`Skill '${name}' not found at ${projectPath}/SKILL.md`);
     process.exit(1);
   }
-  if (existsSync26(join29(globalPath, "SKILL.md"))) {
+  if (existsSync26(join30(globalPath, "SKILL.md"))) {
     console.error(`Skill '${name}' already exists at ${globalPath}/SKILL.md \u2014 refusing to overwrite. Remove it first or rename the project skill.`);
     process.exit(1);
   }
-  mkdirSync11(dirname7(globalPath), { recursive: true });
-  renameSync6(projectPath, globalPath);
+  mkdirSync12(dirname7(globalPath), { recursive: true });
+  renameSync7(projectPath, globalPath);
   console.log(`Promoted '${name}' from ${projectPath} \u2192 ${globalPath}.`);
 }
 function teamAdd(name) {
@@ -7092,7 +7215,7 @@ async function pullSkills(args) {
     console.error(`pull failed: ${e?.message ?? e}`);
     process.exit(1);
   }
-  const dest = toRaw === "global" ? join29(homedir19(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join30(homedir20(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterDesc = users.length === 0 ? "all users" : users.join(", ");
   console.log(`Destination: ${dest}`);
   console.log(`Filter:      ${filterDesc}${skillName ? ` \xB7 skill='${skillName}'` : ""}${dryRun ? " \xB7 dry-run" : ""}${force ? " \xB7 force" : ""}`);
@@ -7142,7 +7265,7 @@ async function unpullSkills(args) {
     all,
     legacyCleanup
   });
-  const dest = toRaw === "global" ? join29(homedir19(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
+  const dest = toRaw === "global" ? join30(homedir20(), ".claude", "skills") : `${process.cwd()}/.claude/skills`;
   const filterParts = [];
   if (users.length > 0)
     filterParts.push(`users=${users.join(",")}`);
@@ -7238,13 +7361,13 @@ if (process.argv[1] && process.argv[1].endsWith("skillify.js")) {
 
 // dist/src/cli/update.js
 import { execFileSync as execFileSync4 } from "node:child_process";
-import { existsSync as existsSync27, readFileSync as readFileSync22, realpathSync } from "node:fs";
+import { existsSync as existsSync27, readFileSync as readFileSync23, realpathSync } from "node:fs";
 import { dirname as dirname9, sep } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync21 } from "node:fs";
-import { dirname as dirname8, join as join30 } from "node:path";
+import { readFileSync as readFileSync22 } from "node:fs";
+import { dirname as dirname8, join as join31 } from "node:path";
 function isNewer(latest, current) {
   const parse = (v) => v.split(".").map(Number);
   const [la, lb, lc] = parse(latest);
@@ -7268,7 +7391,7 @@ function detectInstallKind(argv1) {
   for (let i = 0; i < 10; i++) {
     const pkgPath = `${dir}${sep}package.json`;
     try {
-      const pkg = JSON.parse(readFileSync22(pkgPath, "utf-8"));
+      const pkg = JSON.parse(readFileSync23(pkgPath, "utf-8"));
       if (pkg.name === PKG_NAME || pkg.name === "hivemind") {
         installDir = dir;
         break;

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -176,7 +176,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +206,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -1272,9 +1272,9 @@ function tryStopCounterTrigger(opts) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync9, readFileSync as readFileSync9 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
+import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync3, unlinkSync as unlinkSync3, existsSync as existsSync8, readFileSync as readFileSync7 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1287,105 +1287,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync7, renameSync as renameSync4, mkdirSync as mkdirSync8, openSync as openSync3, closeSync as closeSync3, unlinkSync as unlinkSync3, statSync } from "node:fs";
-import { join as join13, resolve } from "node:path";
-import { homedir as homedir10 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join13(homedir10(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join13(homedir10(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath3() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync7(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync8(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir10());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync8(join13(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync4(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath3();
-  mkdirSync8(join13(homedir10(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync3(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync3(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync8(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync3(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync3(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync8(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync7(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync8(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync3(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync3(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync3(this.pidPath, "wx", 384);
+      writeSync3(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync3(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync3(this.pidPath, "wx", 384);
+          writeSync3(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync8(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync3(fd);
+        unlinkSync3(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn3(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync3(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync7(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync8(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v of vec) {
+    if (!Number.isFinite(v))
+      return "NULL";
+    parts.push(String(v));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -1395,7 +1674,7 @@ import { join as join15 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync8, mkdirSync as mkdirSync9, readFileSync as readFileSync8, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
+import { existsSync as existsSync9, mkdirSync as mkdirSync8, readFileSync as readFileSync8, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
 import { dirname as dirname4, join as join14 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join14(homedir11(), ".deeplake", "config.json");
@@ -1405,7 +1684,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync8(path)) {
+  if (!existsSync9(path)) {
     _cache = {};
     return _cache;
   }
@@ -1423,11 +1702,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname4(path);
-  if (!existsSync8(dir))
-    mkdirSync9(dir, { recursive: true });
+  if (!existsSync9(dir))
+    mkdirSync8(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync5(tmp, path);
+  writeFileSync7(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync4(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1506,414 +1785,17 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join16(homedir13(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync9(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync9(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync9(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync9(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync9(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync4(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync4(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync4(this.pidPath, "wx", 384);
-      writeSync3(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync4(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync4(this.pidPath, "wx", 384);
-          writeSync3(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync9(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync4(fd);
-        unlinkSync4(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn3(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync4(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync9(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync9(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v of vec) {
-    if (!Number.isFinite(v))
-      return "NULL";
-    parts.push(String(v));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
-}
-
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync10, readlinkSync, renameSync as renameSync6, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { basename as basename2, dirname as dirname5, join as join17 } from "node:path";
+import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync9, readlinkSync, renameSync as renameSync5, rmSync, symlinkSync, statSync } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { basename as basename2, dirname as dirname5, join as join16 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename2(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join17(homedir14(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join16(homedir13(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname5(opts.bundleDir);
-  const link = join17(pluginDir, "node_modules");
+  const link = join16(pluginDir, "node_modules");
   if (!existsSync10(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1934,7 +1816,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync2(link);
+      statSync(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1954,14 +1836,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname5(link);
     if (!existsSync10(parent))
-      mkdirSync10(parent, { recursive: true });
+      mkdirSync9(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync6(tmp, link);
+    renameSync5(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1970,10 +1852,10 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
-var log5 = (msg) => log("capture", msg);
+import { dirname as dirname6, join as join17 } from "node:path";
+var log4 = (msg) => log("capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1990,7 +1872,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log5("no config");
+    log4("no config");
     return;
   }
   const sessionsTable = config.sessionsTableName;
@@ -2008,7 +1890,7 @@ async function main() {
   };
   let entry;
   if (input.prompt !== void 0) {
-    log5(`user session=${input.session_id}`);
+    log4(`user session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2016,7 +1898,7 @@ async function main() {
       content: input.prompt
     };
   } else if (input.tool_name !== void 0) {
-    log5(`tool=${input.tool_name} session=${input.session_id}`);
+    log4(`tool=${input.tool_name} session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2027,7 +1909,7 @@ async function main() {
       tool_response: JSON.stringify(input.tool_response)
     };
   } else if (input.last_assistant_message !== void 0) {
-    log5(`assistant session=${input.session_id}`);
+    log4(`assistant session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2036,12 +1918,12 @@ async function main() {
       ...input.agent_transcript_path ? { agent_transcript_path: input.agent_transcript_path } : {}
     };
   } else {
-    log5("unknown event, skipping");
+    log4("unknown event, skipping");
     return;
   }
   const sessionPath = buildSessionPath(config, input.session_id);
   const line = JSON.stringify(entry);
-  log5(`writing to ${sessionPath}`);
+  log4(`writing to ${sessionPath}`);
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -2052,14 +1934,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log5("table missing, creating and retrying");
+      log4("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log5("capture ok \u2192 cloud");
+  log4("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(input.session_id, input.cwd ?? "", config);
   if (input.hook_event_name === "Stop") {
     if (process.env.HIVEMIND_WIKI_WORKER === "1")
@@ -2082,7 +1964,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -2095,19 +1977,19 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log5(`periodic spawn failed: ${e.message}`);
+      log4(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch (releaseErr) {
-        log5(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
+        log4(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
       }
       throw e;
     }
   } catch (e) {
-    log5(`periodic trigger error: ${e.message}`);
+    log4(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -297,13 +297,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -248,6 +248,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -284,11 +302,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -691,37 +719,37 @@ function buildSessionPath(config, sessionId) {
 }
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, writeSync, mkdirSync as mkdirSync3, renameSync as renameSync2, existsSync as existsSync3, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, writeSync, mkdirSync as mkdirSync4, renameSync as renameSync2, existsSync as existsSync3, unlinkSync as unlinkSync3, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join5(homedir4(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join6(homedir5(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join5(STATE_DIR, `${sessionId}.json`);
+  return join6(STATE_DIR, `${sessionId}.json`);
 }
 function lockPath2(sessionId) {
-  return join5(STATE_DIR, `${sessionId}.lock`);
+  return join6(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync3(p))
     return null;
   try {
-    return JSON.parse(readFileSync4(p, "utf-8"));
+    return JSON.parse(readFileSync5(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync3(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(state));
+  writeFileSync4(tmp, JSON.stringify(state));
   renameSync2(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync3(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -734,7 +762,7 @@ function withRmwLock(sessionId, fn) {
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmwLock);
+          unlinkSync3(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -748,7 +776,7 @@ function withRmwLock(sessionId, fn) {
   } finally {
     closeSync2(fd);
     try {
-      unlinkSync2(rmwLock);
+      unlinkSync3(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -783,18 +811,18 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync3(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const p = lockPath2(sessionId);
   if (existsSync3(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync4(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
@@ -816,7 +844,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync2(lockPath2(sessionId));
+    unlinkSync3(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -827,20 +855,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/spawn-wiki-worker.js
 import { spawn, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5 } from "node:fs";
-import { homedir as homedir5, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname2, join as join9 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync6 } from "node:fs";
+import { homedir as homedir6, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join6 } from "node:path";
+import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join6(hooksDir, filename);
+  const path = join7(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync4(hooksDir, { recursive: true });
+        mkdirSync5(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -850,18 +878,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync5 } from "node:fs";
-import { dirname, join as join7 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname, join as join8 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
+    const pluginJson = join8(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync5(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join8(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -876,9 +904,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join7(dir, "package.json");
+    const candidate = join8(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -892,8 +920,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/spawn-wiki-worker.js
-var HOME = homedir5();
-var wikiLogger = makeWikiLogger(join8(HOME, ".claude", "hooks"));
+var HOME = homedir6();
+var wikiLogger = makeWikiLogger(join9(HOME, ".claude", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry. Think of this as building a knowledge graph, not writing a summary.
 
@@ -952,17 +980,17 @@ function findClaudeBin() {
   try {
     return execSync("which claude 2>/dev/null", { encoding: "utf-8" }).trim();
   } catch {
-    return join8(HOME, ".claude", "local", "claude");
+    return join9(HOME, ".claude", "local", "claude");
   }
 }
 function spawnWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join8(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync5(tmpDir, { recursive: true });
+  const tmpDir = join9(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join8(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join9(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -976,11 +1004,11 @@ function spawnWikiWorker(opts) {
     tmpDir,
     claudeBin: findClaudeBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join8(HOME, ".claude", "hooks"),
+    hooksDir: join9(HOME, ".claude", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join8(bundleDir, "wiki-worker.js");
+  const workerPath = join9(bundleDir, "wiki-worker.js");
   spawn("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -994,15 +1022,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn2 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname3, join as join10 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync6, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir7, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname3, join as join11 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync7, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir8, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync4 } from "node:fs";
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join9 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join10 } from "node:path";
 var requireForCp = createRequire(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1014,7 +1042,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir6();
+  const home = homedir7();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1023,54 +1051,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join9(home, ".claude", "local", "claude"),
+        join10(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join9(home, ".npm-global", "bin", "claude"),
-        join9(home, ".local", "bin", "claude"),
+        join10(home, ".npm-global", "bin", "claude"),
+        join10(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join9(home, ".claude", "local", "claude");
+      ]) ?? join10(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join9(home, ".npm-global", "bin", "codex"),
-        join9(home, ".local", "bin", "codex"),
+        join10(home, ".npm-global", "bin", "codex"),
+        join10(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join9(home, ".npm-global", "bin", "cursor-agent"),
-        join9(home, ".local", "bin", "cursor-agent"),
+        join10(home, ".npm-global", "bin", "cursor-agent"),
+        join10(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join9(home, ".local", "bin", "hermes"),
+        join10(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join9(home, ".npm-global", "bin", "hermes"),
+        join10(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join9(home, ".local", "bin", "hermes");
+      ]) ?? join10(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join9(home, ".local", "bin", "pi"),
+        join10(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join9(home, ".npm-global", "bin", "pi"),
+        join10(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join9(home, ".local", "bin", "pi");
+      ]) ?? join10(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir7();
-var SKILLIFY_LOG = join10(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir8();
+var SKILLIFY_LOG = join11(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync6(dirname3(SKILLIFY_LOG), { recursive: true });
+    mkdirSync7(dirname3(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1078,11 +1106,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join10(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync6(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join11(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join10(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join11(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1112,7 +1140,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join10(bundleDir, "skillify-worker.js");
+  const workerPath = join11(bundleDir, "skillify-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1121,25 +1149,25 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync6, writeSync as writeSync2, mkdirSync as mkdirSync7, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync7, writeSync as writeSync2, mkdirSync as mkdirSync8, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync4, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir9 } from "node:os";
+import { homedir as homedir10 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join12, basename } from "node:path";
+import { join as join13, basename } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
 import { existsSync as existsSync5, renameSync as renameSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join11 } from "node:path";
+import { homedir as homedir9 } from "node:os";
+import { join as join12 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join11(homedir8(), ".deeplake", "state");
-  const legacy = join11(root, "skilify");
-  const current = join11(root, "skillify");
+  const root = join12(homedir9(), ".deeplake", "state");
+  const legacy = join12(root, "skilify");
+  const current = join12(root, "skillify");
   if (!existsSync5(legacy))
     return;
   if (existsSync5(current))
@@ -1159,17 +1187,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join12(homedir9(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join13(homedir10(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join12(STATE_DIR2, `${projectKey}.json`);
+  return join13(STATE_DIR2, `${projectKey}.json`);
 }
 function lockPath3(projectKey) {
-  return join12(STATE_DIR2, `${projectKey}.lock`);
+  return join13(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1218,22 +1246,22 @@ function readState2(projectKey) {
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync7(STATE_DIR2, { recursive: true });
+  mkdirSync8(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync6(tmp, JSON.stringify(state, null, 2));
+  writeFileSync7(tmp, JSON.stringify(state, null, 2));
   renameSync4(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync7(STATE_DIR2, { recursive: true });
+  mkdirSync8(STATE_DIR2, { recursive: true });
   const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1246,7 +1274,7 @@ function withRmwLock2(projectKey, fn) {
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmw);
+          unlinkSync4(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1260,7 +1288,7 @@ function withRmwLock2(projectKey, fn) {
   } finally {
     closeSync3(fd);
     try {
-      unlinkSync3(rmw);
+      unlinkSync4(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1293,18 +1321,18 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync7(STATE_DIR2, { recursive: true });
+  mkdirSync8(STATE_DIR2, { recursive: true });
   const p = lockPath3(projectKey);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
@@ -1325,24 +1353,24 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
 function releaseWorkerLock(projectKey) {
   const p = lockPath3(projectKey);
   try {
-    unlinkSync3(p);
+    unlinkSync4(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync7, mkdirSync as mkdirSync8, readFileSync as readFileSync7, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
-var STATE_DIR3 = join13(homedir10(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join13(STATE_DIR3, "config.json");
+import { existsSync as existsSync7, mkdirSync as mkdirSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
+var STATE_DIR3 = join14(homedir11(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join14(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync7(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync7(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync8(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1395,9 +1423,9 @@ function tryStopCounterTrigger(opts) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync8, readFileSync as readFileSync8 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { join as join14 } from "node:path";
+import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync5, existsSync as existsSync8, readFileSync as readFileSync9 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { join as join15 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1411,7 +1439,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join14(homedir11(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join15(homedir12(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1602,7 +1630,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync8(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync9(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1615,11 +1643,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync4(this.socketPath);
+      unlinkSync5(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync4(this.pidPath);
+      unlinkSync5(this.pidPath);
     } catch {
     }
   }
@@ -1670,7 +1698,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync4(this.pidPath);
+          unlinkSync5(this.pidPath);
         } catch {
         }
         try {
@@ -1687,7 +1715,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync4(fd);
-        unlinkSync4(this.pidPath);
+        unlinkSync5(this.pidPath);
       } catch {
       }
       return;
@@ -1706,7 +1734,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync8(this.pidPath, "utf-8").trim();
+      const raw = readFileSync9(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1792,15 +1820,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
+import { homedir as homedir14 } from "node:os";
+import { join as join17 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync9, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { dirname as dirname4, join as join15 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join15(homedir12(), ".deeplake", "config.json");
+import { existsSync as existsSync9, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { dirname as dirname4, join as join16 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join16(homedir13(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1812,7 +1840,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync9(path, "utf-8");
+    const raw = readFileSync10(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1826,9 +1854,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname4(path);
   if (!existsSync9(dir))
-    mkdirSync9(dir, { recursive: true });
+    mkdirSync10(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync9(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync5(tmp, path);
   _cache = merged;
   return merged;
@@ -1878,7 +1906,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join16(homedir13(), ".hivemind", "embed-deps");
+  const sharedDir = join17(homedir14(), ".hivemind", "embed-deps");
   try {
     createRequire2(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1909,16 +1937,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync10, readlinkSync, renameSync as renameSync6, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { basename as basename2, dirname as dirname5, join as join17 } from "node:path";
+import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync11, readlinkSync, renameSync as renameSync6, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { basename as basename2, dirname as dirname5, join as join18 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename2(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join17(homedir14(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join18(homedir15(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname5(opts.bundleDir);
-  const link = join17(pluginDir, "node_modules");
+  const link = join18(pluginDir, "node_modules");
   if (!existsSync10(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1959,7 +1987,7 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname5(link);
     if (!existsSync10(parent))
-      mkdirSync10(parent, { recursive: true });
+      mkdirSync11(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
@@ -1975,10 +2003,10 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
+import { dirname as dirname6, join as join19 } from "node:path";
 var log5 = (msg) => log("capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join19(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -2004,6 +2004,8 @@ function createSymlinkAtomic(target, link) {
 // dist/src/hooks/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 import { dirname as dirname6, join as join19 } from "node:path";
+import { readFileSync as readFileSync11 } from "node:fs";
+import { homedir as homedir16 } from "node:os";
 var log5 = (msg) => log("capture", msg);
 function resolveEmbedDaemonPath() {
   return join19(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
@@ -2141,6 +2143,30 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  const msg = e?.message ?? String(e);
+  log5(`fatal: ${msg}`);
+  if (msg.includes("402") && msg.includes("balance_cents")) {
+    try {
+      emitBalanceExhaustedInline();
+    } catch (emitErr) {
+      log5(`inline emit failed: ${emitErr?.message ?? String(emitErr)}`);
+    }
+  }
   process.exit(0);
 });
+function emitBalanceExhaustedInline() {
+  let url = "https://deeplake.ai";
+  try {
+    const credsPath2 = join19(homedir16(), ".deeplake", "credentials.json");
+    const c = JSON.parse(readFileSync11(credsPath2, "utf-8"));
+    if (c.orgName && c.workspaceId) {
+      url = `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  const msg = `\u26A0\uFE0F HIVEMIND ALERT: This capture failed because the org is out of Deeplake credits (balance is 0). Memory recall is also returning empty. Tell the user clearly: "Hivemind credits are exhausted \u2014 sessions are not being saved and memory recall is empty. Top up at ${url} to restore."`;
+  const payload = {
+    hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: msg }
+  };
+  process.stdout.write(JSON.stringify(payload));
+}

--- a/claude-code/bundle/capture.js
+++ b/claude-code/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -147,6 +147,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -154,7 +255,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -166,7 +267,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -175,8 +297,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +328,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -277,8 +399,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -294,10 +416,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -318,7 +441,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -374,7 +497,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -464,13 +587,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -498,9 +621,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -526,9 +649,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -551,9 +674,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -568,50 +691,50 @@ function buildSessionPath(config, sessionId) {
 }
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, writeSync, mkdirSync as mkdirSync2, renameSync, existsSync as existsSync3, unlinkSync, openSync, closeSync } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, writeSync, mkdirSync as mkdirSync3, renameSync as renameSync2, existsSync as existsSync3, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join4(homedir3(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join5(homedir4(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join4(STATE_DIR, `${sessionId}.json`);
+  return join5(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath(sessionId) {
-  return join4(STATE_DIR, `${sessionId}.lock`);
+function lockPath2(sessionId) {
+  return join5(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync3(p))
     return null;
   try {
-    return JSON.parse(readFileSync3(p, "utf-8"));
+    return JSON.parse(readFileSync4(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync2(STATE_DIR, { recursive: true });
+  mkdirSync3(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(state));
-  renameSync(tmp, p);
+  writeFileSync3(tmp, JSON.stringify(state));
+  renameSync2(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync2(STATE_DIR, { recursive: true });
+  mkdirSync3(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync(rmwLock, "wx");
+      fd = openSync2(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync(rmwLock);
+          unlinkSync2(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -623,9 +746,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync(fd);
+    closeSync2(fd);
     try {
-      unlinkSync(rmwLock);
+      unlinkSync2(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -660,29 +783,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync2(STATE_DIR, { recursive: true });
-  const p = lockPath(sessionId);
+  mkdirSync3(STATE_DIR, { recursive: true });
+  const p = lockPath2(sessionId);
   if (existsSync3(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync3(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync4(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync(p);
+      unlinkSync2(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync(p, "wx");
+    const fd = openSync2(p, "wx");
     try {
       writeSync(fd, String(Date.now()));
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
     return true;
   } catch (e) {
@@ -693,7 +816,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync(lockPath(sessionId));
+    unlinkSync2(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -704,20 +827,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/spawn-wiki-worker.js
 import { spawn, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
-import { writeFileSync as writeFileSync3, mkdirSync as mkdirSync4 } from "node:fs";
-import { homedir as homedir4, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname2, join as join8 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5 } from "node:fs";
+import { homedir as homedir5, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join5 } from "node:path";
+import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join6 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join5(hooksDir, filename);
+  const path = join6(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync3(hooksDir, { recursive: true });
+        mkdirSync4(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -727,18 +850,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync4 } from "node:fs";
-import { dirname, join as join6 } from "node:path";
+import { readFileSync as readFileSync5 } from "node:fs";
+import { dirname, join as join7 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join6(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync4(pluginJson, "utf-8"));
+    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync4(join6(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync5(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -753,9 +876,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join6(dir, "package.json");
+    const candidate = join7(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync4(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -769,8 +892,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/spawn-wiki-worker.js
-var HOME = homedir4();
-var wikiLogger = makeWikiLogger(join7(HOME, ".claude", "hooks"));
+var HOME = homedir5();
+var wikiLogger = makeWikiLogger(join8(HOME, ".claude", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry. Think of this as building a knowledge graph, not writing a summary.
 
@@ -829,17 +952,17 @@ function findClaudeBin() {
   try {
     return execSync("which claude 2>/dev/null", { encoding: "utf-8" }).trim();
   } catch {
-    return join7(HOME, ".claude", "local", "claude");
+    return join8(HOME, ".claude", "local", "claude");
   }
 }
 function spawnWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join7(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync4(tmpDir, { recursive: true });
+  const tmpDir = join8(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync5(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join7(tmpDir, "config.json");
-  writeFileSync3(configFile, JSON.stringify({
+  const configFile = join8(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -853,11 +976,11 @@ function spawnWikiWorker(opts) {
     tmpDir,
     claudeBin: findClaudeBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join7(HOME, ".claude", "hooks"),
+    hooksDir: join8(HOME, ".claude", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join7(bundleDir, "wiki-worker.js");
+  const workerPath = join8(bundleDir, "wiki-worker.js");
   spawn("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -871,15 +994,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn2 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname3, join as join9 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir6, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname3, join as join10 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync6, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir7, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync4 } from "node:fs";
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join8 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join9 } from "node:path";
 var requireForCp = createRequire(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -891,7 +1014,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir5();
+  const home = homedir6();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -900,54 +1023,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join8(home, ".claude", "local", "claude"),
+        join9(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join8(home, ".npm-global", "bin", "claude"),
-        join8(home, ".local", "bin", "claude"),
+        join9(home, ".npm-global", "bin", "claude"),
+        join9(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join8(home, ".claude", "local", "claude");
+      ]) ?? join9(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join8(home, ".npm-global", "bin", "codex"),
-        join8(home, ".local", "bin", "codex"),
+        join9(home, ".npm-global", "bin", "codex"),
+        join9(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join8(home, ".npm-global", "bin", "cursor-agent"),
-        join8(home, ".local", "bin", "cursor-agent"),
+        join9(home, ".npm-global", "bin", "cursor-agent"),
+        join9(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join8(home, ".local", "bin", "hermes"),
+        join9(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join8(home, ".npm-global", "bin", "hermes"),
+        join9(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join8(home, ".local", "bin", "hermes");
+      ]) ?? join9(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join8(home, ".local", "bin", "pi"),
+        join9(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join8(home, ".npm-global", "bin", "pi"),
+        join9(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join8(home, ".local", "bin", "pi");
+      ]) ?? join9(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir6();
-var SKILLIFY_LOG = join9(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir7();
+var SKILLIFY_LOG = join10(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync5(dirname3(SKILLIFY_LOG), { recursive: true });
+    mkdirSync6(dirname3(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -955,11 +1078,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join9(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync5(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join10(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join9(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join10(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -989,7 +1112,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join9(bundleDir, "skillify-worker.js");
+  const workerPath = join10(bundleDir, "skillify-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -998,31 +1121,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync5, writeSync as writeSync2, mkdirSync as mkdirSync6, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync6, writeSync as writeSync2, mkdirSync as mkdirSync7, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join11, basename } from "node:path";
+import { join as join12, basename } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync5, renameSync as renameSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join10 } from "node:path";
+import { existsSync as existsSync5, renameSync as renameSync3 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join11 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join10(homedir7(), ".deeplake", "state");
-  const legacy = join10(root, "skilify");
-  const current = join10(root, "skillify");
+  const root = join11(homedir8(), ".deeplake", "state");
+  const legacy = join11(root, "skilify");
+  const current = join11(root, "skillify");
   if (!existsSync5(legacy))
     return;
   if (existsSync5(current))
     return;
   try {
-    renameSync2(legacy, current);
+    renameSync3(legacy, current);
     dlog2(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -1036,17 +1159,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join11(homedir8(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join12(homedir9(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join11(STATE_DIR2, `${projectKey}.json`);
+  return join12(STATE_DIR2, `${projectKey}.json`);
 }
-function lockPath2(projectKey) {
-  return join11(STATE_DIR2, `${projectKey}.lock`);
+function lockPath3(projectKey) {
+  return join12(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1095,35 +1218,35 @@ function readState2(projectKey) {
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync5(p, "utf-8"));
+    return JSON.parse(readFileSync6(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR2, { recursive: true });
+  mkdirSync7(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync5(tmp, JSON.stringify(state, null, 2));
-  renameSync3(tmp, p);
+  writeFileSync6(tmp, JSON.stringify(state, null, 2));
+  renameSync4(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR2, { recursive: true });
-  const rmw = lockPath2(projectKey) + ".rmw";
+  mkdirSync7(STATE_DIR2, { recursive: true });
+  const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync2(rmw, "wx");
+      fd = openSync3(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmw);
+          unlinkSync3(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1135,9 +1258,9 @@ function withRmwLock2(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync2(fd);
+    closeSync3(fd);
     try {
-      unlinkSync2(rmw);
+      unlinkSync3(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1170,29 +1293,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR2, { recursive: true });
-  const p = lockPath2(projectKey);
+  mkdirSync7(STATE_DIR2, { recursive: true });
+  const p = lockPath3(projectKey);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync2(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
     return true;
   } catch {
@@ -1200,26 +1323,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath2(projectKey);
+  const p = lockPath3(projectKey);
   try {
-    unlinkSync2(p);
+    unlinkSync3(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync7, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync6 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
-var STATE_DIR3 = join12(homedir9(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join12(STATE_DIR3, "config.json");
+import { existsSync as existsSync7, mkdirSync as mkdirSync8, readFileSync as readFileSync7, writeFileSync as writeFileSync7 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
+var STATE_DIR3 = join13(homedir10(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join13(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync7(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync6(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync7(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1272,9 +1395,9 @@ function tryStopCounterTrigger(opts) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync3, unlinkSync as unlinkSync3, existsSync as existsSync8, readFileSync as readFileSync7 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync8, readFileSync as readFileSync8 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1288,8 +1411,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join13(homedir10(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join14(homedir11(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1365,7 +1488,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1374,7 +1497,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1421,7 +1544,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1430,13 +1553,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync8(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1479,7 +1602,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync7(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync8(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1489,14 +1612,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync3(this.socketPath);
+      unlinkSync4(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync3(this.pidPath);
+      unlinkSync4(this.pidPath);
     } catch {
     }
   }
@@ -1523,7 +1646,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1531,7 +1654,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1542,16 +1665,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync3(this.pidPath, "wx", 384);
+      fd = openSync4(this.pidPath, "wx", 384);
       writeSync3(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync3(this.pidPath);
+          unlinkSync4(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync3(this.pidPath, "wx", 384);
+          fd = openSync4(this.pidPath, "wx", 384);
           writeSync3(fd, String(process.pid));
         } catch {
           return;
@@ -1561,10 +1684,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync8(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
+        closeSync4(fd);
+        unlinkSync4(this.pidPath);
       } catch {
       }
       return;
@@ -1576,14 +1699,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync3(fd);
+      closeSync4(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync7(this.pidPath, "utf-8").trim();
+      const raw = readFileSync8(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1601,7 +1724,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync8(this.socketPath))
         continue;
@@ -1613,7 +1736,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1628,7 +1751,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1645,7 +1768,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1669,15 +1792,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync9, mkdirSync as mkdirSync8, readFileSync as readFileSync8, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { dirname as dirname4, join as join14 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join14(homedir11(), ".deeplake", "config.json");
+import { existsSync as existsSync9, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { dirname as dirname4, join as join15 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join15(homedir12(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1689,7 +1812,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync8(path, "utf-8");
+    const raw = readFileSync9(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1703,10 +1826,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname4(path);
   if (!existsSync9(dir))
-    mkdirSync8(dir, { recursive: true });
+    mkdirSync9(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync7(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync4(tmp, path);
+  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync5(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1755,7 +1878,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join15(homedir12(), ".hivemind", "embed-deps");
+  const sharedDir = join16(homedir13(), ".hivemind", "embed-deps");
   try {
     createRequire2(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1786,16 +1909,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync9, readlinkSync, renameSync as renameSync5, rmSync, symlinkSync, statSync } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { basename as basename2, dirname as dirname5, join as join16 } from "node:path";
+import { existsSync as existsSync10, lstatSync, mkdirSync as mkdirSync10, readlinkSync, renameSync as renameSync6, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { basename as basename2, dirname as dirname5, join as join17 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename2(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join16(homedir13(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join17(homedir14(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname5(opts.bundleDir);
-  const link = join16(pluginDir, "node_modules");
+  const link = join17(pluginDir, "node_modules");
   if (!existsSync10(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1816,7 +1939,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync(link);
+      statSync2(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1836,14 +1959,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname5(link);
     if (!existsSync10(parent))
-      mkdirSync9(parent, { recursive: true });
+      mkdirSync10(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync5(tmp, link);
+    renameSync6(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1852,10 +1975,10 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join17 } from "node:path";
-var log4 = (msg) => log("capture", msg);
+import { dirname as dirname6, join as join18 } from "node:path";
+var log5 = (msg) => log("capture", msg);
 function resolveEmbedDaemonPath() {
-  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1872,7 +1995,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log4("no config");
+    log5("no config");
     return;
   }
   const sessionsTable = config.sessionsTableName;
@@ -1890,7 +2013,7 @@ async function main() {
   };
   let entry;
   if (input.prompt !== void 0) {
-    log4(`user session=${input.session_id}`);
+    log5(`user session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1898,7 +2021,7 @@ async function main() {
       content: input.prompt
     };
   } else if (input.tool_name !== void 0) {
-    log4(`tool=${input.tool_name} session=${input.session_id}`);
+    log5(`tool=${input.tool_name} session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1909,7 +2032,7 @@ async function main() {
       tool_response: JSON.stringify(input.tool_response)
     };
   } else if (input.last_assistant_message !== void 0) {
-    log4(`assistant session=${input.session_id}`);
+    log5(`assistant session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1918,12 +2041,12 @@ async function main() {
       ...input.agent_transcript_path ? { agent_transcript_path: input.agent_transcript_path } : {}
     };
   } else {
-    log4("unknown event, skipping");
+    log5("unknown event, skipping");
     return;
   }
   const sessionPath = buildSessionPath(config, input.session_id);
   const line = JSON.stringify(entry);
-  log4(`writing to ${sessionPath}`);
+  log5(`writing to ${sessionPath}`);
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -1934,14 +2057,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log4("table missing, creating and retrying");
+      log5("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log4("capture ok \u2192 cloud");
+  log5("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(input.session_id, input.cwd ?? "", config);
   if (input.hook_event_name === "Stop") {
     if (process.env.HIVEMIND_WIKI_WORKER === "1")
@@ -1964,7 +2087,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -1977,19 +2100,19 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log4(`periodic spawn failed: ${e.message}`);
+      log5(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch (releaseErr) {
-        log4(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
+        log5(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
       }
       throw e;
     }
   } catch (e) {
-    log4(`periodic trigger error: ${e.message}`);
+    log5(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -469,13 +469,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -474,11 +474,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/claude-code/bundle/commands/auth-login.js
+++ b/claude-code/bundle/commands/auth-login.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -337,6 +337,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -344,7 +445,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -356,7 +457,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -365,8 +487,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -396,7 +518,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -467,8 +589,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -484,10 +606,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -508,7 +631,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -564,7 +687,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -654,13 +777,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -688,9 +811,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -701,9 +824,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -716,9 +839,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -741,9 +864,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -774,10 +897,10 @@ function parseArgs(argv) {
 }
 function confirm(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     rl.question(`${message} [y/N] `, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
+      resolve2(answer.trim().toLowerCase() === "y");
     });
   });
 }

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -53,20 +53,20 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/pre-tool-use.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync5, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join11, dirname as dirname3, sep } from "node:path";
+import { existsSync as existsSync5, mkdirSync as mkdirSync4, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join10, dirname as dirname3, sep } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve3, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve3(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -182,7 +182,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve3) => setTimeout(resolve3, ms));
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -212,7 +212,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve3) => this.waiting.push(resolve3));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -1063,9 +1063,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1078,105 +1078,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve as resolve2 } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve2(path);
-  const h = resolve2(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve2(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve2, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve2(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve2, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve2(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -1186,7 +1452,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -1196,7 +1462,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -1214,11 +1480,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1297,397 +1563,13 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve3, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve3(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve3, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve3(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join7 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join7(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2690,20 +2572,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
-import { join as join9 } from "node:path";
-import { homedir as homedir7 } from "node:os";
-var log5 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
+import { mkdirSync as mkdirSync3, readFileSync as readFileSync5, rmSync, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+var log4 = (msg) => log("query-cache", msg);
+var DEFAULT_CACHE_ROOT = join8(homedir6(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join9(cacheRoot, sessionId);
+  return join8(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
-  const { logFn = log5 } = deps;
+  const { logFn = log4 } = deps;
   try {
-    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync5(join8(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2712,20 +2594,20 @@ function readCachedIndexContent(sessionId, deps = {}) {
   }
 }
 function writeCachedIndexContent(sessionId, content, deps = {}) {
-  const { logFn = log5 } = deps;
+  const { logFn = log4 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync4(dir, { recursive: true });
-    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync3(dir, { recursive: true });
+    writeFileSync3(join8(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir8 } from "node:os";
-import { join as join10 } from "node:path";
-var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
+var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2841,21 +2723,21 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/pre-tool-use.js
-var log6 = (msg) => log("pre", msg);
+var log5 = (msg) => log("pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
-var READ_CACHE_ROOT = join11(homedir9(), ".deeplake", "query-cache");
+var SHELL_BUNDLE = existsSync5(join10(__bundleDir, "shell", "deeplake-shell.js")) ? join10(__bundleDir, "shell", "deeplake-shell.js") : join10(__bundleDir, "..", "shell", "deeplake-shell.js");
+var READ_CACHE_ROOT = join10(homedir8(), ".deeplake", "query-cache");
 function writeReadCacheFile(sessionId, virtualPath, content, deps = {}) {
   const { cacheRoot = READ_CACHE_ROOT } = deps;
   const safeSessionId = sessionId.replace(/[^a-zA-Z0-9._-]/g, "_") || "unknown";
   const rel = virtualPath.replace(/^\/+/, "") || "content";
-  const expectedRoot = join11(cacheRoot, safeSessionId, "read");
-  const absPath = join11(expectedRoot, rel);
+  const expectedRoot = join10(cacheRoot, safeSessionId, "read");
+  const absPath = join10(expectedRoot, rel);
   if (absPath !== expectedRoot && !absPath.startsWith(expectedRoot + sep)) {
     throw new Error(`writeReadCacheFile: path escapes cache root: ${absPath}`);
   }
-  mkdirSync5(dirname3(absPath), { recursive: true });
-  writeFileSync5(absPath, content, "utf-8");
+  mkdirSync4(dirname3(absPath), { recursive: true });
+  writeFileSync4(absPath, content, "utf-8");
   return absPath;
 }
 function buildReadDecision(file_path, description) {
@@ -2901,7 +2783,7 @@ function getShellCommand(toolName, toolInput) {
         break;
       const rewritten = rewritePaths(cmd);
       if (!isSafe(rewritten)) {
-        log6(`unsafe command blocked: ${rewritten}`);
+        log5(`unsafe command blocked: ${rewritten}`);
         return null;
       }
       return rewritten;
@@ -2941,7 +2823,7 @@ function buildFallbackDecision(shellCmd, shellBundle = SHELL_BUNDLE) {
   return buildAllowDecision(`node "${shellBundle}" -c "${shellCmd.replace(/"/g, '\\"')}"`, `[DeepLake shell] ${shellCmd}`);
 }
 async function processPreToolUse(input, deps = {}) {
-  const { config = loadConfig(), createApi = (table2, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table2), executeCompiledBashCommandFn = executeCompiledBashCommand, handleGrepDirectFn = handleGrepDirect, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, writeReadCacheFileFn = writeReadCacheFile, shellBundle = SHELL_BUNDLE, logFn = log6 } = deps;
+  const { config = loadConfig(), createApi = (table2, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table2), executeCompiledBashCommandFn = executeCompiledBashCommand, handleGrepDirectFn = handleGrepDirect, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, writeReadCacheFileFn = writeReadCacheFile, shellBundle = SHELL_BUNDLE, logFn = log5 } = deps;
   const cmd = input.tool_input.command ?? "";
   const shellCmd = getShellCommand(input.tool_name, input.tool_input);
   const toolPath = getReadTargetPath(input.tool_input) ?? input.tool_input.path ?? "";
@@ -3164,7 +3046,7 @@ async function main() {
 }
 if (isDirectRun(import.meta.url)) {
   main().catch((e) => {
-    log6(`fatal: ${e.message}`);
+    log5(`fatal: ${e.message}`);
     process.exit(0);
   });
 }

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,9 +53,9 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/pre-tool-use.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync5, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join11, dirname as dirname3, sep } from "node:path";
+import { existsSync as existsSync5, mkdirSync as mkdirSync6, writeFileSync as writeFileSync6 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join12, dirname as dirname3, sep } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
@@ -254,6 +254,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -290,11 +308,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -1186,9 +1214,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1202,7 +1230,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1393,7 +1421,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1406,11 +1434,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -1461,7 +1489,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -1478,7 +1506,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1497,7 +1525,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1570,15 +1598,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1590,7 +1618,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1604,9 +1632,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1656,7 +1684,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1688,11 +1716,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join9 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join9(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2695,20 +2723,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
-import { join as join9 } from "node:path";
-import { homedir as homedir7 } from "node:os";
+import { mkdirSync as mkdirSync5, readFileSync as readFileSync7, rmSync, writeFileSync as writeFileSync5 } from "node:fs";
+import { join as join10 } from "node:path";
+import { homedir as homedir8 } from "node:os";
 var log5 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
+var DEFAULT_CACHE_ROOT = join10(homedir8(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join9(cacheRoot, sessionId);
+  return join10(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
   const { logFn = log5 } = deps;
   try {
-    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync7(join10(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2720,17 +2748,17 @@ function writeCachedIndexContent(sessionId, content, deps = {}) {
   const { logFn = log5 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync4(dir, { recursive: true });
-    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync5(dir, { recursive: true });
+    writeFileSync5(join10(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir8 } from "node:os";
-import { join as join10 } from "node:path";
-var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
+import { homedir as homedir9 } from "node:os";
+import { join as join11 } from "node:path";
+var MEMORY_PATH = join11(homedir9(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2848,19 +2876,19 @@ function rewritePaths(cmd) {
 // dist/src/hooks/pre-tool-use.js
 var log6 = (msg) => log("pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
-var READ_CACHE_ROOT = join11(homedir9(), ".deeplake", "query-cache");
+var SHELL_BUNDLE = existsSync5(join12(__bundleDir, "shell", "deeplake-shell.js")) ? join12(__bundleDir, "shell", "deeplake-shell.js") : join12(__bundleDir, "..", "shell", "deeplake-shell.js");
+var READ_CACHE_ROOT = join12(homedir10(), ".deeplake", "query-cache");
 function writeReadCacheFile(sessionId, virtualPath, content, deps = {}) {
   const { cacheRoot = READ_CACHE_ROOT } = deps;
   const safeSessionId = sessionId.replace(/[^a-zA-Z0-9._-]/g, "_") || "unknown";
   const rel = virtualPath.replace(/^\/+/, "") || "content";
-  const expectedRoot = join11(cacheRoot, safeSessionId, "read");
-  const absPath = join11(expectedRoot, rel);
+  const expectedRoot = join12(cacheRoot, safeSessionId, "read");
+  const absPath = join12(expectedRoot, rel);
   if (absPath !== expectedRoot && !absPath.startsWith(expectedRoot + sep)) {
     throw new Error(`writeReadCacheFile: path escapes cache root: ${absPath}`);
   }
-  mkdirSync5(dirname3(absPath), { recursive: true });
-  writeFileSync5(absPath, content, "utf-8");
+  mkdirSync6(dirname3(absPath), { recursive: true });
+  writeFileSync6(absPath, content, "utf-8");
   return absPath;
 }
 function buildReadDecision(file_path, description) {

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -303,13 +303,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/claude-code/bundle/pre-tool-use.js
+++ b/claude-code/bundle/pre-tool-use.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,20 +53,20 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/pre-tool-use.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync4, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join10, dirname as dirname3, sep } from "node:path";
+import { existsSync as existsSync5, mkdirSync as mkdirSync5, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join11, dirname as dirname3, sep } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve3, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve3(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -153,6 +153,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -160,7 +261,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -172,7 +273,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -181,8 +303,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+function sleep2(ms) {
+  return new Promise((resolve3) => setTimeout(resolve3, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -212,7 +334,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve3) => this.waiting.push(resolve3));
   }
   release() {
     this.active--;
@@ -283,8 +405,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -300,10 +422,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -324,7 +447,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -380,7 +503,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -470,13 +593,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -504,9 +627,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -517,9 +640,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -532,9 +655,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -557,9 +680,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -568,14 +691,14 @@ var DeeplakeApi = class {
 };
 
 // dist/src/utils/direct-run.js
-import { resolve } from "node:path";
+import { resolve as resolve2 } from "node:path";
 import { fileURLToPath } from "node:url";
 function isDirectRun(metaUrl) {
   const entry = process.argv[1];
   if (!entry)
     return false;
   try {
-    return resolve(fileURLToPath(metaUrl)) === resolve(entry);
+    return resolve2(fileURLToPath(metaUrl)) === resolve2(entry);
   } catch {
     return false;
   }
@@ -1063,9 +1186,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1079,8 +1202,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1156,7 +1279,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1165,7 +1288,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1212,7 +1335,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1221,13 +1344,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1270,7 +1393,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1280,14 +1403,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -1314,7 +1437,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1322,7 +1445,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve2(sock);
+        resolve3(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1333,16 +1456,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -1352,10 +1475,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -1367,14 +1490,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1392,7 +1515,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -1404,7 +1527,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1419,7 +1542,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve2(JSON.parse(line));
+          resolve3(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1436,7 +1559,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1447,15 +1570,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1467,7 +1590,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1481,10 +1604,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1533,7 +1656,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1565,11 +1688,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join8 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join7(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join8(dirname2(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2572,20 +2695,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync3, readFileSync as readFileSync5, rmSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { join as join8 } from "node:path";
-import { homedir as homedir6 } from "node:os";
-var log4 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join8(homedir6(), ".deeplake", "query-cache");
+import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
+import { join as join9 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+var log5 = (msg) => log("query-cache", msg);
+var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join8(cacheRoot, sessionId);
+  return join9(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
-  const { logFn = log4 } = deps;
+  const { logFn = log5 } = deps;
   try {
-    return readFileSync5(join8(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2594,20 +2717,20 @@ function readCachedIndexContent(sessionId, deps = {}) {
   }
 }
 function writeCachedIndexContent(sessionId, content, deps = {}) {
-  const { logFn = log4 } = deps;
+  const { logFn = log5 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync3(dir, { recursive: true });
-    writeFileSync3(join8(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync4(dir, { recursive: true });
+    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir8 } from "node:os";
+import { join as join10 } from "node:path";
+var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2723,21 +2846,21 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/pre-tool-use.js
-var log5 = (msg) => log("pre", msg);
+var log6 = (msg) => log("pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join10(__bundleDir, "shell", "deeplake-shell.js")) ? join10(__bundleDir, "shell", "deeplake-shell.js") : join10(__bundleDir, "..", "shell", "deeplake-shell.js");
-var READ_CACHE_ROOT = join10(homedir8(), ".deeplake", "query-cache");
+var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
+var READ_CACHE_ROOT = join11(homedir9(), ".deeplake", "query-cache");
 function writeReadCacheFile(sessionId, virtualPath, content, deps = {}) {
   const { cacheRoot = READ_CACHE_ROOT } = deps;
   const safeSessionId = sessionId.replace(/[^a-zA-Z0-9._-]/g, "_") || "unknown";
   const rel = virtualPath.replace(/^\/+/, "") || "content";
-  const expectedRoot = join10(cacheRoot, safeSessionId, "read");
-  const absPath = join10(expectedRoot, rel);
+  const expectedRoot = join11(cacheRoot, safeSessionId, "read");
+  const absPath = join11(expectedRoot, rel);
   if (absPath !== expectedRoot && !absPath.startsWith(expectedRoot + sep)) {
     throw new Error(`writeReadCacheFile: path escapes cache root: ${absPath}`);
   }
-  mkdirSync4(dirname3(absPath), { recursive: true });
-  writeFileSync4(absPath, content, "utf-8");
+  mkdirSync5(dirname3(absPath), { recursive: true });
+  writeFileSync5(absPath, content, "utf-8");
   return absPath;
 }
 function buildReadDecision(file_path, description) {
@@ -2783,7 +2906,7 @@ function getShellCommand(toolName, toolInput) {
         break;
       const rewritten = rewritePaths(cmd);
       if (!isSafe(rewritten)) {
-        log5(`unsafe command blocked: ${rewritten}`);
+        log6(`unsafe command blocked: ${rewritten}`);
         return null;
       }
       return rewritten;
@@ -2823,7 +2946,7 @@ function buildFallbackDecision(shellCmd, shellBundle = SHELL_BUNDLE) {
   return buildAllowDecision(`node "${shellBundle}" -c "${shellCmd.replace(/"/g, '\\"')}"`, `[DeepLake shell] ${shellCmd}`);
 }
 async function processPreToolUse(input, deps = {}) {
-  const { config = loadConfig(), createApi = (table2, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table2), executeCompiledBashCommandFn = executeCompiledBashCommand, handleGrepDirectFn = handleGrepDirect, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, writeReadCacheFileFn = writeReadCacheFile, shellBundle = SHELL_BUNDLE, logFn = log5 } = deps;
+  const { config = loadConfig(), createApi = (table2, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table2), executeCompiledBashCommandFn = executeCompiledBashCommand, handleGrepDirectFn = handleGrepDirect, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, writeReadCacheFileFn = writeReadCacheFile, shellBundle = SHELL_BUNDLE, logFn = log6 } = deps;
   const cmd = input.tool_input.command ?? "";
   const shellCmd = getShellCommand(input.tool_name, input.tool_input);
   const toolPath = getReadTargetPath(input.tool_input) ?? input.tool_input.path ?? "";
@@ -3046,7 +3169,7 @@ async function main() {
 }
 if (isDirectRun(import.meta.url)) {
   main().catch((e) => {
-    log5(`fatal: ${e.message}`);
+    log6(`fatal: ${e.message}`);
     process.exit(0);
   });
 }

--- a/claude-code/bundle/session-notifications.js
+++ b/claude-code/bundle/session-notifications.js
@@ -115,7 +115,7 @@ function writeQueue(q) {
 }
 
 // dist/src/notifications/state.js
-import { closeSync as closeSync2, mkdirSync as mkdirSync3, openSync as openSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { closeSync as closeSync2, mkdirSync as mkdirSync3, openSync as openSync2, readFileSync as readFileSync3, renameSync as renameSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync3 } from "node:fs";
 import { createHash } from "node:crypto";
 import { join as join4, resolve as resolve2 } from "node:path";
 import { homedir as homedir4 } from "node:os";
@@ -170,9 +170,7 @@ function tryClaim(n) {
     log3(`tryClaim mkdir failed: ${e?.message ?? String(e)}`);
     return true;
   }
-  const keyHash = createHash("sha256").update(JSON.stringify(n.dedupKey)).digest("hex").slice(0, 12);
-  const safeId = n.id.replace(/[^a-zA-Z0-9_.:-]/g, "_");
-  const claimPath = join4(claimsDir, `${safeId}-${keyHash}`);
+  const claimPath = claimPathFor(claimsDir, n);
   try {
     const fd = openSync2(claimPath, "wx", 384);
     closeSync2(fd);
@@ -183,6 +181,23 @@ function tryClaim(n) {
     log3(`tryClaim open failed: ${e?.message ?? String(e)}`);
     return true;
   }
+}
+function releaseClaim(n) {
+  const home = resolve2(homedir4());
+  const claimsDir = join4(home, ".deeplake", "notifications-claims");
+  const claimPath = claimPathFor(claimsDir, n);
+  try {
+    unlinkSync3(claimPath);
+  } catch (e) {
+    if (e?.code !== "ENOENT") {
+      log3(`releaseClaim unlink failed: ${e?.message ?? String(e)}`);
+    }
+  }
+}
+function claimPathFor(claimsDir, n) {
+  const keyHash = createHash("sha256").update(JSON.stringify(n.dedupKey)).digest("hex").slice(0, 12);
+  const safeId = n.id.replace(/[^a-zA-Z0-9_.:-]/g, "_");
+  return join4(claimsDir, `${safeId}-${keyHash}`);
 }
 
 // dist/src/notifications/format.js
@@ -467,8 +482,12 @@ async function drainSessionStart(opts) {
     const rendered = renderNotifications(claimed);
     emit(opts.agent, rendered);
     let nextState = state;
-    for (const n of claimed)
-      nextState = markShown(nextState, n);
+    for (const n of claimed) {
+      if (n.transient)
+        releaseClaim(n);
+      else
+        nextState = markShown(nextState, n);
+    }
     writeState(nextState);
     if (queue.queue.length > 0)
       writeQueue({ queue: [] });

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -54,8 +54,8 @@ var init_index_marker_store = __esm({
 
 // dist/src/hooks/session-start-setup.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join11 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { dirname as dirname2, join as join10 } from "node:path";
+import { homedir as homedir7 } from "node:os";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -189,7 +189,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -219,7 +219,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -576,13 +576,13 @@ var DeeplakeApi = class {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -612,9 +612,9 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync4, readFileSync as readFileSync6 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -627,105 +627,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, renameSync, mkdirSync as mkdirSync4, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join6, resolve } from "node:path";
-import { homedir as homedir4 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join6(homedir4(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join6(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync4(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir4());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync4(join6(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync4(join6(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -735,7 +1001,7 @@ import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync5, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync5, renameSync, writeFileSync as writeFileSync3 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
 import { dirname, join as join7 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir5(), ".deeplake", "config.json");
@@ -745,7 +1011,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -763,11 +1029,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync5(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -846,395 +1112,11 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join9(homedir7(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync6(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync6(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/shared/autoupdate.js
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join10 } from "node:path";
-var log5 = (msg) => log("autoupdate", msg);
+import { join as join9 } from "node:path";
+var log4 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn2(cmd, args, {
     detached: true,
@@ -1249,7 +1131,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join10(dir, "hivemind");
+    const candidate = join9(dir, "hivemind");
     if (existsSync5(candidate))
       return candidate;
   }
@@ -1257,43 +1139,43 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log5(`agent=${opts.agent} entered`);
+  log4(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log5(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log5(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log5(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log5(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log5(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log5(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/hooks/session-start-setup.js
-var log6 = (msg) => log("session-setup", msg);
+var log5 = (msg) => log("session-setup", msg);
 var __bundleDir = dirname2(fileURLToPath(import.meta.url));
-var { log: wikiLog } = makeWikiLogger(join11(homedir8(), ".claude", "hooks"));
+var { log: wikiLog } = makeWikiLogger(join10(homedir7(), ".claude", "hooks"));
 async function main() {
   if (process.env.HIVEMIND_WIKI_WORKER === "1")
     return;
   const input = await readStdin();
   const creds = loadCredentials();
   if (!creds?.token) {
-    log6("no credentials");
+    log5("no credentials");
     return;
   }
   if (!creds.userName) {
@@ -1301,7 +1183,7 @@ async function main() {
       const { userInfo: userInfo2 } = await import("node:os");
       creds.userName = userInfo2().username ?? "unknown";
       saveCredentials(creds);
-      log6(`backfilled userName: ${creds.userName}`);
+      log5(`backfilled userName: ${creds.userName}`);
     } catch {
     }
   }
@@ -1313,31 +1195,31 @@ async function main() {
         const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
         await api.ensureTable();
         await api.ensureSessionsTable(config.sessionsTableName);
-        log6("setup complete");
+        log5("setup complete");
       }
     } catch (e) {
-      log6(`setup failed: ${e.message}`);
+      log5(`setup failed: ${e.message}`);
       wikiLog(`SessionSetup: failed for ${input.session_id}: ${e.message}`);
     }
   }
   if (embeddingsDisabled()) {
     const status = embeddingsStatus();
     const reason = status === "no-transformers" ? "@huggingface/transformers not installed (run `hivemind embeddings install` to enable)" : "embeddings disabled in ~/.deeplake/config.json (run `hivemind embeddings enable` to opt in)";
-    log6(`embed daemon warmup skipped: ${reason}`);
+    log5(`embed daemon warmup skipped: ${reason}`);
   } else if (process.env.HIVEMIND_EMBED_WARMUP !== "false") {
     try {
-      const daemonEntry = join11(__bundleDir, "embeddings", "embed-daemon.js");
+      const daemonEntry = join10(__bundleDir, "embeddings", "embed-daemon.js");
       const client = new EmbedClient({ daemonEntry, timeoutMs: 300, spawnWaitMs: 5e3 });
       const ok = await client.warmup();
-      log6(`embed daemon warmup: ${ok ? "ok" : "failed"}`);
+      log5(`embed daemon warmup: ${ok ? "ok" : "failed"}`);
     } catch (e) {
-      log6(`embed daemon warmup threw: ${e.message}`);
+      log5(`embed daemon warmup threw: ${e.message}`);
     }
   } else {
-    log6("embed daemon warmup skipped via HIVEMIND_EMBED_WARMUP=false");
+    log5("embed daemon warmup skipped via HIVEMIND_EMBED_WARMUP=false");
   }
 }
 main().catch((e) => {
-  log6(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -297,11 +297,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -292,13 +292,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/claude-code/bundle/session-start-setup.js
+++ b/claude-code/bundle/session-start-setup.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,8 +54,8 @@ var init_index_marker_store = __esm({
 
 // dist/src/hooks/session-start-setup.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join10 } from "node:path";
-import { homedir as homedir7 } from "node:os";
+import { dirname as dirname2, join as join11 } from "node:path";
+import { homedir as homedir8 } from "node:os";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -160,6 +160,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -167,7 +268,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -179,7 +280,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -188,8 +310,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -219,7 +341,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -290,8 +412,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -307,10 +429,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -331,7 +454,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -387,7 +510,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -477,13 +600,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -524,9 +647,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -539,9 +662,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -564,9 +687,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -576,13 +699,13 @@ var DeeplakeApi = class {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -592,15 +715,15 @@ function readStdin() {
 }
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join5 } from "node:path";
+import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join6 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join5(hooksDir, filename);
+  const path = join6(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync3(hooksDir, { recursive: true });
+        mkdirSync4(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -612,9 +735,9 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join7 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -628,8 +751,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join7(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -705,7 +828,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -714,7 +837,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -761,7 +884,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -770,13 +893,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -819,7 +942,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -829,14 +952,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -863,7 +986,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -871,7 +994,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -882,16 +1005,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -901,10 +1024,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync2(this.pidPath);
+        closeSync2(fd);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -916,14 +1039,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -941,7 +1064,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -953,7 +1076,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -968,7 +1091,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -985,7 +1108,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -996,15 +1119,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join8 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync5, renameSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join7 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync5, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join8 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1016,7 +1139,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1030,10 +1153,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync4(dir, { recursive: true });
+    mkdirSync5(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1082,7 +1205,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join8(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join9(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1115,8 +1238,8 @@ function embeddingsDisabled() {
 // dist/src/hooks/shared/autoupdate.js
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join9 } from "node:path";
-var log4 = (msg) => log("autoupdate", msg);
+import { join as join10 } from "node:path";
+var log5 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn2(cmd, args, {
     detached: true,
@@ -1131,7 +1254,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join9(dir, "hivemind");
+    const candidate = join10(dir, "hivemind");
     if (existsSync5(candidate))
       return candidate;
   }
@@ -1139,43 +1262,43 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log4(`agent=${opts.agent} entered`);
+  log5(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log5(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log5(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log5(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log5(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log5(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log5(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/hooks/session-start-setup.js
-var log5 = (msg) => log("session-setup", msg);
+var log6 = (msg) => log("session-setup", msg);
 var __bundleDir = dirname2(fileURLToPath(import.meta.url));
-var { log: wikiLog } = makeWikiLogger(join10(homedir7(), ".claude", "hooks"));
+var { log: wikiLog } = makeWikiLogger(join11(homedir8(), ".claude", "hooks"));
 async function main() {
   if (process.env.HIVEMIND_WIKI_WORKER === "1")
     return;
   const input = await readStdin();
   const creds = loadCredentials();
   if (!creds?.token) {
-    log5("no credentials");
+    log6("no credentials");
     return;
   }
   if (!creds.userName) {
@@ -1183,7 +1306,7 @@ async function main() {
       const { userInfo: userInfo2 } = await import("node:os");
       creds.userName = userInfo2().username ?? "unknown";
       saveCredentials(creds);
-      log5(`backfilled userName: ${creds.userName}`);
+      log6(`backfilled userName: ${creds.userName}`);
     } catch {
     }
   }
@@ -1195,31 +1318,31 @@ async function main() {
         const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
         await api.ensureTable();
         await api.ensureSessionsTable(config.sessionsTableName);
-        log5("setup complete");
+        log6("setup complete");
       }
     } catch (e) {
-      log5(`setup failed: ${e.message}`);
+      log6(`setup failed: ${e.message}`);
       wikiLog(`SessionSetup: failed for ${input.session_id}: ${e.message}`);
     }
   }
   if (embeddingsDisabled()) {
     const status = embeddingsStatus();
     const reason = status === "no-transformers" ? "@huggingface/transformers not installed (run `hivemind embeddings install` to enable)" : "embeddings disabled in ~/.deeplake/config.json (run `hivemind embeddings enable` to opt in)";
-    log5(`embed daemon warmup skipped: ${reason}`);
+    log6(`embed daemon warmup skipped: ${reason}`);
   } else if (process.env.HIVEMIND_EMBED_WARMUP !== "false") {
     try {
-      const daemonEntry = join10(__bundleDir, "embeddings", "embed-daemon.js");
+      const daemonEntry = join11(__bundleDir, "embeddings", "embed-daemon.js");
       const client = new EmbedClient({ daemonEntry, timeoutMs: 300, spawnWaitMs: 5e3 });
       const ok = await client.warmup();
-      log5(`embed daemon warmup: ${ok ? "ok" : "failed"}`);
+      log6(`embed daemon warmup: ${ok ? "ok" : "failed"}`);
     } catch (e) {
-      log5(`embed daemon warmup threw: ${e.message}`);
+      log6(`embed daemon warmup threw: ${e.message}`);
     }
   } else {
-    log5("embed daemon warmup skipped via HIVEMIND_EMBED_WARMUP=false");
+    log6("embed daemon warmup skipped via HIVEMIND_EMBED_WARMUP=false");
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log6(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -297,11 +297,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -292,13 +292,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/claude-code/bundle/session-start.js
+++ b/claude-code/bundle/session-start.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,8 +54,8 @@ var init_index_marker_store = __esm({
 
 // dist/src/hooks/session-start.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join15 } from "node:path";
-import { homedir as homedir11 } from "node:os";
+import { dirname as dirname6, join as join16 } from "node:path";
+import { homedir as homedir12 } from "node:os";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -160,6 +160,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -167,7 +268,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -179,7 +280,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -188,8 +310,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -219,7 +341,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -290,8 +412,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -307,10 +429,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -331,7 +454,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -387,7 +510,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -477,13 +600,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -524,9 +647,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -539,9 +662,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -564,9 +687,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -576,13 +699,13 @@ var DeeplakeApi = class {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -592,18 +715,18 @@ function readStdin() {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync4 } from "node:fs";
-import { dirname, join as join5 } from "node:path";
+import { readFileSync as readFileSync5 } from "node:fs";
+import { dirname, join as join6 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join5(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync4(pluginJson, "utf-8"));
+    const pluginJson = join6(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync4(join5(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync5(join6(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -618,9 +741,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join5(dir, "package.json");
+    const candidate = join6(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync4(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -634,15 +757,15 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join6 } from "node:path";
+import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join6(hooksDir, filename);
+  const path = join7(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync3(hooksDir, { recursive: true });
+        mkdirSync4(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -654,8 +777,8 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 // dist/src/hooks/shared/autoupdate.js
 import { spawn } from "node:child_process";
 import { existsSync as existsSync3 } from "node:fs";
-import { join as join7 } from "node:path";
-var log3 = (msg) => log("autoupdate", msg);
+import { join as join8 } from "node:path";
+var log4 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn(cmd, args, {
     detached: true,
@@ -670,7 +793,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join7(dir, "hivemind");
+    const candidate = join8(dir, "hivemind");
     if (existsSync3(candidate))
       return candidate;
   }
@@ -678,41 +801,41 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log3(`agent=${opts.agent} entered`);
+  log4(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log3(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log3(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log3(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log3(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync8, readFileSync as readFileSync7, writeFileSync as writeFileSync5, mkdirSync as mkdirSync6, renameSync as renameSync3, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { dirname as dirname3, join as join12 } from "node:path";
+import { existsSync as existsSync8, readFileSync as readFileSync8, writeFileSync as writeFileSync6, mkdirSync as mkdirSync7, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync4 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { dirname as dirname3, join as join13 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync5, readdirSync, statSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join8 } from "node:path";
+import { existsSync as existsSync4, mkdirSync as mkdirSync5, readFileSync as readFileSync6, readdirSync, statSync as statSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join9 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -778,29 +901,29 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync6, lstatSync, mkdirSync as mkdirSync5, readFileSync as readFileSync6, renameSync as renameSync2, unlinkSync as unlinkSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { dirname as dirname2, join as join10 } from "node:path";
+import { existsSync as existsSync6, lstatSync, mkdirSync as mkdirSync6, readFileSync as readFileSync7, renameSync as renameSync3, unlinkSync as unlinkSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { dirname as dirname2, join as join11 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync5, renameSync } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { join as join9 } from "node:path";
+import { existsSync as existsSync5, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join9(homedir5(), ".deeplake", "state");
-  const legacy = join9(root, "skilify");
-  const current = join9(root, "skillify");
+  const root = join10(homedir6(), ".deeplake", "state");
+  const legacy = join10(root, "skilify");
+  const current = join10(root, "skillify");
   if (!existsSync5(legacy))
     return;
   if (existsSync5(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -817,7 +940,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join10(homedir6(), ".deeplake", "state", "skillify", "pulled.json");
+  return join11(homedir7(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -825,7 +948,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync6(path, "utf-8");
+    raw = readFileSync7(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -872,10 +995,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync5(dirname2(path), { recursive: true });
+  mkdirSync6(dirname2(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  writeFileSync5(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -900,7 +1023,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync2(path);
+      unlinkSync3(path);
     } catch {
     }
   }
@@ -910,7 +1033,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync6(join10(e.installRoot, e.dirName))) {
+    if (existsSync6(join11(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -924,25 +1047,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync7 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join11 } from "node:path";
+import { homedir as homedir8 } from "node:os";
+import { join as join12 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync7(join11(home, ".codex"));
-  const piInstalled = existsSync7(join11(home, ".pi", "agent"));
-  const hermesInstalled = existsSync7(join11(home, ".hermes"));
+  const codexInstalled = existsSync7(join12(home, ".codex"));
+  const piInstalled = existsSync7(join12(home, ".pi", "agent"));
+  const hermesInstalled = existsSync7(join12(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join11(home, ".agents", "skills"));
+    out.push(join12(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join11(home, ".hermes", "skills"));
+    out.push(join12(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join11(home, ".pi", "agent", "skills"));
+    out.push(join12(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir7()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir8()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -986,15 +1109,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join12(homedir8(), ".claude", "skills");
+    return join13(homedir9(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join12(cwd, ".claude", "skills");
+  return join13(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join12(root, dirName);
+    const link = join13(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -1016,13 +1139,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync3(link);
+        unlinkSync4(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync6(dirname3(link), { recursive: true });
+      mkdirSync7(dirname3(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -1037,7 +1160,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join12(entry.installRoot, entry.dirName);
+    const canonical = join13(entry.installRoot, entry.dirName);
     if (!existsSync8(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -1151,7 +1274,7 @@ function readLocalVersion(path) {
   if (!existsSync8(path))
     return null;
   try {
-    const text = readFileSync7(path, "utf-8");
+    const text = readFileSync8(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1246,8 +1369,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join12(root, dirName);
-    const skillFile = join12(skillDir, "SKILL.md");
+    const skillDir = join13(root, dirName);
+    const skillFile = join13(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1258,14 +1381,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync6(skillDir, { recursive: true });
+      mkdirSync7(skillDir, { recursive: true });
       if (existsSync8(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync5(skillFile, renderSkillFile(row));
+      writeFileSync6(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -1307,7 +1430,7 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/auto-pull.js
-var log4 = (msg) => log("skillify-autopull", msg);
+var log5 = (msg) => log("skillify-autopull", msg);
 var DEFAULT_TIMEOUT_MS = 5e3;
 function withTimeout(p, ms) {
   let timer = null;
@@ -1323,13 +1446,13 @@ function withTimeout(p, ms) {
 }
 async function autoPullSkills(deps = {}) {
   if (process.env.HIVEMIND_AUTOPULL_DISABLED === "1") {
-    log4("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
+    log5("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
     return { pulled: 0, skipped: true, reason: "disabled" };
   }
   const loadFn = deps.loadConfigFn ?? loadConfig;
   const config = loadFn();
   if (!config) {
-    log4("skipped: not logged in");
+    log5("skipped: not logged in");
     return { pulled: 0, skipped: true, reason: "not-logged-in" };
   }
   let query;
@@ -1351,10 +1474,10 @@ async function autoPullSkills(deps = {}) {
       dryRun: false,
       force: false
     }), timeoutMs);
-    log4(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
+    log5(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
     return { pulled: summary.wrote, skipped: false };
   } catch (e) {
-    log4(`pull failed (swallowed): ${e?.message ?? e}`);
+    log5(`pull failed (swallowed): ${e?.message ?? e}`);
     return { pulled: 0, skipped: true, reason: "error" };
   }
 }
@@ -1389,16 +1512,16 @@ function renderSkillifyCommands() {
 }
 
 // dist/src/skillify/local-manifest.js
-import { existsSync as existsSync9, mkdirSync as mkdirSync7, readFileSync as readFileSync8, writeFileSync as writeFileSync6 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { dirname as dirname4, join as join13 } from "node:path";
-var LOCAL_MANIFEST_PATH = join13(homedir9(), ".claude", "hivemind", "local-mined.json");
-var LOCAL_MINE_LOCK_PATH = join13(homedir9(), ".claude", "hivemind", "local-mined.lock");
+import { existsSync as existsSync9, mkdirSync as mkdirSync8, readFileSync as readFileSync9, writeFileSync as writeFileSync7 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { dirname as dirname4, join as join14 } from "node:path";
+var LOCAL_MANIFEST_PATH = join14(homedir10(), ".claude", "hivemind", "local-mined.json");
+var LOCAL_MINE_LOCK_PATH = join14(homedir10(), ".claude", "hivemind", "local-mined.lock");
 function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
   if (!existsSync9(path))
     return null;
   try {
-    return JSON.parse(readFileSync8(path, "utf-8"));
+    return JSON.parse(readFileSync9(path, "utf-8"));
   } catch {
     return null;
   }
@@ -1410,19 +1533,19 @@ function countLocalManifestEntries(path = LOCAL_MANIFEST_PATH) {
 
 // dist/src/skillify/spawn-mine-local-worker.js
 import { execFileSync, spawn as spawn2 } from "node:child_process";
-import { closeSync, existsSync as existsSync10, mkdirSync as mkdirSync8, openSync, readdirSync as readdirSync2, statSync as statSync2, unlinkSync as unlinkSync4 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { dirname as dirname5, join as join14 } from "node:path";
+import { closeSync as closeSync2, existsSync as existsSync10, mkdirSync as mkdirSync9, openSync as openSync2, readdirSync as readdirSync2, statSync as statSync3, unlinkSync as unlinkSync5 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { dirname as dirname5, join as join15 } from "node:path";
 import { fileURLToPath } from "node:url";
-var HOME = homedir10();
-var HIVEMIND_DIR = join14(HOME, ".claude", "hivemind");
-var LOG_PATH = join14(HOME, ".claude", "hooks", "mine-local.log");
-var CLAUDE_PROJECTS_DIR = join14(HOME, ".claude", "projects");
-var LOCK_STALE_MS = 15 * 60 * 1e3;
+var HOME = homedir11();
+var HIVEMIND_DIR = join15(HOME, ".claude", "hivemind");
+var LOG_PATH = join15(HOME, ".claude", "hooks", "mine-local.log");
+var CLAUDE_PROJECTS_DIR = join15(HOME, ".claude", "projects");
+var LOCK_STALE_MS2 = 15 * 60 * 1e3;
 function findBundledCliPath() {
   try {
     const thisDir = dirname5(fileURLToPath(import.meta.url));
-    const cliPath = join14(thisDir, "..", "..", "bundle", "cli.js");
+    const cliPath = join15(thisDir, "..", "..", "bundle", "cli.js");
     return existsSync10(cliPath) ? cliPath : null;
   } catch {
     return null;
@@ -1455,7 +1578,7 @@ function hasLocalClaudeSessions() {
   for (const sub of subdirs) {
     let files;
     try {
-      files = readdirSync2(join14(CLAUDE_PROJECTS_DIR, sub));
+      files = readdirSync2(join15(CLAUDE_PROJECTS_DIR, sub));
     } catch {
       continue;
     }
@@ -1470,14 +1593,14 @@ function maybeAutoMineLocal() {
   if (existsSync10(LOCAL_MINE_LOCK_PATH)) {
     let stale = false;
     try {
-      const stats = statSync2(LOCAL_MINE_LOCK_PATH);
-      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS;
+      const stats = statSync3(LOCAL_MINE_LOCK_PATH);
+      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS2;
     } catch {
     }
     if (!stale)
       return { triggered: false, reason: "lock-exists" };
     try {
-      unlinkSync4(LOCAL_MINE_LOCK_PATH);
+      unlinkSync5(LOCAL_MINE_LOCK_PATH);
     } catch {
       return { triggered: false, reason: "lock-exists" };
     }
@@ -1488,27 +1611,27 @@ function maybeAutoMineLocal() {
   if (!launcher)
     return { triggered: false, reason: "no-hivemind-bin" };
   try {
-    mkdirSync8(HIVEMIND_DIR, { recursive: true });
-    const fd = openSync(LOCAL_MINE_LOCK_PATH, "wx");
-    closeSync(fd);
+    mkdirSync9(HIVEMIND_DIR, { recursive: true });
+    const fd = openSync2(LOCAL_MINE_LOCK_PATH, "wx");
+    closeSync2(fd);
   } catch {
     return { triggered: false, reason: "lock-acquire-failed" };
   }
   try {
-    mkdirSync8(join14(HOME, ".claude", "hooks"), { recursive: true });
-    const out = openSync(LOG_PATH, "a");
+    mkdirSync9(join15(HOME, ".claude", "hooks"), { recursive: true });
+    const out = openSync2(LOG_PATH, "a");
     const [cmd, args] = launcher.kind === "node-script" ? [process.execPath, [launcher.path, "skillify", "mine-local"]] : [launcher.path, ["skillify", "mine-local"]];
     const child = spawn2(cmd, args, {
       detached: true,
       stdio: ["ignore", out, out],
       env: process.env
     });
-    closeSync(out);
+    closeSync2(out);
     child.unref();
     return { triggered: true };
   } catch {
     try {
-      unlinkSync4(LOCAL_MINE_LOCK_PATH);
+      unlinkSync5(LOCAL_MINE_LOCK_PATH);
     } catch {
     }
     return { triggered: false, reason: "spawn-failed" };
@@ -1516,7 +1639,7 @@ function maybeAutoMineLocal() {
 }
 
 // dist/src/hooks/session-start.js
-var log5 = (msg) => log("session-start", msg);
+var log6 = (msg) => log("session-start", msg);
 var __bundleDir = dirname6(fileURLToPath2(import.meta.url));
 var context = `DEEPLAKE MEMORY: You have TWO memory sources. ALWAYS check BOTH when the user asks you to recall, remember, or look up ANY information:
 
@@ -1564,8 +1687,8 @@ IMPORTANT: Only use bash commands (cat, ls, grep, echo, jq, head, tail, etc.) to
 LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 
 Debugging: Set HIVEMIND_DEBUG=1 to enable verbose logging to ~/.deeplake/hook-debug.log`;
-var HOME2 = homedir11();
-var { log: wikiLog } = makeWikiLogger(join15(HOME2, ".claude", "hooks"));
+var HOME2 = homedir12();
+var { log: wikiLog } = makeWikiLogger(join16(HOME2, ".claude", "hooks"));
 async function createPlaceholder(api, table, sessionId, cwd, userName, orgName, workspaceId, pluginVersion) {
   const summaryPath = `/summaries/${userName}/${sessionId}.md`;
   const existing = await api.query(`SELECT path FROM "${table}" WHERE path = '${sqlStr(summaryPath)}' LIMIT 1`);
@@ -1592,21 +1715,21 @@ async function main() {
   if (process.env.HIVEMIND_WIKI_WORKER === "1")
     return;
   const __hookT0 = Date.now();
-  log5(`hook entered (pid=${process.pid})`);
+  log6(`hook entered (pid=${process.pid})`);
   const input = await readStdin();
   let creds = loadCredentials();
   if (!creds?.token) {
-    log5("no credentials found \u2014 run /hivemind:login to authenticate");
+    log6("no credentials found \u2014 run /hivemind:login to authenticate");
     const auto = maybeAutoMineLocal();
-    log5(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
+    log6(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
-    log5(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    log6(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
     if (creds.token && !creds.userName) {
       try {
         const { userInfo: userInfo2 } = await import("node:os");
         creds.userName = userInfo2().username ?? "unknown";
         saveCredentials(creds);
-        log5(`backfilled and persisted userName: ${creds.userName}`);
+        log6(`backfilled and persisted userName: ${creds.userName}`);
       } catch {
       }
     }
@@ -1626,18 +1749,18 @@ async function main() {
         await api.ensureSessionsTable(sessionsTable);
         if (captureEnabled) {
           await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId, pluginVersion);
-          log5("placeholder created");
+          log6("placeholder created");
         } else {
-          log5("placeholder skipped (HIVEMIND_CAPTURE=false)");
+          log6("placeholder skipped (HIVEMIND_CAPTURE=false)");
         }
       }
     } catch (e) {
-      log5(`placeholder failed: ${e.message}`);
+      log6(`placeholder failed: ${e.message}`);
       wikiLog(`SessionStart: placeholder failed for ${input.session_id}: ${e.message}`);
     }
   }
   const pullResult = await autoPullSkills();
-  log5(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
+  log6(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
   const updateNotice = current ? `
 
 \u2705 Hivemind v${current}` : "";
@@ -1657,9 +1780,9 @@ Logged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${cred
       additionalContext
     }
   }));
-  log5(`hook done (${Date.now() - __hookT0}ms total)`);
+  log6(`hook done (${Date.now() - __hookT0}ms total)`);
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log6(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join12(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join12(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join12(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -66870,7 +66870,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms3) {
-  return new Promise((resolve6) => setTimeout(resolve6, ms3));
+  return new Promise((resolve5) => setTimeout(resolve5, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +66900,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve6) => this.waiting.push(resolve6));
+    await new Promise((resolve5) => this.waiting.push(resolve5));
   }
   release() {
     this.active--;
@@ -67259,7 +67259,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join10 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67689,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join7 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67704,105 +67704,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
-import { join as join7, resolve as resolve4 } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join7(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m26) => log("embed-client", m26);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path2, home) {
-  const r10 = resolve4(path2);
-  const h18 = resolve4(home);
-  return r10.startsWith(h18 + "/") || r10 === h18;
-}
-function writeQueue(q17) {
-  const path2 = queuePath();
-  const home = resolve4(homedir3());
-  if (!_isQueuePathInsideHome(path2, home)) {
-    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v27 = await this.embedAttempt(text, kind);
+    if (v27 !== "recycled")
+      return v27;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join7(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path2}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
-  renameSync(tmp, path2);
-}
-async function withQueueLock(fn4) {
-  const path2 = lockPath();
-  mkdirSync2(join7(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path2, "wx", 384);
-      break;
-    } catch (e6) {
-      const code = e6.code;
-      if (code !== "EEXIST")
-        throw e6;
-      try {
-        const age = Date.now() - statSync2(path2).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path2);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e6) {
+      const err = e6 instanceof Error ? e6.message : String(e6);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn4();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync4(this.socketPath))
+        return;
+      await new Promise((r10) => setTimeout(r10, 50));
+    }
   }
-  try {
-    return fn4();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e6) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      return false;
     }
-    try {
-      unlinkSync(path2);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a15, b26) {
-  if (a15.id !== b26.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
-}
-async function enqueueNotification(n24) {
-  await withQueueLock(() => {
-    const q17 = readQueue();
-    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s10 = await this.connectOnce();
+      s10.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s10 = await this.waitForSocket();
+        s10.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve5, reject) => {
+      const sock = connect(this.socketPath);
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to3);
+        resolve5(sock);
+      });
+      sock.once("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e6) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q17.queue.push(n24);
-    writeQueue(q17);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync4(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve5, reject) => {
+      let buf = "";
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl3 = buf.indexOf("\n");
+        if (nl3 === -1)
+          return;
+        const line = buf.slice(0, nl3);
+        clearTimeout(to3);
+        try {
+          resolve5(JSON.parse(line));
+        } catch (e6) {
+          reject(e6);
+        }
+      });
+      sock.on("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+      sock.on("end", () => {
+        clearTimeout(to3);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms3) {
+  return new Promise((r10) => setTimeout(r10, ms3));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v27 of vec) {
+    if (!Number.isFinite(v27))
+      return "NULL";
+    parts.push(String(v27));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -67812,7 +68091,7 @@ import { join as join9 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname as dirname4, join as join8 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
@@ -67822,7 +68101,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path2 = _configPath();
-  if (!existsSync4(path2)) {
+  if (!existsSync5(path2)) {
     _cache = {};
     return _cache;
   }
@@ -67840,11 +68119,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path2 = _configPath();
   const dir = dirname4(path2);
-  if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync5(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path2);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -67921,403 +68200,6 @@ function embeddingsStatus() {
 }
 function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
-}
-
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join10(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m26) => log("embed-client", m26);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync5(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v27 = await this.embedAttempt(text, kind);
-    if (v27 !== "recycled")
-      return v27;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e6) {
-      const err = e6 instanceof Error ? e6.message : String(e6);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync5(this.socketPath))
-        return;
-      await new Promise((r10) => setTimeout(r10, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e6) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync5(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e6) => {
-      log4(`enqueue embed-deps-missing failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync5(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s10 = await this.connectOnce();
-      s10.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s10 = await this.waitForSocket();
-        s10.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve6, reject) => {
-      const sock = connect(this.socketPath);
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to3);
-        resolve6(sock);
-      });
-      sock.once("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e6) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync5(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync5(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve6, reject) => {
-      let buf = "";
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl3 = buf.indexOf("\n");
-        if (nl3 === -1)
-          return;
-        const line = buf.slice(0, nl3);
-        clearTimeout(to3);
-        try {
-          resolve6(JSON.parse(line));
-        } catch (e6) {
-          reject(e6);
-        }
-      });
-      sock.on("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-      sock.on("end", () => {
-        clearTimeout(to3);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms3) {
-  return new Promise((r10) => setTimeout(r10, ms3));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v27 of vec) {
-    if (!Number.isFinite(v27))
-      return "NULL";
-    parts.push(String(v27));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/hooks/virtual-table-query.js
@@ -68412,7 +68294,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68978,7 +68860,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve5 } from "path";
+import { normalize, resolve as resolve4 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69916,7 +69798,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync5 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69938,12 +69820,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve5,
+  resolve: resolve4,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync5(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69963,11 +69845,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join11 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join14(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join14(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join14(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join7 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join8(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join7(getIndexMarkerDir(), `${markerKey}.json`);
+  return join8(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66942,6 +66942,24 @@ async function enqueueNotification(n24) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join7 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join7(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join7(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66978,11 +66996,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c15 = loadCredentials();
+    if (c15?.orgName && c15?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c15.orgName)}/workspace/${encodeURIComponent(c15.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -67382,7 +67410,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join12 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67812,9 +67840,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join8 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join9 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67828,7 +67856,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join9(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -68019,7 +68047,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -68032,11 +68060,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -68087,7 +68115,7 @@ var EmbedClient = class {
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -68104,7 +68132,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -68123,7 +68151,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68209,15 +68237,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname4, join as join9 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname4, join as join10 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join10(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68229,7 +68257,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path2, "utf-8");
+    const raw = readFileSync6(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68243,9 +68271,9 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path2);
   _cache = merged;
   return merged;
@@ -68295,7 +68323,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join11(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68417,7 +68445,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -69921,7 +69949,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync7 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69948,7 +69976,7 @@ var parser = new YargsParser({
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync7(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69968,11 +69996,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join13 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join13(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -66991,13 +66991,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });

--- a/claude-code/bundle/shell/deeplake-shell.js
+++ b/claude-code/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join12(output, replacement);
+        return join13(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join12(output, rule.append(self2.options));
+          output = join13(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join12(output, replacement) {
+    function join13(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join6 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join6(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join6(getIndexMarkerDir(), `${markerKey}.json`);
+  return join7(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66841,6 +66841,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
+import { join as join6, resolve as resolve4 } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join6(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path2, home) {
+  const r10 = resolve4(path2);
+  const h18 = resolve4(home);
+  return r10.startsWith(h18 + "/") || r10 === h18;
+}
+function writeQueue(q17) {
+  const path2 = queuePath();
+  const home = resolve4(homedir3());
+  if (!_isQueuePathInsideHome(path2, home)) {
+    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  }
+  mkdirSync(join6(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path2}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
+  renameSync(tmp, path2);
+}
+async function withQueueLock(fn4) {
+  const path2 = lockPath();
+  mkdirSync(join6(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path2, "wx", 384);
+      break;
+    } catch (e6) {
+      const code = e6.code;
+      if (code !== "EEXIST")
+        throw e6;
+      try {
+        const age = Date.now() - statSync2(path2).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path2);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn4();
+  }
+  try {
+    return fn4();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path2);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a15, b26) {
+  if (a15.id !== b26.id)
+    return false;
+  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
+}
+async function enqueueNotification(n24) {
+  await withQueueLock(() => {
+    const q17 = readQueue();
+    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+      return;
+    }
+    q17.queue.push(n24);
+    writeQueue(q17);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66848,7 +66949,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -66860,7 +66961,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e6) => {
+    log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -66869,8 +66991,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms3) {
-  return new Promise((resolve5) => setTimeout(resolve5, ms3));
+function sleep2(ms3) {
+  return new Promise((resolve6) => setTimeout(resolve6, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +67022,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve5) => this.waiting.push(resolve5));
+    await new Promise((resolve6) => this.waiting.push(resolve6));
   }
   release() {
     this.active--;
@@ -66971,8 +67093,8 @@ var DeeplakeApi = class {
         lastError = e6 instanceof Error ? e6 : new Error(String(e6));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -66988,10 +67110,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -67012,7 +67135,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i11, i11 + CONCURRENCY);
       await Promise.allSettled(chunk.map((r10) => this.upsertRowSql(r10)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts3 = (/* @__PURE__ */ new Date()).toISOString();
@@ -67068,7 +67191,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e6.message}`);
+      log3(`index "${indexName}" skipped: ${e6.message}`);
     }
   }
   /**
@@ -67158,13 +67281,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -67192,9 +67315,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -67205,9 +67328,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -67220,9 +67343,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67245,9 +67368,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67259,7 +67382,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join10 } from "node:path";
+import { dirname as dirname5, join as join11 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67812,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join8 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67705,8 +67828,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m26) => log("embed-client", m26);
+var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -67782,7 +67905,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -67791,7 +67914,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e6) {
       const err = e6 instanceof Error ? e6.message : String(e6);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -67838,7 +67961,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e6) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
       return false;
     }
     const hello = resp;
@@ -67847,13 +67970,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -67896,7 +68019,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -67906,14 +68029,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -67940,7 +68063,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       const sock = connect(this.socketPath);
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -67948,7 +68071,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to3);
-        resolve5(sock);
+        resolve6(sock);
       });
       sock.once("error", (e6) => {
         clearTimeout(to3);
@@ -67959,16 +68082,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -67978,10 +68101,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -67993,14 +68116,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68018,7 +68141,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync4(this.socketPath))
         continue;
@@ -68030,7 +68153,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       let buf = "";
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -68045,7 +68168,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl3);
         clearTimeout(to3);
         try {
-          resolve5(JSON.parse(line));
+          resolve6(JSON.parse(line));
         } catch (e6) {
           reject(e6);
         }
@@ -68062,7 +68185,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms3) {
+function sleep3(ms3) {
   return new Promise((r10) => setTimeout(r10, ms3));
 }
 function isTransformersMissingError(err) {
@@ -68086,15 +68209,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join9 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join10 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname as dirname4, join as join8 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname as dirname4, join as join9 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68106,7 +68229,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path2, "utf-8");
+    const raw = readFileSync5(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68120,10 +68243,10 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path2);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -68172,7 +68295,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join9(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68294,7 +68417,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68860,7 +68983,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve4 } from "path";
+import { normalize, resolve as resolve5 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69798,7 +69921,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync5 } from "fs";
+import { readFileSync as readFileSync6 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69820,12 +69943,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve4,
+  resolve: resolve5,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync5(path2, "utf8"));
+      return JSON.parse(readFileSync6(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69845,11 +69968,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join11 } from "node:path";
+import { dirname as dirname6, join as join12 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/claude-code/bundle/wiki-worker.js
+++ b/claude-code/bundle/wiki-worker.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // dist/src/hooks/wiki-worker.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync4, rmSync } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync3, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join6 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // dist/src/utils/debug.js
@@ -164,9 +164,9 @@ async function uploadSummary(query2, params) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync2, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync as writeSync2, unlinkSync as unlinkSync2, existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join3 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -179,105 +179,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, renameSync as renameSync2, mkdirSync as mkdirSync2, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join3, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
-var log2 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join3(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log2 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath2() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync2(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log2(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync2(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join3(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync2(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath2();
-  mkdirSync2(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync2(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log2(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log2(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep(delay);
     }
   }
-  if (fd === null) {
-    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync2(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync2(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log2(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log2(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync2(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log2(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync2(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync2(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log2(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync2(this.pidPath, "wx", 384);
+      writeSync2(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync2(this.pidPath, "wx", 384);
+          writeSync2(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync2(this.daemonEntry)) {
+      log2(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log2(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync2(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync2(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync2(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -287,7 +553,7 @@ import { join as join5 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync3, renameSync as renameSync3, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join4 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join4(homedir4(), ".deeplake", "config.json");
@@ -297,7 +563,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     _cache = {};
     return _cache;
   }
@@ -315,11 +581,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync2(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync3(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync3(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -398,399 +664,15 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync3(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log3(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync3(this.pidPath, "wx", 384);
-      writeSync2(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync3(this.pidPath, "wx", 384);
-          writeSync2(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync3(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep2(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync3(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep2(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/wiki-worker.js
 var dlog2 = (msg) => log("wiki-worker", msg);
-var cfg = JSON.parse(readFileSync5(process.argv[2], "utf-8"));
+var cfg = JSON.parse(readFileSync4(process.argv[2], "utf-8"));
 var tmpDir = cfg.tmpDir;
-var tmpJsonl = join7(tmpDir, "session.jsonl");
-var tmpSummary = join7(tmpDir, "summary.md");
+var tmpJsonl = join6(tmpDir, "session.jsonl");
+var tmpSummary = join6(tmpDir, "summary.md");
 function wlog(msg) {
   try {
-    mkdirSync4(cfg.hooksDir, { recursive: true });
+    mkdirSync3(cfg.hooksDir, { recursive: true });
     appendFileSync2(cfg.wikiLog, `[${utcTimestamp()}] wiki-worker(${cfg.sessionId}): ${msg}
 `);
   } catch {
@@ -822,7 +704,7 @@ async function query(sql, retries = 4) {
       const base = Math.min(3e4, 2e3 * Math.pow(2, attempt));
       const delay = base + Math.floor(Math.random() * 1e3);
       wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise((resolve2) => setTimeout(resolve2, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       continue;
     }
     throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
@@ -848,7 +730,7 @@ async function main() {
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc2(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
-    writeFileSync4(tmpJsonl, jsonlContent);
+    writeFileSync3(tmpJsonl, jsonlContent);
     wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
     let prevOffset = 0;
     try {
@@ -858,7 +740,7 @@ async function main() {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
-        writeFileSync4(tmpSummary, existing);
+        writeFileSync3(tmpSummary, existing);
         wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch {
@@ -884,14 +766,14 @@ async function main() {
       wlog(`claude -p failed: ${e.status ?? e.message}`);
     }
     if (existsSync4(tmpSummary)) {
-      const text = readFileSync5(tmpSummary, "utf-8");
+      const text = readFileSync4(tmpSummary, "utf-8");
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         let embedding = null;
         if (!embeddingsDisabled()) {
           try {
-            const daemonEntry = join7(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
+            const daemonEntry = join6(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
             embedding = await new EmbedClient({ daemonEntry }).embed(text, "document");
           } catch (e) {
             wlog(`summary embedding failed, writing NULL: ${e.message}`);

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -176,7 +176,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +206,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -570,9 +570,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -585,105 +585,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v of vec) {
+    if (!Number.isFinite(v))
+      return "NULL";
+    parts.push(String(v));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -693,7 +972,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -703,7 +982,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -721,11 +1000,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -804,414 +1083,17 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v of vec) {
-    if (!Number.isFinite(v))
-      return "NULL";
-    parts.push(String(v));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
-}
-
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { basename, dirname as dirname2, join as join7 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join7(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1232,7 +1114,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync2(link);
+      statSync(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1252,14 +1134,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync3(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync3(tmp, link);
+    renameSync2(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1268,53 +1150,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/codex/capture.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join13 } from "node:path";
+import { dirname as dirname5, join as join12 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join8(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+function lockPath(sessionId) {
+  return join8(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync5(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
-  renameSync4(tmp, p);
+  writeFileSync3(tmp, JSON.stringify(state));
+  renameSync3(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync3(rmwLock, "wx");
+      fd = openSync2(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync2(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1326,9 +1208,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync3(fd);
+    closeSync2(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync2(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1363,29 +1245,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
-  const p = lockPath2(sessionId);
+  mkdirSync4(STATE_DIR, { recursive: true });
+  const p = lockPath(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync2(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync3(p, "wx");
+    const fd = openSync2(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync3(fd);
+      closeSync2(fd);
     }
     return true;
   } catch (e) {
@@ -1396,7 +1278,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync2(lockPath(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1407,20 +1289,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/codex/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join11 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
+import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join9 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join9(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync5(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1430,18 +1312,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname3, join as join10 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1456,9 +1338,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join10(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1472,8 +1354,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".codex", "hooks"));
+var HOME = homedir8();
+var wikiLogger = makeWikiLogger(join11(HOME, ".codex", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1535,11 +1417,11 @@ function findCodexBin() {
 function spawnCodexWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".codex-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join11(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1553,11 +1435,11 @@ function spawnCodexWikiWorker(opts) {
     tmpDir,
     codexBin: findCodexBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".codex", "hooks"),
+    hooksDir: join11(HOME, ".codex", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join11(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1569,9 +1451,9 @@ function bundleDirFromImportMeta(importMetaUrl) {
 }
 
 // dist/src/hooks/codex/capture.js
-var log5 = (msg) => log("codex-capture", msg);
+var log4 = (msg) => log("codex-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join13(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join12(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath2(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
@@ -1588,7 +1470,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log5("no config");
+    log4("no config");
     return;
   }
   const sessionsTable = config.sessionsTableName;
@@ -1605,7 +1487,7 @@ async function main() {
   };
   let entry;
   if (input.hook_event_name === "UserPromptSubmit" && input.prompt !== void 0) {
-    log5(`user session=${input.session_id}`);
+    log4(`user session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1613,7 +1495,7 @@ async function main() {
       content: input.prompt
     };
   } else if (input.hook_event_name === "PostToolUse" && input.tool_name !== void 0) {
-    log5(`tool=${input.tool_name} session=${input.session_id}`);
+    log4(`tool=${input.tool_name} session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1624,12 +1506,12 @@ async function main() {
       tool_response: JSON.stringify(input.tool_response)
     };
   } else {
-    log5(`unknown event: ${input.hook_event_name}, skipping`);
+    log4(`unknown event: ${input.hook_event_name}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, input.session_id);
   const line = JSON.stringify(entry);
-  log5(`writing to ${sessionPath}`);
+  log4(`writing to ${sessionPath}`);
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -1640,14 +1522,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log5("table missing, creating and retrying");
+      log4("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log5("capture ok");
+  log4("capture ok");
   maybeTriggerPeriodicSummary(input.session_id, input.cwd ?? "", config);
 }
 function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
@@ -1659,7 +1541,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -1672,19 +1554,19 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log5(`periodic spawn failed: ${e.message}`);
+      log4(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch (releaseErr) {
-        log5(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
+        log4(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
       }
       throw e;
     }
   } catch (e) {
-    log5(`periodic trigger error: ${e.message}`);
+    log4(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -297,13 +297,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -248,6 +248,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -284,11 +302,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -693,9 +721,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -709,7 +737,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -900,7 +928,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -913,11 +941,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -968,7 +996,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -985,7 +1013,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1004,7 +1032,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1090,15 +1118,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1110,7 +1138,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1124,9 +1152,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1176,7 +1204,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1207,16 +1235,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync5, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { basename, dirname as dirname2, join as join9 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join9(homedir8(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join9(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1257,7 +1285,7 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync5(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
@@ -1273,40 +1301,40 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/codex/capture.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join13 } from "node:path";
+import { dirname as dirname5, join as join14 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync5, writeSync as writeSync2, mkdirSync as mkdirSync6, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync4, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join10(homedir9(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join10(STATE_DIR, `${sessionId}.json`);
 }
 function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+  return join10(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
+  writeFileSync5(tmp, JSON.stringify(state));
   renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1319,7 +1347,7 @@ function withRmwLock(sessionId, fn) {
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync4(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1333,7 +1361,7 @@ function withRmwLock(sessionId, fn) {
   } finally {
     closeSync3(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync4(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1368,18 +1396,18 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
@@ -1401,7 +1429,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync4(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1412,20 +1440,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/codex/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join13 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8 } from "node:fs";
+import { homedir as homedir10, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync7, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join11 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join11(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync7(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1435,18 +1463,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync8 } from "node:fs";
+import { dirname as dirname3, join as join12 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join12(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync8(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync8(join12(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1461,9 +1489,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join12(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync8(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1477,8 +1505,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".codex", "hooks"));
+var HOME = homedir10();
+var wikiLogger = makeWikiLogger(join13(HOME, ".codex", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1540,11 +1568,11 @@ function findCodexBin() {
 function spawnCodexWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join13(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync8(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".codex-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join13(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1558,11 +1586,11 @@ function spawnCodexWikiWorker(opts) {
     tmpDir,
     codexBin: findCodexBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".codex", "hooks"),
+    hooksDir: join13(HOME, ".codex", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join13(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1576,7 +1604,7 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/hooks/codex/capture.js
 var log5 = (msg) => log("codex-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join13(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join14(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath2(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";

--- a/codex/bundle/capture.js
+++ b/codex/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -147,6 +147,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -154,7 +255,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -166,7 +267,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -175,8 +297,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +328,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -277,8 +399,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -294,10 +416,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -318,7 +441,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -374,7 +497,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -464,13 +587,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -498,9 +621,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -526,9 +649,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -551,9 +674,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -570,9 +693,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -586,8 +709,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -663,7 +786,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -672,7 +795,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -719,7 +842,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -728,13 +851,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -777,7 +900,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -787,14 +910,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -821,7 +944,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -829,7 +952,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -840,16 +963,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -859,10 +982,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -874,14 +997,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -899,7 +1022,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -911,7 +1034,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -926,7 +1049,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -943,7 +1066,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -967,15 +1090,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -987,7 +1110,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1001,10 +1124,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1053,7 +1176,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1084,16 +1207,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { basename, dirname as dirname2, join as join7 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { basename, dirname as dirname2, join as join8 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join7(pluginDir, "node_modules");
+  const link = join8(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1114,7 +1237,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync(link);
+      statSync2(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1134,14 +1257,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync3(parent, { recursive: true });
+      mkdirSync4(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync2(tmp, link);
+    renameSync3(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1150,53 +1273,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/codex/capture.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join12 } from "node:path";
+import { dirname as dirname5, join as join13 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join8 } from "node:path";
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join9 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.json`);
+  return join9(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.lock`);
+function lockPath2(sessionId) {
+  return join9(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync5(p, "utf-8"));
+    return JSON.parse(readFileSync6(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(state));
-  renameSync3(tmp, p);
+  writeFileSync4(tmp, JSON.stringify(state));
+  renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync2(rmwLock, "wx");
+      fd = openSync3(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmwLock);
+          unlinkSync3(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1208,9 +1331,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync2(fd);
+    closeSync3(fd);
     try {
-      unlinkSync2(rmwLock);
+      unlinkSync3(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1245,29 +1368,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync4(STATE_DIR, { recursive: true });
-  const p = lockPath(sessionId);
+  mkdirSync5(STATE_DIR, { recursive: true });
+  const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync2(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
     return true;
   } catch (e) {
@@ -1278,7 +1401,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync2(lockPath(sessionId));
+    unlinkSync3(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1289,20 +1412,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/codex/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join11 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
-import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join12 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
+import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join9 } from "node:path";
+import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join10 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join9(hooksDir, filename);
+  const path = join10(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync5(hooksDir, { recursive: true });
+        mkdirSync6(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1312,18 +1435,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync6 } from "node:fs";
-import { dirname as dirname3, join as join10 } from "node:path";
+import { readFileSync as readFileSync7 } from "node:fs";
+import { dirname as dirname3, join as join11 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
+    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1338,9 +1461,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join10(dir, "package.json");
+    const candidate = join11(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1354,8 +1477,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/spawn-wiki-worker.js
-var HOME = homedir8();
-var wikiLogger = makeWikiLogger(join11(HOME, ".codex", "hooks"));
+var HOME = homedir9();
+var wikiLogger = makeWikiLogger(join12(HOME, ".codex", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1417,11 +1540,11 @@ function findCodexBin() {
 function spawnCodexWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync6(tmpDir, { recursive: true });
+  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".codex-plugin") ?? "";
-  const configFile = join11(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join12(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1435,11 +1558,11 @@ function spawnCodexWikiWorker(opts) {
     tmpDir,
     codexBin: findCodexBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join11(HOME, ".codex", "hooks"),
+    hooksDir: join12(HOME, ".codex", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join11(bundleDir, "wiki-worker.js");
+  const workerPath = join12(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1451,9 +1574,9 @@ function bundleDirFromImportMeta(importMetaUrl) {
 }
 
 // dist/src/hooks/codex/capture.js
-var log4 = (msg) => log("codex-capture", msg);
+var log5 = (msg) => log("codex-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join12(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join13(dirname5(fileURLToPath2(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath2(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
@@ -1470,7 +1593,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log4("no config");
+    log5("no config");
     return;
   }
   const sessionsTable = config.sessionsTableName;
@@ -1487,7 +1610,7 @@ async function main() {
   };
   let entry;
   if (input.hook_event_name === "UserPromptSubmit" && input.prompt !== void 0) {
-    log4(`user session=${input.session_id}`);
+    log5(`user session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1495,7 +1618,7 @@ async function main() {
       content: input.prompt
     };
   } else if (input.hook_event_name === "PostToolUse" && input.tool_name !== void 0) {
-    log4(`tool=${input.tool_name} session=${input.session_id}`);
+    log5(`tool=${input.tool_name} session=${input.session_id}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1506,12 +1629,12 @@ async function main() {
       tool_response: JSON.stringify(input.tool_response)
     };
   } else {
-    log4(`unknown event: ${input.hook_event_name}, skipping`);
+    log5(`unknown event: ${input.hook_event_name}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, input.session_id);
   const line = JSON.stringify(entry);
-  log4(`writing to ${sessionPath}`);
+  log5(`writing to ${sessionPath}`);
   const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -1522,14 +1645,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log4("table missing, creating and retrying");
+      log5("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log4("capture ok");
+  log5("capture ok");
   maybeTriggerPeriodicSummary(input.session_id, input.cwd ?? "", config);
 }
 function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
@@ -1541,7 +1664,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -1554,19 +1677,19 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log4(`periodic spawn failed: ${e.message}`);
+      log5(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch (releaseErr) {
-        log4(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
+        log5(`releaseLock after periodic spawn failure also failed: ${releaseErr.message}`);
       }
       throw e;
     }
   } catch (e) {
-    log4(`periodic trigger error: ${e.message}`);
+    log5(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -469,13 +469,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -474,11 +474,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/codex/bundle/commands/auth-login.js
+++ b/codex/bundle/commands/auth-login.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -337,6 +337,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -344,7 +445,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -356,7 +457,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -365,8 +487,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -396,7 +518,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -467,8 +589,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -484,10 +606,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -508,7 +631,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -564,7 +687,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -654,13 +777,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -688,9 +811,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -701,9 +824,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -716,9 +839,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -741,9 +864,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -774,10 +897,10 @@ function parseArgs(argv) {
 }
 function confirm(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     rl.question(`${message} [y/N] `, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
+      resolve2(answer.trim().toLowerCase() === "y");
     });
   });
 }

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -55,18 +55,18 @@ var init_index_marker_store = __esm({
 // dist/src/hooks/codex/pre-tool-use.js
 import { execFileSync } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join11, dirname as dirname3 } from "node:path";
+import { join as join10, dirname as dirname3 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve3, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve3(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -182,7 +182,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve3) => setTimeout(resolve3, ms));
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -212,7 +212,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve3) => this.waiting.push(resolve3));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -1049,9 +1049,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1064,105 +1064,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve2, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve2(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve2, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve2(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -1172,7 +1438,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -1182,7 +1448,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -1200,11 +1466,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1283,397 +1549,13 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve3, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve3(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve3, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve3(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join7 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2676,20 +2558,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
-import { join as join9 } from "node:path";
-import { homedir as homedir7 } from "node:os";
-var log5 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
+import { mkdirSync as mkdirSync3, readFileSync as readFileSync5, rmSync, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+var log4 = (msg) => log("query-cache", msg);
+var DEFAULT_CACHE_ROOT = join8(homedir6(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join9(cacheRoot, sessionId);
+  return join8(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
-  const { logFn = log5 } = deps;
+  const { logFn = log4 } = deps;
   try {
-    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync5(join8(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2698,34 +2580,34 @@ function readCachedIndexContent(sessionId, deps = {}) {
   }
 }
 function writeCachedIndexContent(sessionId, content, deps = {}) {
-  const { logFn = log5 } = deps;
+  const { logFn = log4 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync4(dir, { recursive: true });
-    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync3(dir, { recursive: true });
+    writeFileSync3(join8(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
 }
 
 // dist/src/utils/direct-run.js
-import { resolve as resolve2 } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 function isDirectRun(metaUrl) {
   const entry = process.argv[1];
   if (!entry)
     return false;
   try {
-    return resolve2(fileURLToPath2(metaUrl)) === resolve2(entry);
+    return resolve(fileURLToPath2(metaUrl)) === resolve(entry);
   } catch {
     return false;
   }
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir8 } from "node:os";
-import { join as join10 } from "node:path";
-var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
+var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2841,13 +2723,13 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/codex/pre-tool-use.js
-var log6 = (msg) => log("codex-pre", msg);
+var log5 = (msg) => log("codex-pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
+var SHELL_BUNDLE = existsSync5(join10(__bundleDir, "shell", "deeplake-shell.js")) ? join10(__bundleDir, "shell", "deeplake-shell.js") : join10(__bundleDir, "..", "shell", "deeplake-shell.js");
 function buildUnsupportedGuidance() {
   return "This command is not supported for ~/.deeplake/memory/ operations. Only bash builtins are available: cat, ls, grep, echo, jq, head, tail, sed, awk, wc, sort, find, etc. Do NOT use python, python3, node, curl, or other interpreters. Rewrite your command using only bash tools and retry.";
 }
-function runVirtualShell(cmd, shellBundle = SHELL_BUNDLE, logFn = log6) {
+function runVirtualShell(cmd, shellBundle = SHELL_BUNDLE, logFn = log5) {
   try {
     return execFileSync("node", [shellBundle, "-c", cmd], {
       encoding: "utf-8",
@@ -2872,7 +2754,7 @@ function buildIndexContent(rows) {
   return lines.join("\n");
 }
 async function processCodexPreToolUse(input, deps = {}) {
-  const { config = loadConfig(), createApi = (table, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table), executeCompiledBashCommandFn = executeCompiledBashCommand, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, handleGrepDirectFn = handleGrepDirect, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, runVirtualShellFn = runVirtualShell, shellBundle = SHELL_BUNDLE, logFn = log6 } = deps;
+  const { config = loadConfig(), createApi = (table, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table), executeCompiledBashCommandFn = executeCompiledBashCommand, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, handleGrepDirectFn = handleGrepDirect, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, runVirtualShellFn = runVirtualShell, shellBundle = SHELL_BUNDLE, logFn = log5 } = deps;
   const cmd = input.tool_input?.command ?? "";
   logFn(`hook fired: cmd=${cmd}`);
   if (!touchesMemory(cmd))
@@ -3082,7 +2964,7 @@ async function main() {
 }
 if (isDirectRun(import.meta.url)) {
   main().catch((e) => {
-    log6(`fatal: ${e.message}`);
+    log5(`fatal: ${e.message}`);
     process.exit(0);
   });
 }

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -55,7 +55,7 @@ var init_index_marker_store = __esm({
 // dist/src/hooks/codex/pre-tool-use.js
 import { execFileSync } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join11, dirname as dirname3 } from "node:path";
+import { join as join12, dirname as dirname3 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
@@ -254,6 +254,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -290,11 +308,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -1172,9 +1200,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1188,7 +1216,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1379,7 +1407,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1392,11 +1420,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -1447,7 +1475,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -1464,7 +1492,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1483,7 +1511,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1556,15 +1584,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1576,7 +1604,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1590,9 +1618,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1642,7 +1670,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1674,11 +1702,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join9 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join9(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2681,20 +2709,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
-import { join as join9 } from "node:path";
-import { homedir as homedir7 } from "node:os";
+import { mkdirSync as mkdirSync5, readFileSync as readFileSync7, rmSync, writeFileSync as writeFileSync5 } from "node:fs";
+import { join as join10 } from "node:path";
+import { homedir as homedir8 } from "node:os";
 var log5 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
+var DEFAULT_CACHE_ROOT = join10(homedir8(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join9(cacheRoot, sessionId);
+  return join10(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
   const { logFn = log5 } = deps;
   try {
-    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync7(join10(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2706,8 +2734,8 @@ function writeCachedIndexContent(sessionId, content, deps = {}) {
   const { logFn = log5 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync4(dir, { recursive: true });
-    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync5(dir, { recursive: true });
+    writeFileSync5(join10(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
@@ -2728,9 +2756,9 @@ function isDirectRun(metaUrl) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir8 } from "node:os";
-import { join as join10 } from "node:path";
-var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
+import { homedir as homedir9 } from "node:os";
+import { join as join11 } from "node:path";
+var MEMORY_PATH = join11(homedir9(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2848,7 +2876,7 @@ function rewritePaths(cmd) {
 // dist/src/hooks/codex/pre-tool-use.js
 var log6 = (msg) => log("codex-pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
+var SHELL_BUNDLE = existsSync5(join12(__bundleDir, "shell", "deeplake-shell.js")) ? join12(__bundleDir, "shell", "deeplake-shell.js") : join12(__bundleDir, "..", "shell", "deeplake-shell.js");
 function buildUnsupportedGuidance() {
   return "This command is not supported for ~/.deeplake/memory/ operations. Only bash builtins are available: cat, ls, grep, echo, jq, head, tail, sed, awk, wc, sort, find, etc. Do NOT use python, python3, node, curl, or other interpreters. Rewrite your command using only bash tools and retry.";
 }

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -303,13 +303,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/pre-tool-use.js
+++ b/codex/bundle/pre-tool-use.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -55,18 +55,18 @@ var init_index_marker_store = __esm({
 // dist/src/hooks/codex/pre-tool-use.js
 import { execFileSync } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join10, dirname as dirname3 } from "node:path";
+import { join as join11, dirname as dirname3 } from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve3, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve3(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -153,6 +153,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -160,7 +261,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -172,7 +273,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -181,8 +303,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+function sleep2(ms) {
+  return new Promise((resolve3) => setTimeout(resolve3, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -212,7 +334,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve3) => this.waiting.push(resolve3));
   }
   release() {
     this.active--;
@@ -283,8 +405,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -300,10 +422,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -324,7 +447,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -380,7 +503,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -470,13 +593,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -504,9 +627,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -517,9 +640,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -532,9 +655,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -557,9 +680,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -1049,9 +1172,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1065,8 +1188,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1142,7 +1265,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1151,7 +1274,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1198,7 +1321,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1207,13 +1330,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1256,7 +1379,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1266,14 +1389,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -1300,7 +1423,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1308,7 +1431,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve2(sock);
+        resolve3(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1319,16 +1442,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -1338,10 +1461,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -1353,14 +1476,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1378,7 +1501,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -1390,7 +1513,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1405,7 +1528,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve2(JSON.parse(line));
+          resolve3(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1422,7 +1545,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1433,15 +1556,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1453,7 +1576,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1467,10 +1590,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1519,7 +1642,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1551,11 +1674,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join8 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2558,20 +2681,20 @@ async function executeCompiledBashCommand(api, memoryTable, sessionsTable, cmd, 
 }
 
 // dist/src/hooks/query-cache.js
-import { mkdirSync as mkdirSync3, readFileSync as readFileSync5, rmSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { join as join8 } from "node:path";
-import { homedir as homedir6 } from "node:os";
-var log4 = (msg) => log("query-cache", msg);
-var DEFAULT_CACHE_ROOT = join8(homedir6(), ".deeplake", "query-cache");
+import { mkdirSync as mkdirSync4, readFileSync as readFileSync6, rmSync, writeFileSync as writeFileSync4 } from "node:fs";
+import { join as join9 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+var log5 = (msg) => log("query-cache", msg);
+var DEFAULT_CACHE_ROOT = join9(homedir7(), ".deeplake", "query-cache");
 var INDEX_CACHE_FILE = "index.md";
 function getSessionQueryCacheDir(sessionId, deps = {}) {
   const { cacheRoot = DEFAULT_CACHE_ROOT } = deps;
-  return join8(cacheRoot, sessionId);
+  return join9(cacheRoot, sessionId);
 }
 function readCachedIndexContent(sessionId, deps = {}) {
-  const { logFn = log4 } = deps;
+  const { logFn = log5 } = deps;
   try {
-    return readFileSync5(join8(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
+    return readFileSync6(join9(getSessionQueryCacheDir(sessionId, deps), INDEX_CACHE_FILE), "utf-8");
   } catch (e) {
     if (e?.code === "ENOENT")
       return null;
@@ -2580,34 +2703,34 @@ function readCachedIndexContent(sessionId, deps = {}) {
   }
 }
 function writeCachedIndexContent(sessionId, content, deps = {}) {
-  const { logFn = log4 } = deps;
+  const { logFn = log5 } = deps;
   try {
     const dir = getSessionQueryCacheDir(sessionId, deps);
-    mkdirSync3(dir, { recursive: true });
-    writeFileSync3(join8(dir, INDEX_CACHE_FILE), content, "utf-8");
+    mkdirSync4(dir, { recursive: true });
+    writeFileSync4(join9(dir, INDEX_CACHE_FILE), content, "utf-8");
   } catch (e) {
     logFn(`write failed for session=${sessionId}: ${e.message}`);
   }
 }
 
 // dist/src/utils/direct-run.js
-import { resolve } from "node:path";
+import { resolve as resolve2 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 function isDirectRun(metaUrl) {
   const entry = process.argv[1];
   if (!entry)
     return false;
   try {
-    return resolve(fileURLToPath2(metaUrl)) === resolve(entry);
+    return resolve2(fileURLToPath2(metaUrl)) === resolve2(entry);
   } catch {
     return false;
   }
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir8 } from "node:os";
+import { join as join10 } from "node:path";
+var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 var SAFE_BUILTINS = /* @__PURE__ */ new Set([
@@ -2723,13 +2846,13 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/codex/pre-tool-use.js
-var log5 = (msg) => log("codex-pre", msg);
+var log6 = (msg) => log("codex-pre", msg);
 var __bundleDir = dirname3(fileURLToPath3(import.meta.url));
-var SHELL_BUNDLE = existsSync5(join10(__bundleDir, "shell", "deeplake-shell.js")) ? join10(__bundleDir, "shell", "deeplake-shell.js") : join10(__bundleDir, "..", "shell", "deeplake-shell.js");
+var SHELL_BUNDLE = existsSync5(join11(__bundleDir, "shell", "deeplake-shell.js")) ? join11(__bundleDir, "shell", "deeplake-shell.js") : join11(__bundleDir, "..", "shell", "deeplake-shell.js");
 function buildUnsupportedGuidance() {
   return "This command is not supported for ~/.deeplake/memory/ operations. Only bash builtins are available: cat, ls, grep, echo, jq, head, tail, sed, awk, wc, sort, find, etc. Do NOT use python, python3, node, curl, or other interpreters. Rewrite your command using only bash tools and retry.";
 }
-function runVirtualShell(cmd, shellBundle = SHELL_BUNDLE, logFn = log5) {
+function runVirtualShell(cmd, shellBundle = SHELL_BUNDLE, logFn = log6) {
   try {
     return execFileSync("node", [shellBundle, "-c", cmd], {
       encoding: "utf-8",
@@ -2754,7 +2877,7 @@ function buildIndexContent(rows) {
   return lines.join("\n");
 }
 async function processCodexPreToolUse(input, deps = {}) {
-  const { config = loadConfig(), createApi = (table, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table), executeCompiledBashCommandFn = executeCompiledBashCommand, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, handleGrepDirectFn = handleGrepDirect, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, runVirtualShellFn = runVirtualShell, shellBundle = SHELL_BUNDLE, logFn = log5 } = deps;
+  const { config = loadConfig(), createApi = (table, activeConfig) => new DeeplakeApi(activeConfig.token, activeConfig.apiUrl, activeConfig.orgId, activeConfig.workspaceId, table), executeCompiledBashCommandFn = executeCompiledBashCommand, readVirtualPathContentsFn = readVirtualPathContents, readVirtualPathContentFn = readVirtualPathContent, listVirtualPathRowsFn = listVirtualPathRows, findVirtualPathsFn = findVirtualPaths, handleGrepDirectFn = handleGrepDirect, readCachedIndexContentFn = readCachedIndexContent, writeCachedIndexContentFn = writeCachedIndexContent, runVirtualShellFn = runVirtualShell, shellBundle = SHELL_BUNDLE, logFn = log6 } = deps;
   const cmd = input.tool_input?.command ?? "";
   logFn(`hook fired: cmd=${cmd}`);
   if (!touchesMemory(cmd))
@@ -2964,7 +3087,7 @@ async function main() {
 }
 if (isDirectRun(import.meta.url)) {
   main().catch((e) => {
-    log5(`fatal: ${e.message}`);
+    log6(`fatal: ${e.message}`);
     process.exit(0);
   });
 }

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -297,11 +297,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -292,13 +292,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/session-start-setup.js
+++ b/codex/bundle/session-start-setup.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,9 +53,9 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/codex/session-start-setup.js
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join9 } from "node:path";
 import { fileURLToPath } from "node:url";
-import { homedir as homedir4 } from "node:os";
+import { homedir as homedir5 } from "node:os";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -160,6 +160,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -167,7 +268,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -179,7 +280,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -188,8 +310,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -219,7 +341,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -290,8 +412,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -307,10 +429,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -331,7 +454,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -387,7 +510,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -477,13 +600,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -524,9 +647,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -539,9 +662,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -564,9 +687,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -576,13 +699,13 @@ var DeeplakeApi = class {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -592,15 +715,15 @@ function readStdin() {
 }
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join5 } from "node:path";
+import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join6 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join5(hooksDir, filename);
+  const path = join6(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync3(hooksDir, { recursive: true });
+        mkdirSync4(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -612,8 +735,8 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 // dist/src/hooks/shared/autoupdate.js
 import { spawn } from "node:child_process";
 import { existsSync as existsSync3 } from "node:fs";
-import { join as join6 } from "node:path";
-var log3 = (msg) => log("autoupdate", msg);
+import { join as join7 } from "node:path";
+var log4 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn(cmd, args, {
     detached: true,
@@ -628,7 +751,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join6(dir, "hivemind");
+    const candidate = join7(dir, "hivemind");
     if (existsSync3(candidate))
       return candidate;
   }
@@ -636,45 +759,45 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log3(`agent=${opts.agent} entered`);
+  log4(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log3(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log3(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log3(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log3(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync4 } from "node:fs";
-import { dirname, join as join7 } from "node:path";
+import { readFileSync as readFileSync5 } from "node:fs";
+import { dirname, join as join8 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync4(pluginJson, "utf-8"));
+    const pluginJson = join8(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync4(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync5(join8(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -689,9 +812,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join7(dir, "package.json");
+    const candidate = join8(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync4(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -705,8 +828,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/session-start-setup.js
-var log4 = (msg) => log("codex-session-setup", msg);
-var { log: wikiLog } = makeWikiLogger(join8(homedir4(), ".codex", "hooks"));
+var log5 = (msg) => log("codex-session-setup", msg);
+var { log: wikiLog } = makeWikiLogger(join9(homedir5(), ".codex", "hooks"));
 var __bundleDir = dirname2(fileURLToPath(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
 async function createPlaceholder(api, table, sessionId, cwd, userName, orgName, workspaceId) {
@@ -737,7 +860,7 @@ async function main() {
   const input = await readStdin();
   const creds = loadCredentials();
   if (!creds?.token) {
-    log4("no credentials");
+    log5("no credentials");
     return;
   }
   if (!creds.userName) {
@@ -745,7 +868,7 @@ async function main() {
       const { userInfo: userInfo2 } = await import("node:os");
       creds.userName = userInfo2().username ?? "unknown";
       saveCredentials(creds);
-      log4(`backfilled userName: ${creds.userName}`);
+      log5(`backfilled userName: ${creds.userName}`);
     } catch {
     }
   }
@@ -761,15 +884,15 @@ async function main() {
         if (captureEnabled) {
           await createPlaceholder(api, config.tableName, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);
         }
-        log4("setup complete");
+        log5("setup complete");
       }
     } catch (e) {
-      log4(`setup failed: ${e.message}`);
+      log5(`setup failed: ${e.message}`);
       wikiLog(`SessionSetup: failed for ${input.session_id}: ${e.message}`);
     }
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/session-start.js
+++ b/codex/bundle/session-start.js
@@ -471,13 +471,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/session-start.js
+++ b/codex/bundle/session-start.js
@@ -476,11 +476,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/codex/bundle/session-start.js
+++ b/codex/bundle/session-start.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync5, writeFileSync as writeFileSync3 } from "node:fs";
-import { join as join7 } from "node:path";
+import { existsSync as existsSync4, mkdirSync as mkdirSync5, readFileSync as readFileSync6, writeFileSync as writeFileSync4 } from "node:fs";
+import { join as join8 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join8(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join7(getIndexMarkerDir(), `${markerKey}.json`);
+  return join8(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync4(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync5(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync6(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync4(getIndexMarkerDir(), { recursive: true });
-  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync5(getIndexMarkerDir(), { recursive: true });
+  writeFileSync4(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -55,7 +55,7 @@ var init_index_marker_store = __esm({
 // dist/src/hooks/codex/session-start.js
 import { spawn as spawn2 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join13 } from "node:path";
+import { dirname as dirname6, join as join14 } from "node:path";
 
 // dist/src/commands/auth.js
 import { execSync } from "node:child_process";
@@ -89,13 +89,13 @@ function loadCredentials() {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -339,6 +339,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, renameSync, mkdirSync as mkdirSync4, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync3, statSync as statSync2 } from "node:fs";
+import { join as join7, resolve } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS2 = 5e3;
+function queuePath() {
+  return join7(homedir6(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync5(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir6());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync4(join7(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync3(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync4(join7(homedir6(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync2(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync2(path).mtimeMs;
+        if (age > LOCK_STALE_MS2) {
+          unlinkSync3(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync2(fd);
+    } catch {
+    }
+    try {
+      unlinkSync3(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -346,7 +447,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -358,7 +459,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -367,8 +489,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -398,7 +520,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -469,8 +591,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -486,10 +608,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -510,7 +633,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -566,7 +689,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -656,13 +779,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -690,9 +813,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -703,9 +826,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -718,9 +841,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -743,9 +866,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -754,14 +877,14 @@ var DeeplakeApi = class {
 };
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync6, mkdirSync as mkdirSync7, renameSync as renameSync3, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync4 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { dirname as dirname5, join as join12 } from "node:path";
+import { existsSync as existsSync9, readFileSync as readFileSync9, writeFileSync as writeFileSync7, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync5 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { dirname as dirname5, join as join13 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync5, readFileSync as readFileSync6, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join8 } from "node:path";
+import { existsSync as existsSync5, mkdirSync as mkdirSync6, readFileSync as readFileSync7, readdirSync as readdirSync2, statSync as statSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -827,29 +950,29 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync7, lstatSync, mkdirSync as mkdirSync6, readFileSync as readFileSync7, renameSync as renameSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { dirname as dirname4, join as join10 } from "node:path";
+import { existsSync as existsSync7, lstatSync, mkdirSync as mkdirSync7, readFileSync as readFileSync8, renameSync as renameSync3, unlinkSync as unlinkSync4, writeFileSync as writeFileSync6 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { dirname as dirname4, join as join11 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync6, renameSync } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
+import { existsSync as existsSync6, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join9(homedir7(), ".deeplake", "state");
-  const legacy = join9(root, "skilify");
-  const current = join9(root, "skillify");
+  const root = join10(homedir8(), ".deeplake", "state");
+  const legacy = join10(root, "skilify");
+  const current = join10(root, "skillify");
   if (!existsSync6(legacy))
     return;
   if (existsSync6(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -866,7 +989,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join10(homedir8(), ".deeplake", "state", "skillify", "pulled.json");
+  return join11(homedir9(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -874,7 +997,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync7(path, "utf-8");
+    raw = readFileSync8(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -921,10 +1044,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync6(dirname4(path), { recursive: true });
+  mkdirSync7(dirname4(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync5(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  writeFileSync6(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -949,7 +1072,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync3(path);
+      unlinkSync4(path);
     } catch {
     }
   }
@@ -959,7 +1082,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync7(join10(e.installRoot, e.dirName))) {
+    if (existsSync7(join11(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -973,25 +1096,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync8 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join11 } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { join as join12 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync8(join11(home, ".codex"));
-  const piInstalled = existsSync8(join11(home, ".pi", "agent"));
-  const hermesInstalled = existsSync8(join11(home, ".hermes"));
+  const codexInstalled = existsSync8(join12(home, ".codex"));
+  const piInstalled = existsSync8(join12(home, ".pi", "agent"));
+  const hermesInstalled = existsSync8(join12(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join11(home, ".agents", "skills"));
+    out.push(join12(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join11(home, ".hermes", "skills"));
+    out.push(join12(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join11(home, ".pi", "agent", "skills"));
+    out.push(join12(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir9()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir10()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -1035,15 +1158,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join12(homedir10(), ".claude", "skills");
+    return join13(homedir11(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join12(cwd, ".claude", "skills");
+  return join13(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join12(root, dirName);
+    const link = join13(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -1065,13 +1188,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync4(link);
+        unlinkSync5(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync7(dirname5(link), { recursive: true });
+      mkdirSync8(dirname5(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -1086,7 +1209,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join12(entry.installRoot, entry.dirName);
+    const canonical = join13(entry.installRoot, entry.dirName);
     if (!existsSync9(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -1200,7 +1323,7 @@ function readLocalVersion(path) {
   if (!existsSync9(path))
     return null;
   try {
-    const text = readFileSync8(path, "utf-8");
+    const text = readFileSync9(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1295,8 +1418,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join12(root, dirName);
-    const skillFile = join12(skillDir, "SKILL.md");
+    const skillDir = join13(root, dirName);
+    const skillFile = join13(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1307,14 +1430,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync7(skillDir, { recursive: true });
+      mkdirSync8(skillDir, { recursive: true });
       if (existsSync9(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync6(skillFile, renderSkillFile(row));
+      writeFileSync7(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -1356,7 +1479,7 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/auto-pull.js
-var log3 = (msg) => log("skillify-autopull", msg);
+var log4 = (msg) => log("skillify-autopull", msg);
 var DEFAULT_TIMEOUT_MS = 5e3;
 function withTimeout(p, ms) {
   let timer = null;
@@ -1372,13 +1495,13 @@ function withTimeout(p, ms) {
 }
 async function autoPullSkills(deps = {}) {
   if (process.env.HIVEMIND_AUTOPULL_DISABLED === "1") {
-    log3("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
+    log4("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
     return { pulled: 0, skipped: true, reason: "disabled" };
   }
   const loadFn = deps.loadConfigFn ?? loadConfig;
   const config = loadFn();
   if (!config) {
-    log3("skipped: not logged in");
+    log4("skipped: not logged in");
     return { pulled: 0, skipped: true, reason: "not-logged-in" };
   }
   let query;
@@ -1400,16 +1523,16 @@ async function autoPullSkills(deps = {}) {
       dryRun: false,
       force: false
     }), timeoutMs);
-    log3(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
+    log4(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
     return { pulled: summary.wrote, skipped: false };
   } catch (e) {
-    log3(`pull failed (swallowed): ${e?.message ?? e}`);
+    log4(`pull failed (swallowed): ${e?.message ?? e}`);
     return { pulled: 0, skipped: true, reason: "error" };
   }
 }
 
 // dist/src/hooks/codex/session-start.js
-var log4 = (msg) => log("codex-session-start", msg);
+var log5 = (msg) => log("codex-session-start", msg);
 var __bundleDir = dirname6(fileURLToPath2(import.meta.url));
 async function main() {
   if (process.env.HIVEMIND_WIKI_WORKER === "1")
@@ -1417,14 +1540,14 @@ async function main() {
   const input = await readStdin();
   const creds = loadCredentials();
   if (!creds?.token) {
-    log4("no credentials found \u2014 run auth login to authenticate");
+    log5("no credentials found \u2014 run auth login to authenticate");
     const auto = maybeAutoMineLocal();
-    log4(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
+    log5(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
-    log4(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    log5(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
   }
   if (creds?.token) {
-    const setupScript = join13(__bundleDir, "session-start-setup.js");
+    const setupScript = join14(__bundleDir, "session-start-setup.js");
     const child = spawn2("node", [setupScript], {
       detached: true,
       stdio: ["pipe", "ignore", "ignore"],
@@ -1433,10 +1556,10 @@ async function main() {
     child.stdin?.write(JSON.stringify(input));
     child.stdin?.end();
     child.unref();
-    log4("spawned async setup process");
+    log5("spawned async setup process");
   }
   const pullResult = await autoPullSkills();
-  log4(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
+  log5(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
   let versionNotice = "";
   const current = getInstalledVersion(__bundleDir, ".codex-plugin");
   if (current) {
@@ -1458,6 +1581,6 @@ Hivemind v${current}`;
   console.log(JSON.stringify(output));
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join12(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join12(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join12(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -66870,7 +66870,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms3) {
-  return new Promise((resolve6) => setTimeout(resolve6, ms3));
+  return new Promise((resolve5) => setTimeout(resolve5, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +66900,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve6) => this.waiting.push(resolve6));
+    await new Promise((resolve5) => this.waiting.push(resolve5));
   }
   release() {
     this.active--;
@@ -67259,7 +67259,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join10 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67689,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join7 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67704,105 +67704,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
-import { join as join7, resolve as resolve4 } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join7(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m26) => log("embed-client", m26);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path2, home) {
-  const r10 = resolve4(path2);
-  const h18 = resolve4(home);
-  return r10.startsWith(h18 + "/") || r10 === h18;
-}
-function writeQueue(q17) {
-  const path2 = queuePath();
-  const home = resolve4(homedir3());
-  if (!_isQueuePathInsideHome(path2, home)) {
-    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v27 = await this.embedAttempt(text, kind);
+    if (v27 !== "recycled")
+      return v27;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join7(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path2}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
-  renameSync(tmp, path2);
-}
-async function withQueueLock(fn4) {
-  const path2 = lockPath();
-  mkdirSync2(join7(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path2, "wx", 384);
-      break;
-    } catch (e6) {
-      const code = e6.code;
-      if (code !== "EEXIST")
-        throw e6;
-      try {
-        const age = Date.now() - statSync2(path2).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path2);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e6) {
+      const err = e6 instanceof Error ? e6.message : String(e6);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn4();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync4(this.socketPath))
+        return;
+      await new Promise((r10) => setTimeout(r10, 50));
+    }
   }
-  try {
-    return fn4();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e6) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      return false;
     }
-    try {
-      unlinkSync(path2);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a15, b26) {
-  if (a15.id !== b26.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
-}
-async function enqueueNotification(n24) {
-  await withQueueLock(() => {
-    const q17 = readQueue();
-    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s10 = await this.connectOnce();
+      s10.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s10 = await this.waitForSocket();
+        s10.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve5, reject) => {
+      const sock = connect(this.socketPath);
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to3);
+        resolve5(sock);
+      });
+      sock.once("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e6) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q17.queue.push(n24);
-    writeQueue(q17);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync4(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve5, reject) => {
+      let buf = "";
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl3 = buf.indexOf("\n");
+        if (nl3 === -1)
+          return;
+        const line = buf.slice(0, nl3);
+        clearTimeout(to3);
+        try {
+          resolve5(JSON.parse(line));
+        } catch (e6) {
+          reject(e6);
+        }
+      });
+      sock.on("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+      sock.on("end", () => {
+        clearTimeout(to3);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms3) {
+  return new Promise((r10) => setTimeout(r10, ms3));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v27 of vec) {
+    if (!Number.isFinite(v27))
+      return "NULL";
+    parts.push(String(v27));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -67812,7 +68091,7 @@ import { join as join9 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname as dirname4, join as join8 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
@@ -67822,7 +68101,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path2 = _configPath();
-  if (!existsSync4(path2)) {
+  if (!existsSync5(path2)) {
     _cache = {};
     return _cache;
   }
@@ -67840,11 +68119,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path2 = _configPath();
   const dir = dirname4(path2);
-  if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync5(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path2);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -67921,403 +68200,6 @@ function embeddingsStatus() {
 }
 function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
-}
-
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join10(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m26) => log("embed-client", m26);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync5(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v27 = await this.embedAttempt(text, kind);
-    if (v27 !== "recycled")
-      return v27;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e6) {
-      const err = e6 instanceof Error ? e6.message : String(e6);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync5(this.socketPath))
-        return;
-      await new Promise((r10) => setTimeout(r10, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e6) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync5(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e6) => {
-      log4(`enqueue embed-deps-missing failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync5(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s10 = await this.connectOnce();
-      s10.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s10 = await this.waitForSocket();
-        s10.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve6, reject) => {
-      const sock = connect(this.socketPath);
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to3);
-        resolve6(sock);
-      });
-      sock.once("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e6) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync5(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync5(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve6, reject) => {
-      let buf = "";
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl3 = buf.indexOf("\n");
-        if (nl3 === -1)
-          return;
-        const line = buf.slice(0, nl3);
-        clearTimeout(to3);
-        try {
-          resolve6(JSON.parse(line));
-        } catch (e6) {
-          reject(e6);
-        }
-      });
-      sock.on("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-      sock.on("end", () => {
-        clearTimeout(to3);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms3) {
-  return new Promise((r10) => setTimeout(r10, ms3));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v27 of vec) {
-    if (!Number.isFinite(v27))
-      return "NULL";
-    parts.push(String(v27));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/hooks/virtual-table-query.js
@@ -68412,7 +68294,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68978,7 +68860,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve5 } from "path";
+import { normalize, resolve as resolve4 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69916,7 +69798,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync5 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69938,12 +69820,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve5,
+  resolve: resolve4,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync5(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69963,11 +69845,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join11 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join14(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join14(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join14(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join7 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join8(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join7(getIndexMarkerDir(), `${markerKey}.json`);
+  return join8(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66942,6 +66942,24 @@ async function enqueueNotification(n24) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join7 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join7(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join7(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66978,11 +66996,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c15 = loadCredentials();
+    if (c15?.orgName && c15?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c15.orgName)}/workspace/${encodeURIComponent(c15.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -67382,7 +67410,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join12 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67812,9 +67840,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join8 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join9 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67828,7 +67856,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join9(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -68019,7 +68047,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -68032,11 +68060,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -68087,7 +68115,7 @@ var EmbedClient = class {
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -68104,7 +68132,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -68123,7 +68151,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68209,15 +68237,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname4, join as join9 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname4, join as join10 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join10(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68229,7 +68257,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path2, "utf-8");
+    const raw = readFileSync6(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68243,9 +68271,9 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path2);
   _cache = merged;
   return merged;
@@ -68295,7 +68323,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join11(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68417,7 +68445,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -69921,7 +69949,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync7 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69948,7 +69976,7 @@ var parser = new YargsParser({
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync7(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69968,11 +69996,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join13 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join13(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -66991,13 +66991,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });

--- a/codex/bundle/shell/deeplake-shell.js
+++ b/codex/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join12(output, replacement);
+        return join13(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join12(output, rule.append(self2.options));
+          output = join13(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join12(output, replacement) {
+    function join13(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join6 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join6(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join6(getIndexMarkerDir(), `${markerKey}.json`);
+  return join7(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66841,6 +66841,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
+import { join as join6, resolve as resolve4 } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join6(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path2, home) {
+  const r10 = resolve4(path2);
+  const h18 = resolve4(home);
+  return r10.startsWith(h18 + "/") || r10 === h18;
+}
+function writeQueue(q17) {
+  const path2 = queuePath();
+  const home = resolve4(homedir3());
+  if (!_isQueuePathInsideHome(path2, home)) {
+    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  }
+  mkdirSync(join6(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path2}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
+  renameSync(tmp, path2);
+}
+async function withQueueLock(fn4) {
+  const path2 = lockPath();
+  mkdirSync(join6(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path2, "wx", 384);
+      break;
+    } catch (e6) {
+      const code = e6.code;
+      if (code !== "EEXIST")
+        throw e6;
+      try {
+        const age = Date.now() - statSync2(path2).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path2);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn4();
+  }
+  try {
+    return fn4();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path2);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a15, b26) {
+  if (a15.id !== b26.id)
+    return false;
+  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
+}
+async function enqueueNotification(n24) {
+  await withQueueLock(() => {
+    const q17 = readQueue();
+    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+      return;
+    }
+    q17.queue.push(n24);
+    writeQueue(q17);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66848,7 +66949,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -66860,7 +66961,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e6) => {
+    log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -66869,8 +66991,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms3) {
-  return new Promise((resolve5) => setTimeout(resolve5, ms3));
+function sleep2(ms3) {
+  return new Promise((resolve6) => setTimeout(resolve6, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +67022,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve5) => this.waiting.push(resolve5));
+    await new Promise((resolve6) => this.waiting.push(resolve6));
   }
   release() {
     this.active--;
@@ -66971,8 +67093,8 @@ var DeeplakeApi = class {
         lastError = e6 instanceof Error ? e6 : new Error(String(e6));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -66988,10 +67110,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -67012,7 +67135,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i11, i11 + CONCURRENCY);
       await Promise.allSettled(chunk.map((r10) => this.upsertRowSql(r10)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts3 = (/* @__PURE__ */ new Date()).toISOString();
@@ -67068,7 +67191,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e6.message}`);
+      log3(`index "${indexName}" skipped: ${e6.message}`);
     }
   }
   /**
@@ -67158,13 +67281,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -67192,9 +67315,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -67205,9 +67328,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -67220,9 +67343,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67245,9 +67368,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67259,7 +67382,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join10 } from "node:path";
+import { dirname as dirname5, join as join11 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67812,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join8 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67705,8 +67828,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m26) => log("embed-client", m26);
+var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -67782,7 +67905,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -67791,7 +67914,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e6) {
       const err = e6 instanceof Error ? e6.message : String(e6);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -67838,7 +67961,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e6) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
       return false;
     }
     const hello = resp;
@@ -67847,13 +67970,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -67896,7 +68019,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -67906,14 +68029,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -67940,7 +68063,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       const sock = connect(this.socketPath);
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -67948,7 +68071,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to3);
-        resolve5(sock);
+        resolve6(sock);
       });
       sock.once("error", (e6) => {
         clearTimeout(to3);
@@ -67959,16 +68082,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -67978,10 +68101,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -67993,14 +68116,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68018,7 +68141,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync4(this.socketPath))
         continue;
@@ -68030,7 +68153,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       let buf = "";
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -68045,7 +68168,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl3);
         clearTimeout(to3);
         try {
-          resolve5(JSON.parse(line));
+          resolve6(JSON.parse(line));
         } catch (e6) {
           reject(e6);
         }
@@ -68062,7 +68185,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms3) {
+function sleep3(ms3) {
   return new Promise((r10) => setTimeout(r10, ms3));
 }
 function isTransformersMissingError(err) {
@@ -68086,15 +68209,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join9 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join10 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname as dirname4, join as join8 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname as dirname4, join as join9 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68106,7 +68229,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path2, "utf-8");
+    const raw = readFileSync5(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68120,10 +68243,10 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path2);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -68172,7 +68295,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join9(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68294,7 +68417,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68860,7 +68983,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve4 } from "path";
+import { normalize, resolve as resolve5 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69798,7 +69921,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync5 } from "fs";
+import { readFileSync as readFileSync6 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69820,12 +69943,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve4,
+  resolve: resolve5,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync5(path2, "utf8"));
+      return JSON.parse(readFileSync6(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69845,11 +69968,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join11 } from "node:path";
+import { dirname as dirname6, join as join12 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -53,19 +53,19 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/codex/stop.js
-import { readFileSync as readFileSync10, existsSync as existsSync10 } from "node:fs";
+import { readFileSync as readFileSync9, existsSync as existsSync10 } from "node:fs";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname5, join as join17 } from "node:path";
+import { dirname as dirname5, join as join16 } from "node:path";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -181,7 +181,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -211,7 +211,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -1175,9 +1175,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync9, readFileSync as readFileSync9 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
+import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync3, unlinkSync as unlinkSync3, existsSync as existsSync8, readFileSync as readFileSync7 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1190,105 +1190,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync7, renameSync as renameSync4, mkdirSync as mkdirSync8, openSync as openSync3, closeSync as closeSync3, unlinkSync as unlinkSync3, statSync } from "node:fs";
-import { join as join13, resolve } from "node:path";
-import { homedir as homedir10 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join13(homedir10(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join13(homedir10(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath3() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync7(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync8(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir10());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync8(join13(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync4(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath3();
-  mkdirSync8(join13(homedir10(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync3(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync3(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync8(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync3(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync3(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync8(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync7(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync8(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync3(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync3(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync3(this.pidPath, "wx", 384);
+      writeSync3(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync3(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync3(this.pidPath, "wx", 384);
+          writeSync3(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync8(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync3(fd);
+        unlinkSync3(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn3(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync3(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync7(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync8(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v of vec) {
+    if (!Number.isFinite(v))
+      return "NULL";
+    parts.push(String(v));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -1298,7 +1577,7 @@ import { join as join15 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync8, mkdirSync as mkdirSync9, readFileSync as readFileSync8, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
+import { existsSync as existsSync9, mkdirSync as mkdirSync8, readFileSync as readFileSync8, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
 import { homedir as homedir11 } from "node:os";
 import { dirname as dirname4, join as join14 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join14(homedir11(), ".deeplake", "config.json");
@@ -1308,7 +1587,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync8(path)) {
+  if (!existsSync9(path)) {
     _cache = {};
     return _cache;
   }
@@ -1326,11 +1605,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname4(path);
-  if (!existsSync8(dir))
-    mkdirSync9(dir, { recursive: true });
+  if (!existsSync9(dir))
+    mkdirSync8(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync5(tmp, path);
+  writeFileSync7(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync4(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1409,407 +1688,10 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join16(homedir13(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync9(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync9(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync9(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync9(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync9(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync4(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync4(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync4(this.pidPath, "wx", 384);
-      writeSync3(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync4(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync4(this.pidPath, "wx", 384);
-          writeSync3(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync9(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync4(fd);
-        unlinkSync4(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn3(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync4(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync9(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync9(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v of vec) {
-    if (!Number.isFinite(v))
-      return "NULL";
-    parts.push(String(v));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
-}
-
 // dist/src/hooks/codex/stop.js
-var log5 = (msg) => log("codex-stop", msg);
+var log4 = (msg) => log("codex-stop", msg);
 function resolveEmbedDaemonPath() {
-  return join17(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join16(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
@@ -1823,7 +1705,7 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log5("no config");
+    log4("no config");
     return;
   }
   if (CAPTURE) {
@@ -1836,7 +1718,7 @@ async function main() {
         try {
           const transcriptPath = input.transcript_path;
           if (existsSync10(transcriptPath)) {
-            const transcript = readFileSync10(transcriptPath, "utf-8");
+            const transcript = readFileSync9(transcriptPath, "utf-8");
             const lines = transcript.trim().split("\n").reverse();
             for (const line2 of lines) {
               try {
@@ -1853,10 +1735,10 @@ async function main() {
               }
             }
             if (lastAssistantMessage)
-              log5(`extracted assistant message from transcript (${lastAssistantMessage.length} chars)`);
+              log4(`extracted assistant message from transcript (${lastAssistantMessage.length} chars)`);
           }
         } catch (e) {
-          log5(`transcript read failed: ${e.message}`);
+          log4(`transcript read failed: ${e.message}`);
         }
       }
       const entry = {
@@ -1879,9 +1761,9 @@ async function main() {
       const embeddingSql = embeddingSqlLiteral(embedding);
       const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, message, message_embedding, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ${embeddingSql}, '${sqlStr(config.userName)}', ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', 'Stop', 'codex', '${sqlStr(PLUGIN_VERSION)}', '${ts}', '${ts}')`;
       await api.query(insertSql);
-      log5("stop event captured");
+      log4("stop event captured");
     } catch (e) {
-      log5(`capture failed: ${e.message}`);
+      log4(`capture failed: ${e.message}`);
     }
   }
   if (!CAPTURE)
@@ -1900,11 +1782,11 @@ async function main() {
       reason: "Stop"
     });
   } catch (e) {
-    log5(`spawn failed: ${e.message}`);
+    log4(`spawn failed: ${e.message}`);
     try {
       releaseLock(sessionId);
     } catch (releaseErr) {
-      log5(`releaseLock after spawn failure also failed: ${releaseErr.message}`);
+      log4(`releaseLock after spawn failure also failed: ${releaseErr.message}`);
     }
     throw e;
   }
@@ -1917,6 +1799,6 @@ async function main() {
   });
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,9 +53,9 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/codex/stop.js
-import { readFileSync as readFileSync10, existsSync as existsSync10 } from "node:fs";
+import { readFileSync as readFileSync11, existsSync as existsSync10 } from "node:fs";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname5, join as join17 } from "node:path";
+import { dirname as dirname5, join as join18 } from "node:path";
 
 // dist/src/utils/stdin.js
 function readStdin() {
@@ -253,6 +253,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -289,11 +307,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -692,20 +720,20 @@ var DeeplakeApi = class {
 // dist/src/hooks/codex/spawn-wiki-worker.js
 import { spawn, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
-import { writeFileSync as writeFileSync3, mkdirSync as mkdirSync4 } from "node:fs";
-import { homedir as homedir4, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname2, join as join8 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5 } from "node:fs";
+import { homedir as homedir5, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join5 } from "node:path";
+import { mkdirSync as mkdirSync4, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join6 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join5(hooksDir, filename);
+  const path = join6(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync3(hooksDir, { recursive: true });
+        mkdirSync4(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -715,18 +743,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync4 } from "node:fs";
-import { dirname, join as join6 } from "node:path";
+import { readFileSync as readFileSync5 } from "node:fs";
+import { dirname, join as join7 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join6(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync4(pluginJson, "utf-8"));
+    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync4(join6(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync5(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -741,9 +769,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join6(dir, "package.json");
+    const candidate = join7(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync4(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -757,8 +785,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/spawn-wiki-worker.js
-var HOME = homedir4();
-var wikiLogger = makeWikiLogger(join7(HOME, ".codex", "hooks"));
+var HOME = homedir5();
+var wikiLogger = makeWikiLogger(join8(HOME, ".codex", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -820,11 +848,11 @@ function findCodexBin() {
 function spawnCodexWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join7(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync4(tmpDir, { recursive: true });
+  const tmpDir = join8(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync5(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".codex-plugin") ?? "";
-  const configFile = join7(tmpDir, "config.json");
-  writeFileSync3(configFile, JSON.stringify({
+  const configFile = join8(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -838,11 +866,11 @@ function spawnCodexWikiWorker(opts) {
     tmpDir,
     codexBin: findCodexBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join7(HOME, ".codex", "hooks"),
+    hooksDir: join8(HOME, ".codex", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join7(bundleDir, "wiki-worker.js");
+  const workerPath = join8(bundleDir, "wiki-worker.js");
   spawn("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -856,15 +884,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn2 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname3, join as join9 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir6, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname3, join as join10 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync6, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir7, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync3 } from "node:fs";
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join8 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join9 } from "node:path";
 var requireForCp = createRequire(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -876,7 +904,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir5();
+  const home = homedir6();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -885,54 +913,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join8(home, ".claude", "local", "claude"),
+        join9(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join8(home, ".npm-global", "bin", "claude"),
-        join8(home, ".local", "bin", "claude"),
+        join9(home, ".npm-global", "bin", "claude"),
+        join9(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join8(home, ".claude", "local", "claude");
+      ]) ?? join9(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join8(home, ".npm-global", "bin", "codex"),
-        join8(home, ".local", "bin", "codex"),
+        join9(home, ".npm-global", "bin", "codex"),
+        join9(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join8(home, ".npm-global", "bin", "cursor-agent"),
-        join8(home, ".local", "bin", "cursor-agent"),
+        join9(home, ".npm-global", "bin", "cursor-agent"),
+        join9(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join8(home, ".local", "bin", "hermes"),
+        join9(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join8(home, ".npm-global", "bin", "hermes"),
+        join9(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join8(home, ".local", "bin", "hermes");
+      ]) ?? join9(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join8(home, ".local", "bin", "pi"),
+        join9(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join8(home, ".npm-global", "bin", "pi"),
+        join9(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join8(home, ".local", "bin", "pi");
+      ]) ?? join9(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir6();
-var SKILLIFY_LOG = join9(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir7();
+var SKILLIFY_LOG = join10(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync5(dirname3(SKILLIFY_LOG), { recursive: true });
+    mkdirSync6(dirname3(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -940,11 +968,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join9(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync5(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join10(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join9(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join10(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -974,7 +1002,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join9(bundleDir, "skillify-worker.js");
+  const workerPath = join10(bundleDir, "skillify-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -983,25 +1011,25 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync5, writeSync, mkdirSync as mkdirSync6, renameSync as renameSync3, existsSync as existsSync5, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync6, writeSync, mkdirSync as mkdirSync7, renameSync as renameSync3, existsSync as existsSync5, unlinkSync as unlinkSync3, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join11, basename } from "node:path";
+import { join as join12, basename } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
 import { existsSync as existsSync4, renameSync as renameSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join10 } from "node:path";
+import { homedir as homedir8 } from "node:os";
+import { join as join11 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join10(homedir7(), ".deeplake", "state");
-  const legacy = join10(root, "skilify");
-  const current = join10(root, "skillify");
+  const root = join11(homedir8(), ".deeplake", "state");
+  const legacy = join11(root, "skilify");
+  const current = join11(root, "skillify");
   if (!existsSync4(legacy))
     return;
   if (existsSync4(current))
@@ -1021,17 +1049,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog2 = (msg) => log("skillify-state", msg);
-var STATE_DIR = join11(homedir8(), ".deeplake", "state", "skillify");
+var STATE_DIR = join12(homedir9(), ".deeplake", "state", "skillify");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath(projectKey) {
-  return join11(STATE_DIR, `${projectKey}.json`);
+  return join12(STATE_DIR, `${projectKey}.json`);
 }
 function lockPath2(projectKey) {
-  return join11(STATE_DIR, `${projectKey}.lock`);
+  return join12(STATE_DIR, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1080,22 +1108,22 @@ function readState(projectKey) {
   if (!existsSync5(p))
     return null;
   try {
-    return JSON.parse(readFileSync5(p, "utf-8"));
+    return JSON.parse(readFileSync6(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR, { recursive: true });
+  mkdirSync7(STATE_DIR, { recursive: true });
   const p = statePath(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync5(tmp, JSON.stringify(state, null, 2));
+  writeFileSync6(tmp, JSON.stringify(state, null, 2));
   renameSync3(tmp, p);
 }
 function withRmwLock(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR, { recursive: true });
+  mkdirSync7(STATE_DIR, { recursive: true });
   const rmw = lockPath2(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1108,7 +1136,7 @@ function withRmwLock(projectKey, fn) {
       if (Date.now() > deadline) {
         dlog2(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmw);
+          unlinkSync3(rmw);
         } catch (unlinkErr) {
           dlog2(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1122,7 +1150,7 @@ function withRmwLock(projectKey, fn) {
   } finally {
     closeSync2(fd);
     try {
-      unlinkSync2(rmw);
+      unlinkSync3(rmw);
     } catch (unlinkErr) {
       dlog2(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1138,18 +1166,18 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync6(STATE_DIR, { recursive: true });
+  mkdirSync7(STATE_DIR, { recursive: true });
   const p = lockPath2(projectKey);
   if (existsSync5(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog2(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog2(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
@@ -1170,24 +1198,24 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
 function releaseWorkerLock(projectKey) {
   const p = lockPath2(projectKey);
   try {
-    unlinkSync2(p);
+    unlinkSync3(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync6, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync6 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
-var STATE_DIR2 = join12(homedir9(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join12(STATE_DIR2, "config.json");
+import { existsSync as existsSync6, mkdirSync as mkdirSync8, readFileSync as readFileSync7, writeFileSync as writeFileSync7 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
+var STATE_DIR2 = join13(homedir10(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join13(STATE_DIR2, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync6(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync6(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync7(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1238,28 +1266,28 @@ function forceSessionEndTrigger(opts) {
 }
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync7, writeSync as writeSync2, mkdirSync as mkdirSync8, renameSync as renameSync4, existsSync as existsSync7, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { readFileSync as readFileSync8, writeFileSync as writeFileSync8, writeSync as writeSync2, mkdirSync as mkdirSync9, renameSync as renameSync4, existsSync as existsSync7, unlinkSync as unlinkSync4, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 var dlog3 = (msg) => log("summary-state", msg);
-var STATE_DIR3 = join13(homedir10(), ".claude", "hooks", "summary-state");
+var STATE_DIR3 = join14(homedir11(), ".claude", "hooks", "summary-state");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 function lockPath3(sessionId) {
-  return join13(STATE_DIR3, `${sessionId}.lock`);
+  return join14(STATE_DIR3, `${sessionId}.lock`);
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync8(STATE_DIR3, { recursive: true });
+  mkdirSync9(STATE_DIR3, { recursive: true });
   const p = lockPath3(sessionId);
   if (existsSync7(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
@@ -1281,7 +1309,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath3(sessionId));
+    unlinkSync4(lockPath3(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog3(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1298,9 +1326,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync8, readFileSync as readFileSync8 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { join as join14 } from "node:path";
+import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync5, existsSync as existsSync8, readFileSync as readFileSync9 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { join as join15 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1314,7 +1342,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join14(homedir11(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join15(homedir12(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1505,7 +1533,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync8(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync9(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1518,11 +1546,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync4(this.socketPath);
+      unlinkSync5(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync4(this.pidPath);
+      unlinkSync5(this.pidPath);
     } catch {
     }
   }
@@ -1573,7 +1601,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync4(this.pidPath);
+          unlinkSync5(this.pidPath);
         } catch {
         }
         try {
@@ -1590,7 +1618,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync4(fd);
-        unlinkSync4(this.pidPath);
+        unlinkSync5(this.pidPath);
       } catch {
       }
       return;
@@ -1609,7 +1637,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync8(this.pidPath, "utf-8").trim();
+      const raw = readFileSync9(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1695,15 +1723,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
+import { homedir as homedir14 } from "node:os";
+import { join as join17 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync9, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { dirname as dirname4, join as join15 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join15(homedir12(), ".deeplake", "config.json");
+import { existsSync as existsSync9, mkdirSync as mkdirSync10, readFileSync as readFileSync10, renameSync as renameSync5, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { dirname as dirname4, join as join16 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join16(homedir13(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1715,7 +1743,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync9(path, "utf-8");
+    const raw = readFileSync10(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1729,9 +1757,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname4(path);
   if (!existsSync9(dir))
-    mkdirSync9(dir, { recursive: true });
+    mkdirSync10(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync9(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync5(tmp, path);
   _cache = merged;
   return merged;
@@ -1781,7 +1809,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join16(homedir13(), ".hivemind", "embed-deps");
+  const sharedDir = join17(homedir14(), ".hivemind", "embed-deps");
   try {
     createRequire2(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1814,7 +1842,7 @@ function embeddingsDisabled() {
 // dist/src/hooks/codex/stop.js
 var log5 = (msg) => log("codex-stop", msg);
 function resolveEmbedDaemonPath() {
-  return join17(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join18(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
@@ -1841,7 +1869,7 @@ async function main() {
         try {
           const transcriptPath = input.transcript_path;
           if (existsSync10(transcriptPath)) {
-            const transcript = readFileSync10(transcriptPath, "utf-8");
+            const transcript = readFileSync11(transcriptPath, "utf-8");
             const lines = transcript.trim().split("\n").reverse();
             for (const line2 of lines) {
               try {

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -302,13 +302,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/codex/bundle/stop.js
+++ b/codex/bundle/stop.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,19 +53,19 @@ var init_index_marker_store = __esm({
 });
 
 // dist/src/hooks/codex/stop.js
-import { readFileSync as readFileSync9, existsSync as existsSync10 } from "node:fs";
+import { readFileSync as readFileSync10, existsSync as existsSync10 } from "node:fs";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname5, join as join16 } from "node:path";
+import { dirname as dirname5, join as join17 } from "node:path";
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -152,6 +152,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -159,7 +260,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -171,7 +272,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -180,8 +302,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -211,7 +333,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -282,8 +404,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -299,10 +421,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -323,7 +446,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -379,7 +502,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -469,13 +592,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -503,9 +626,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -516,9 +639,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -531,9 +654,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -556,9 +679,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -569,20 +692,20 @@ var DeeplakeApi = class {
 // dist/src/hooks/codex/spawn-wiki-worker.js
 import { spawn, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join6 } from "node:path";
-import { writeFileSync as writeFileSync2, mkdirSync as mkdirSync3 } from "node:fs";
-import { homedir as homedir3, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname2, join as join7 } from "node:path";
+import { writeFileSync as writeFileSync3, mkdirSync as mkdirSync4 } from "node:fs";
+import { homedir as homedir4, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync2, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { mkdirSync as mkdirSync3, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join5 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join4(hooksDir, filename);
+  const path = join5(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync2(hooksDir, { recursive: true });
+        mkdirSync3(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -592,18 +715,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync3 } from "node:fs";
-import { dirname, join as join5 } from "node:path";
+import { readFileSync as readFileSync4 } from "node:fs";
+import { dirname, join as join6 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join5(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync3(pluginJson, "utf-8"));
+    const pluginJson = join6(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync4(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync3(join5(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync4(join6(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -618,9 +741,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join5(dir, "package.json");
+    const candidate = join6(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync3(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync4(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -634,8 +757,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/codex/spawn-wiki-worker.js
-var HOME = homedir3();
-var wikiLogger = makeWikiLogger(join6(HOME, ".codex", "hooks"));
+var HOME = homedir4();
+var wikiLogger = makeWikiLogger(join7(HOME, ".codex", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -697,11 +820,11 @@ function findCodexBin() {
 function spawnCodexWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join6(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync3(tmpDir, { recursive: true });
+  const tmpDir = join7(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync4(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".codex-plugin") ?? "";
-  const configFile = join6(tmpDir, "config.json");
-  writeFileSync2(configFile, JSON.stringify({
+  const configFile = join7(tmpDir, "config.json");
+  writeFileSync3(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -715,11 +838,11 @@ function spawnCodexWikiWorker(opts) {
     tmpDir,
     codexBin: findCodexBin(),
     wikiLog: WIKI_LOG,
-    hooksDir: join6(HOME, ".codex", "hooks"),
+    hooksDir: join7(HOME, ".codex", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join6(bundleDir, "wiki-worker.js");
+  const workerPath = join7(bundleDir, "wiki-worker.js");
   spawn("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -733,15 +856,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn2 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname3, join as join8 } from "node:path";
-import { writeFileSync as writeFileSync3, mkdirSync as mkdirSync4, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir5, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname3, join as join9 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync5, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir6, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync3 } from "node:fs";
 import { createRequire } from "node:module";
-import { homedir as homedir4 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir5 } from "node:os";
+import { join as join8 } from "node:path";
 var requireForCp = createRequire(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -753,7 +876,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir4();
+  const home = homedir5();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -762,54 +885,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join7(home, ".claude", "local", "claude"),
+        join8(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join7(home, ".npm-global", "bin", "claude"),
-        join7(home, ".local", "bin", "claude"),
+        join8(home, ".npm-global", "bin", "claude"),
+        join8(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join7(home, ".claude", "local", "claude");
+      ]) ?? join8(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join7(home, ".npm-global", "bin", "codex"),
-        join7(home, ".local", "bin", "codex"),
+        join8(home, ".npm-global", "bin", "codex"),
+        join8(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join7(home, ".npm-global", "bin", "cursor-agent"),
-        join7(home, ".local", "bin", "cursor-agent"),
+        join8(home, ".npm-global", "bin", "cursor-agent"),
+        join8(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join7(home, ".local", "bin", "hermes"),
+        join8(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join7(home, ".npm-global", "bin", "hermes"),
+        join8(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join7(home, ".local", "bin", "hermes");
+      ]) ?? join8(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join7(home, ".local", "bin", "pi"),
+        join8(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join7(home, ".npm-global", "bin", "pi"),
+        join8(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join7(home, ".local", "bin", "pi");
+      ]) ?? join8(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir5();
-var SKILLIFY_LOG = join8(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir6();
+var SKILLIFY_LOG = join9(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync4(dirname3(SKILLIFY_LOG), { recursive: true });
+    mkdirSync5(dirname3(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -817,11 +940,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join8(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync4(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join9(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync5(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join8(tmpDir, "config.json");
-  writeFileSync3(configFile, JSON.stringify({
+  const configFile = join9(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -851,7 +974,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join8(bundleDir, "skillify-worker.js");
+  const workerPath = join9(bundleDir, "skillify-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -860,31 +983,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync4, writeSync, mkdirSync as mkdirSync5, renameSync as renameSync2, existsSync as existsSync5, unlinkSync, openSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync5, writeSync, mkdirSync as mkdirSync6, renameSync as renameSync3, existsSync as existsSync5, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir7 } from "node:os";
+import { homedir as homedir8 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join10, basename } from "node:path";
+import { join as join11, basename } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync4, renameSync } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join9 } from "node:path";
+import { existsSync as existsSync4, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join9(homedir6(), ".deeplake", "state");
-  const legacy = join9(root, "skilify");
-  const current = join9(root, "skillify");
+  const root = join10(homedir7(), ".deeplake", "state");
+  const legacy = join10(root, "skilify");
+  const current = join10(root, "skillify");
   if (!existsSync4(legacy))
     return;
   if (existsSync4(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -898,17 +1021,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog2 = (msg) => log("skillify-state", msg);
-var STATE_DIR = join10(homedir7(), ".deeplake", "state", "skillify");
+var STATE_DIR = join11(homedir8(), ".deeplake", "state", "skillify");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath(projectKey) {
-  return join10(STATE_DIR, `${projectKey}.json`);
+  return join11(STATE_DIR, `${projectKey}.json`);
 }
-function lockPath(projectKey) {
-  return join10(STATE_DIR, `${projectKey}.lock`);
+function lockPath2(projectKey) {
+  return join11(STATE_DIR, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -957,35 +1080,35 @@ function readState(projectKey) {
   if (!existsSync5(p))
     return null;
   try {
-    return JSON.parse(readFileSync4(p, "utf-8"));
+    return JSON.parse(readFileSync5(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = statePath(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state, null, 2));
-  renameSync2(tmp, p);
+  writeFileSync5(tmp, JSON.stringify(state, null, 2));
+  renameSync3(tmp, p);
 }
 function withRmwLock(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync5(STATE_DIR, { recursive: true });
-  const rmw = lockPath(projectKey) + ".rmw";
+  mkdirSync6(STATE_DIR, { recursive: true });
+  const rmw = lockPath2(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync(rmw, "wx");
+      fd = openSync2(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog2(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync(rmw);
+          unlinkSync2(rmw);
         } catch (unlinkErr) {
           dlog2(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -997,9 +1120,9 @@ function withRmwLock(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync(fd);
+    closeSync2(fd);
     try {
-      unlinkSync(rmw);
+      unlinkSync2(rmw);
     } catch (unlinkErr) {
       dlog2(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1015,29 +1138,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync5(STATE_DIR, { recursive: true });
-  const p = lockPath(projectKey);
+  mkdirSync6(STATE_DIR, { recursive: true });
+  const p = lockPath2(projectKey);
   if (existsSync5(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync4(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog2(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync(p);
+      unlinkSync2(p);
     } catch (unlinkErr) {
       dlog2(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync(p, "wx");
+    const fd = openSync2(p, "wx");
     try {
       writeSync(fd, String(Date.now()));
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
     return true;
   } catch {
@@ -1045,26 +1168,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath(projectKey);
+  const p = lockPath2(projectKey);
   try {
-    unlinkSync(p);
+    unlinkSync2(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync6, mkdirSync as mkdirSync6, readFileSync as readFileSync5, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join11 } from "node:path";
-var STATE_DIR2 = join11(homedir8(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join11(STATE_DIR2, "config.json");
+import { existsSync as existsSync6, mkdirSync as mkdirSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync6 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join12 } from "node:path";
+var STATE_DIR2 = join12(homedir9(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join12(STATE_DIR2, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync6(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync5(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync6(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1115,39 +1238,39 @@ function forceSessionEndTrigger(opts) {
 }
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync6, writeSync as writeSync2, mkdirSync as mkdirSync7, renameSync as renameSync3, existsSync as existsSync7, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync7, writeSync as writeSync2, mkdirSync as mkdirSync8, renameSync as renameSync4, existsSync as existsSync7, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 var dlog3 = (msg) => log("summary-state", msg);
-var STATE_DIR3 = join12(homedir9(), ".claude", "hooks", "summary-state");
+var STATE_DIR3 = join13(homedir10(), ".claude", "hooks", "summary-state");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
-function lockPath2(sessionId) {
-  return join12(STATE_DIR3, `${sessionId}.lock`);
+function lockPath3(sessionId) {
+  return join13(STATE_DIR3, `${sessionId}.lock`);
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync7(STATE_DIR3, { recursive: true });
-  const p = lockPath2(sessionId);
+  mkdirSync8(STATE_DIR3, { recursive: true });
+  const p = lockPath3(sessionId);
   if (existsSync7(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync2(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
     return true;
   } catch (e) {
@@ -1158,7 +1281,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync2(lockPath2(sessionId));
+    unlinkSync3(lockPath3(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog3(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1175,9 +1298,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn as spawn3 } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync3, unlinkSync as unlinkSync3, existsSync as existsSync8, readFileSync as readFileSync7 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { openSync as openSync4, closeSync as closeSync4, writeSync as writeSync3, unlinkSync as unlinkSync4, existsSync as existsSync8, readFileSync as readFileSync8 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1191,8 +1314,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join13(homedir10(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join14(homedir11(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1268,7 +1391,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1277,7 +1400,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1324,7 +1447,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1333,13 +1456,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync8(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1382,7 +1505,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync7(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync8(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1392,14 +1515,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync3(this.socketPath);
+      unlinkSync4(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync3(this.pidPath);
+      unlinkSync4(this.pidPath);
     } catch {
     }
   }
@@ -1426,7 +1549,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1434,7 +1557,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1445,16 +1568,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync3(this.pidPath, "wx", 384);
+      fd = openSync4(this.pidPath, "wx", 384);
       writeSync3(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync3(this.pidPath);
+          unlinkSync4(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync3(this.pidPath, "wx", 384);
+          fd = openSync4(this.pidPath, "wx", 384);
           writeSync3(fd, String(process.pid));
         } catch {
           return;
@@ -1464,10 +1587,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync8(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
+        closeSync4(fd);
+        unlinkSync4(this.pidPath);
       } catch {
       }
       return;
@@ -1479,14 +1602,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync3(fd);
+      closeSync4(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync7(this.pidPath, "utf-8").trim();
+      const raw = readFileSync8(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1504,7 +1627,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync8(this.socketPath))
         continue;
@@ -1516,7 +1639,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1531,7 +1654,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1548,7 +1671,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1572,15 +1695,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync9, mkdirSync as mkdirSync8, readFileSync as readFileSync8, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { dirname as dirname4, join as join14 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join14(homedir11(), ".deeplake", "config.json");
+import { existsSync as existsSync9, mkdirSync as mkdirSync9, readFileSync as readFileSync9, renameSync as renameSync5, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { dirname as dirname4, join as join15 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join15(homedir12(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1592,7 +1715,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync8(path, "utf-8");
+    const raw = readFileSync9(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1606,10 +1729,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname4(path);
   if (!existsSync9(dir))
-    mkdirSync8(dir, { recursive: true });
+    mkdirSync9(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync7(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync4(tmp, path);
+  writeFileSync8(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync5(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1658,7 +1781,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join15(homedir12(), ".hivemind", "embed-deps");
+  const sharedDir = join16(homedir13(), ".hivemind", "embed-deps");
   try {
     createRequire2(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1689,9 +1812,9 @@ function embeddingsDisabled() {
 }
 
 // dist/src/hooks/codex/stop.js
-var log4 = (msg) => log("codex-stop", msg);
+var log5 = (msg) => log("codex-stop", msg);
 function resolveEmbedDaemonPath() {
-  return join16(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join17(dirname5(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname5(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
@@ -1705,7 +1828,7 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log4("no config");
+    log5("no config");
     return;
   }
   if (CAPTURE) {
@@ -1718,7 +1841,7 @@ async function main() {
         try {
           const transcriptPath = input.transcript_path;
           if (existsSync10(transcriptPath)) {
-            const transcript = readFileSync9(transcriptPath, "utf-8");
+            const transcript = readFileSync10(transcriptPath, "utf-8");
             const lines = transcript.trim().split("\n").reverse();
             for (const line2 of lines) {
               try {
@@ -1735,10 +1858,10 @@ async function main() {
               }
             }
             if (lastAssistantMessage)
-              log4(`extracted assistant message from transcript (${lastAssistantMessage.length} chars)`);
+              log5(`extracted assistant message from transcript (${lastAssistantMessage.length} chars)`);
           }
         } catch (e) {
-          log4(`transcript read failed: ${e.message}`);
+          log5(`transcript read failed: ${e.message}`);
         }
       }
       const entry = {
@@ -1761,9 +1884,9 @@ async function main() {
       const embeddingSql = embeddingSqlLiteral(embedding);
       const insertSql = `INSERT INTO "${sessionsTable}" (id, path, filename, message, message_embedding, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) VALUES ('${crypto.randomUUID()}', '${sqlStr(sessionPath)}', '${sqlStr(filename)}', '${jsonForSql}'::jsonb, ${embeddingSql}, '${sqlStr(config.userName)}', ${Buffer.byteLength(line, "utf-8")}, '${sqlStr(projectName)}', 'Stop', 'codex', '${sqlStr(PLUGIN_VERSION)}', '${ts}', '${ts}')`;
       await api.query(insertSql);
-      log4("stop event captured");
+      log5("stop event captured");
     } catch (e) {
-      log4(`capture failed: ${e.message}`);
+      log5(`capture failed: ${e.message}`);
     }
   }
   if (!CAPTURE)
@@ -1782,11 +1905,11 @@ async function main() {
       reason: "Stop"
     });
   } catch (e) {
-    log4(`spawn failed: ${e.message}`);
+    log5(`spawn failed: ${e.message}`);
     try {
       releaseLock(sessionId);
     } catch (releaseErr) {
-      log4(`releaseLock after spawn failure also failed: ${releaseErr.message}`);
+      log5(`releaseLock after spawn failure also failed: ${releaseErr.message}`);
     }
     throw e;
   }
@@ -1799,6 +1922,6 @@ async function main() {
   });
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/codex/bundle/wiki-worker.js
+++ b/codex/bundle/wiki-worker.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // dist/src/hooks/codex/wiki-worker.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync4, rmSync } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync3, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join6 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // dist/src/hooks/summary-state.js
@@ -154,9 +154,9 @@ async function uploadSummary(query2, params) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync2, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync as writeSync2, unlinkSync as unlinkSync2, existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join3 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -169,105 +169,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, renameSync as renameSync2, mkdirSync as mkdirSync2, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join3, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
-var log2 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join3(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log2 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath2() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync2(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log2(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync2(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join3(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync2(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath2();
-  mkdirSync2(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync2(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log2(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log2(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep(delay);
     }
   }
-  if (fd === null) {
-    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync2(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync2(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log2(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log2(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync2(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log2(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync2(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync2(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log2(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync2(this.pidPath, "wx", 384);
+      writeSync2(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync2(this.pidPath, "wx", 384);
+          writeSync2(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync2(this.daemonEntry)) {
+      log2(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log2(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync2(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync2(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync2(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -277,7 +543,7 @@ import { join as join5 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync3, renameSync as renameSync3, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join4 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join4(homedir4(), ".deeplake", "config.json");
@@ -287,7 +553,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     _cache = {};
     return _cache;
   }
@@ -305,11 +571,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync2(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync3(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync3(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -388,390 +654,6 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync3(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log3(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync3(this.pidPath, "wx", 384);
-      writeSync2(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync3(this.pidPath, "wx", 384);
-          writeSync2(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync3(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep2(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync3(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep2(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/utils/client-header.js
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
@@ -783,13 +665,13 @@ function deeplakeClientHeader() {
 
 // dist/src/hooks/codex/wiki-worker.js
 var dlog2 = (msg) => log("codex-wiki-worker", msg);
-var cfg = JSON.parse(readFileSync5(process.argv[2], "utf-8"));
+var cfg = JSON.parse(readFileSync4(process.argv[2], "utf-8"));
 var tmpDir = cfg.tmpDir;
-var tmpJsonl = join7(tmpDir, "session.jsonl");
-var tmpSummary = join7(tmpDir, "summary.md");
+var tmpJsonl = join6(tmpDir, "session.jsonl");
+var tmpSummary = join6(tmpDir, "summary.md");
 function wlog(msg) {
   try {
-    mkdirSync4(cfg.hooksDir, { recursive: true });
+    mkdirSync3(cfg.hooksDir, { recursive: true });
     appendFileSync2(cfg.wikiLog, `[${(/* @__PURE__ */ new Date()).toISOString().replace("T", " ").slice(0, 19)}] wiki-worker(${cfg.sessionId}): ${msg}
 `);
   } catch {
@@ -821,7 +703,7 @@ async function query(sql, retries = 4) {
       const base = Math.min(3e4, 2e3 * Math.pow(2, attempt));
       const delay = base + Math.floor(Math.random() * 1e3);
       wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise((resolve2) => setTimeout(resolve2, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       continue;
     }
     throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
@@ -847,7 +729,7 @@ async function main() {
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc2(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
-    writeFileSync4(tmpJsonl, jsonlContent);
+    writeFileSync3(tmpJsonl, jsonlContent);
     wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
     let prevOffset = 0;
     try {
@@ -857,7 +739,7 @@ async function main() {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
-        writeFileSync4(tmpSummary, existing);
+        writeFileSync3(tmpSummary, existing);
         wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch {
@@ -879,14 +761,14 @@ async function main() {
       wlog(`codex exec failed: ${e.status ?? e.message}`);
     }
     if (existsSync4(tmpSummary)) {
-      const text = readFileSync5(tmpSummary, "utf-8");
+      const text = readFileSync4(tmpSummary, "utf-8");
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         let embedding = null;
         if (!embeddingsDisabled()) {
           try {
-            const daemonEntry = join7(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
+            const daemonEntry = join6(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
             embedding = await new EmbedClient({ daemonEntry }).embed(text, "document");
           } catch (e) {
             wlog(`summary embedding failed, writing NULL: ${e.message}`);

--- a/cursor/bundle/capture.js
+++ b/cursor/bundle/capture.js
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -176,7 +176,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +206,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -570,9 +570,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -585,105 +585,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v of vec) {
+    if (!Number.isFinite(v))
+      return "NULL";
+    parts.push(String(v));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -693,7 +972,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -703,7 +982,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -721,11 +1000,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -804,414 +1083,17 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v of vec) {
-    if (!Number.isFinite(v))
-      return "NULL";
-    parts.push(String(v));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
-}
-
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { basename, dirname as dirname2, join as join7 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join7(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1232,7 +1114,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync2(link);
+      statSync(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1252,14 +1134,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync3(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync3(tmp, link);
+    renameSync2(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1268,53 +1150,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/cursor/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
+import { dirname as dirname6, join as join17 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join8(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+function lockPath(sessionId) {
+  return join8(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync5(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
-  renameSync4(tmp, p);
+  writeFileSync3(tmp, JSON.stringify(state));
+  renameSync3(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync3(rmwLock, "wx");
+      fd = openSync2(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync2(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1326,9 +1208,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync3(fd);
+    closeSync2(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync2(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1363,29 +1245,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
-  const p = lockPath2(sessionId);
+  mkdirSync4(STATE_DIR, { recursive: true });
+  const p = lockPath(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync2(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync3(p, "wx");
+    const fd = openSync2(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync3(fd);
+      closeSync2(fd);
     }
     return true;
   } catch (e) {
@@ -1396,7 +1278,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync2(lockPath(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1407,20 +1289,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/cursor/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join11 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
+import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join9 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join9(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync5(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1430,18 +1312,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname3, join as join10 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1456,9 +1338,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join10(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1472,8 +1354,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/cursor/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".cursor", "hooks"));
+var HOME = homedir8();
+var wikiLogger = makeWikiLogger(join11(HOME, ".cursor", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1535,11 +1417,11 @@ function findCursorBin() {
 function spawnCursorWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join11(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1554,11 +1436,11 @@ function spawnCursorWikiWorker(opts) {
     cursorBin: findCursorBin(),
     cursorModel: process.env.HIVEMIND_CURSOR_MODEL ?? "auto",
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".cursor", "hooks"),
+    hooksDir: join11(HOME, ".cursor", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join11(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1572,15 +1454,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join14 } from "node:path";
-import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join13 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir10, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { homedir as homedir9 } from "node:os";
+import { join as join12 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1592,7 +1474,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir10();
+  const home = homedir9();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1601,54 +1483,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join13(home, ".claude", "local", "claude"),
+        join12(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join13(home, ".npm-global", "bin", "claude"),
-        join13(home, ".local", "bin", "claude"),
+        join12(home, ".npm-global", "bin", "claude"),
+        join12(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join13(home, ".claude", "local", "claude");
+      ]) ?? join12(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join13(home, ".npm-global", "bin", "codex"),
-        join13(home, ".local", "bin", "codex"),
+        join12(home, ".npm-global", "bin", "codex"),
+        join12(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join13(home, ".npm-global", "bin", "cursor-agent"),
-        join13(home, ".local", "bin", "cursor-agent"),
+        join12(home, ".npm-global", "bin", "cursor-agent"),
+        join12(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join13(home, ".local", "bin", "hermes"),
+        join12(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join13(home, ".npm-global", "bin", "hermes"),
+        join12(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join13(home, ".local", "bin", "hermes");
+      ]) ?? join12(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join13(home, ".local", "bin", "pi"),
+        join12(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join13(home, ".npm-global", "bin", "pi"),
+        join12(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join13(home, ".local", "bin", "pi");
+      ]) ?? join12(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir11();
-var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir10();
+var SKILLIFY_LOG = join13(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync7(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1656,11 +1538,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join13(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join14(tmpDir, "config.json");
-  writeFileSync6(configFile, JSON.stringify({
+  const configFile = join13(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1690,7 +1572,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join14(bundleDir, "skillify-worker.js");
+  const workerPath = join13(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1699,31 +1581,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync6, writeSync as writeSync3, mkdirSync as mkdirSync8, renameSync as renameSync5, existsSync as existsSync9, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir13 } from "node:os";
+import { homedir as homedir12 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join16, basename as basename2 } from "node:path";
+import { join as join15, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { existsSync as existsSync8, renameSync as renameSync4 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join15(homedir12(), ".deeplake", "state");
-  const legacy = join15(root, "skilify");
-  const current = join15(root, "skillify");
+  const root = join14(homedir11(), ".deeplake", "state");
+  const legacy = join14(root, "skilify");
+  const current = join14(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
     return;
   try {
-    renameSync5(legacy, current);
+    renameSync4(legacy, current);
     dlog2(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -1737,17 +1619,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join15(homedir12(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.json`);
+  return join15(STATE_DIR2, `${projectKey}.json`);
 }
-function lockPath3(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.lock`);
+function lockPath2(projectKey) {
+  return join15(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1796,35 +1678,35 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync8(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync8(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(state, null, 2));
-  renameSync6(tmp, p);
+  writeFileSync6(tmp, JSON.stringify(state, null, 2));
+  renameSync5(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
-  const rmw = lockPath3(projectKey) + ".rmw";
+  mkdirSync8(STATE_DIR2, { recursive: true });
+  const rmw = lockPath2(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync4(rmw, "wx");
+      fd = openSync3(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync4(rmw);
+          unlinkSync3(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1836,9 +1718,9 @@ function withRmwLock2(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync4(fd);
+    closeSync3(fd);
     try {
-      unlinkSync4(rmw);
+      unlinkSync3(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1871,29 +1753,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
-  const p = lockPath3(projectKey);
+  mkdirSync8(STATE_DIR2, { recursive: true });
+  const p = lockPath2(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync4(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync4(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync3(fd, String(Date.now()));
     } finally {
-      closeSync4(fd);
+      closeSync3(fd);
     }
     return true;
   } catch {
@@ -1901,26 +1783,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath3(projectKey);
+  const p = lockPath2(projectKey);
   try {
-    unlinkSync4(p);
+    unlinkSync3(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { join as join17 } from "node:path";
-var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join17(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync7 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
+var STATE_DIR3 = join16(homedir13(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join16(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync8(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1971,9 +1853,9 @@ function tryStopCounterTrigger(opts) {
 }
 
 // dist/src/hooks/cursor/capture.js
-var log5 = (msg) => log("cursor-capture", msg);
+var log4 = (msg) => log("cursor-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1998,7 +1880,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log5("no config");
+    log4("no config");
     return;
   }
   const sessionId = input.conversation_id ?? `cursor-${Date.now()}`;
@@ -2017,10 +1899,10 @@ async function main() {
   };
   let entry = null;
   if (event === "beforeSubmitPrompt" && typeof input.prompt === "string") {
-    log5(`user session=${sessionId}`);
+    log4(`user session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "user_message", content: input.prompt };
   } else if (event === "postToolUse" && typeof input.tool_name === "string") {
-    log5(`tool=${input.tool_name} session=${sessionId}`);
+    log4(`tool=${input.tool_name} session=${sessionId}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2032,10 +1914,10 @@ async function main() {
       tool_response: typeof input.tool_output === "string" ? input.tool_output : JSON.stringify(input.tool_output)
     };
   } else if (event === "afterAgentResponse" && typeof input.text === "string") {
-    log5(`assistant session=${sessionId}`);
+    log4(`assistant session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "assistant_message", content: input.text };
   } else if (event === "stop") {
-    log5(`stop session=${sessionId} status=${input.status ?? "unknown"}`);
+    log4(`stop session=${sessionId} status=${input.status ?? "unknown"}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2044,12 +1926,12 @@ async function main() {
       loop_count: input.loop_count
     };
   } else {
-    log5(`unknown event: ${event}, skipping`);
+    log4(`unknown event: ${event}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, sessionId);
   const line = JSON.stringify(entry);
-  log5(`writing to ${sessionPath}`);
+  log4(`writing to ${sessionPath}`);
   const projectName = cwd.split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -2060,14 +1942,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log5("table missing, creating and retrying");
+      log4("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log5("capture ok \u2192 cloud");
+  log4("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(sessionId, cwd, config);
   if (event === "afterAgentResponse" && process.env.HIVEMIND_WIKI_WORKER !== "1" && process.env.HIVEMIND_SKILLIFY_WORKER !== "1") {
     tryStopCounterTrigger({
@@ -2088,7 +1970,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -2101,17 +1983,17 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log5(`periodic spawn failed: ${e.message}`);
+      log4(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch {
       }
     }
   } catch (e) {
-    log5(`periodic trigger error: ${e.message}`);
+    log4(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/cursor/bundle/capture.js
+++ b/cursor/bundle/capture.js
@@ -297,13 +297,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/cursor/bundle/capture.js
+++ b/cursor/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -248,6 +248,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -284,11 +302,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -693,9 +721,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -709,7 +737,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -900,7 +928,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -913,11 +941,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -968,7 +996,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -985,7 +1013,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1004,7 +1032,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1090,15 +1118,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1110,7 +1138,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1124,9 +1152,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1176,7 +1204,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1207,16 +1235,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync5, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { basename, dirname as dirname2, join as join9 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join9(homedir8(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join9(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1257,7 +1285,7 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync5(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
@@ -1273,40 +1301,40 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/cursor/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
+import { dirname as dirname6, join as join19 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync5, writeSync as writeSync2, mkdirSync as mkdirSync6, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync4, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join10(homedir9(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join10(STATE_DIR, `${sessionId}.json`);
 }
 function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+  return join10(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
+  writeFileSync5(tmp, JSON.stringify(state));
   renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1319,7 +1347,7 @@ function withRmwLock(sessionId, fn) {
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync4(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1333,7 +1361,7 @@ function withRmwLock(sessionId, fn) {
   } finally {
     closeSync3(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync4(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1368,18 +1396,18 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
@@ -1401,7 +1429,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync4(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1412,20 +1440,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/cursor/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join13 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8 } from "node:fs";
+import { homedir as homedir10, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync7, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join11 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join11(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync7(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1435,18 +1463,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync8 } from "node:fs";
+import { dirname as dirname3, join as join12 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join12(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync8(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync8(join12(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1461,9 +1489,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join12(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync8(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1477,8 +1505,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/cursor/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".cursor", "hooks"));
+var HOME = homedir10();
+var wikiLogger = makeWikiLogger(join13(HOME, ".cursor", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1540,11 +1568,11 @@ function findCursorBin() {
 function spawnCursorWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join13(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync8(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join13(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1559,11 +1587,11 @@ function spawnCursorWikiWorker(opts) {
     cursorBin: findCursorBin(),
     cursorModel: process.env.HIVEMIND_CURSOR_MODEL ?? "auto",
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".cursor", "hooks"),
+    hooksDir: join13(HOME, ".cursor", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join13(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1577,15 +1605,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join14 } from "node:path";
-import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join15 } from "node:path";
+import { writeFileSync as writeFileSync7, mkdirSync as mkdirSync9, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir12, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1597,7 +1625,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir10();
+  const home = homedir11();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1606,54 +1634,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join13(home, ".claude", "local", "claude"),
+        join14(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join13(home, ".npm-global", "bin", "claude"),
-        join13(home, ".local", "bin", "claude"),
+        join14(home, ".npm-global", "bin", "claude"),
+        join14(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join13(home, ".claude", "local", "claude");
+      ]) ?? join14(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join13(home, ".npm-global", "bin", "codex"),
-        join13(home, ".local", "bin", "codex"),
+        join14(home, ".npm-global", "bin", "codex"),
+        join14(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join13(home, ".npm-global", "bin", "cursor-agent"),
-        join13(home, ".local", "bin", "cursor-agent"),
+        join14(home, ".npm-global", "bin", "cursor-agent"),
+        join14(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join13(home, ".local", "bin", "hermes"),
+        join14(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join13(home, ".npm-global", "bin", "hermes"),
+        join14(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join13(home, ".local", "bin", "hermes");
+      ]) ?? join14(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join13(home, ".local", "bin", "pi"),
+        join14(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join13(home, ".npm-global", "bin", "pi"),
+        join14(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join13(home, ".local", "bin", "pi");
+      ]) ?? join14(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir11();
-var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir12();
+var SKILLIFY_LOG = join15(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync9(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1661,11 +1689,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join15(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync9(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join14(tmpDir, "config.json");
-  writeFileSync6(configFile, JSON.stringify({
+  const configFile = join15(tmpDir, "config.json");
+  writeFileSync7(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1695,7 +1723,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join14(bundleDir, "skillify-worker.js");
+  const workerPath = join15(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1704,25 +1732,25 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
+import { readFileSync as readFileSync9, writeFileSync as writeFileSync8, writeSync as writeSync3, mkdirSync as mkdirSync10, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync5, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir13 } from "node:os";
+import { homedir as homedir14 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join16, basename as basename2 } from "node:path";
+import { join as join17, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
 import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join15(homedir12(), ".deeplake", "state");
-  const legacy = join15(root, "skilify");
-  const current = join15(root, "skillify");
+  const root = join16(homedir13(), ".deeplake", "state");
+  const legacy = join16(root, "skilify");
+  const current = join16(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
@@ -1742,17 +1770,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join17(homedir14(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.json`);
+  return join17(STATE_DIR2, `${projectKey}.json`);
 }
 function lockPath3(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.lock`);
+  return join17(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1801,22 +1829,22 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync8(p, "utf-8"));
+    return JSON.parse(readFileSync9(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(state, null, 2));
+  writeFileSync8(tmp, JSON.stringify(state, null, 2));
   renameSync6(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1829,7 +1857,7 @@ function withRmwLock2(projectKey, fn) {
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync4(rmw);
+          unlinkSync5(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1843,7 +1871,7 @@ function withRmwLock2(projectKey, fn) {
   } finally {
     closeSync4(fd);
     try {
-      unlinkSync4(rmw);
+      unlinkSync5(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1876,18 +1904,18 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const p = lockPath3(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync9(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync4(p);
+      unlinkSync5(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
@@ -1908,24 +1936,24 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
 function releaseWorkerLock(projectKey) {
   const p = lockPath3(projectKey);
   try {
-    unlinkSync4(p);
+    unlinkSync5(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { join as join17 } from "node:path";
-var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join17(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync11, readFileSync as readFileSync10, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { join as join18 } from "node:path";
+var STATE_DIR3 = join18(homedir15(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join18(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync10(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1978,7 +2006,7 @@ function tryStopCounterTrigger(opts) {
 // dist/src/hooks/cursor/capture.js
 var log5 = (msg) => log("cursor-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join19(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";

--- a/cursor/bundle/capture.js
+++ b/cursor/bundle/capture.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -54,13 +54,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -147,6 +147,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -154,7 +255,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -166,7 +267,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -175,8 +297,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -206,7 +328,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -277,8 +399,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -294,10 +416,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -318,7 +441,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -374,7 +497,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -464,13 +587,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -498,9 +621,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -511,9 +634,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -526,9 +649,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -551,9 +674,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -570,9 +693,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -586,8 +709,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -663,7 +786,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -672,7 +795,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -719,7 +842,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -728,13 +851,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -777,7 +900,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -787,14 +910,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -821,7 +944,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -829,7 +952,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -840,16 +963,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -859,10 +982,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -874,14 +997,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -899,7 +1022,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -911,7 +1034,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -926,7 +1049,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -943,7 +1066,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -967,15 +1090,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -987,7 +1110,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1001,10 +1124,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1053,7 +1176,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1084,16 +1207,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { basename, dirname as dirname2, join as join7 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { basename, dirname as dirname2, join as join8 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join7(pluginDir, "node_modules");
+  const link = join8(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1114,7 +1237,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync(link);
+      statSync2(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1134,14 +1257,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync3(parent, { recursive: true });
+      mkdirSync4(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync2(tmp, link);
+    renameSync3(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1150,53 +1273,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/cursor/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join17 } from "node:path";
+import { dirname as dirname6, join as join18 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join8 } from "node:path";
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join9 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.json`);
+  return join9(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.lock`);
+function lockPath2(sessionId) {
+  return join9(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync5(p, "utf-8"));
+    return JSON.parse(readFileSync6(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(state));
-  renameSync3(tmp, p);
+  writeFileSync4(tmp, JSON.stringify(state));
+  renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync2(rmwLock, "wx");
+      fd = openSync3(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmwLock);
+          unlinkSync3(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1208,9 +1331,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync2(fd);
+    closeSync3(fd);
     try {
-      unlinkSync2(rmwLock);
+      unlinkSync3(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1245,29 +1368,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync4(STATE_DIR, { recursive: true });
-  const p = lockPath(sessionId);
+  mkdirSync5(STATE_DIR, { recursive: true });
+  const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync2(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
     return true;
   } catch (e) {
@@ -1278,7 +1401,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync2(lockPath(sessionId));
+    unlinkSync3(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1289,20 +1412,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/cursor/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join11 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
-import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join12 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
+import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join9 } from "node:path";
+import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join10 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join9(hooksDir, filename);
+  const path = join10(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync5(hooksDir, { recursive: true });
+        mkdirSync6(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1312,18 +1435,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync6 } from "node:fs";
-import { dirname as dirname3, join as join10 } from "node:path";
+import { readFileSync as readFileSync7 } from "node:fs";
+import { dirname as dirname3, join as join11 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
+    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1338,9 +1461,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join10(dir, "package.json");
+    const candidate = join11(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1354,8 +1477,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/cursor/spawn-wiki-worker.js
-var HOME = homedir8();
-var wikiLogger = makeWikiLogger(join11(HOME, ".cursor", "hooks"));
+var HOME = homedir9();
+var wikiLogger = makeWikiLogger(join12(HOME, ".cursor", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1417,11 +1540,11 @@ function findCursorBin() {
 function spawnCursorWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync6(tmpDir, { recursive: true });
+  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join11(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join12(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1436,11 +1559,11 @@ function spawnCursorWikiWorker(opts) {
     cursorBin: findCursorBin(),
     cursorModel: process.env.HIVEMIND_CURSOR_MODEL ?? "auto",
     wikiLog: WIKI_LOG,
-    hooksDir: join11(HOME, ".cursor", "hooks"),
+    hooksDir: join12(HOME, ".cursor", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join11(bundleDir, "wiki-worker.js");
+  const workerPath = join12(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1454,15 +1577,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join13 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir10, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join14 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1474,7 +1597,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir9();
+  const home = homedir10();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1483,54 +1606,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join12(home, ".claude", "local", "claude"),
+        join13(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join12(home, ".npm-global", "bin", "claude"),
-        join12(home, ".local", "bin", "claude"),
+        join13(home, ".npm-global", "bin", "claude"),
+        join13(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join12(home, ".claude", "local", "claude");
+      ]) ?? join13(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join12(home, ".npm-global", "bin", "codex"),
-        join12(home, ".local", "bin", "codex"),
+        join13(home, ".npm-global", "bin", "codex"),
+        join13(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join12(home, ".npm-global", "bin", "cursor-agent"),
-        join12(home, ".local", "bin", "cursor-agent"),
+        join13(home, ".npm-global", "bin", "cursor-agent"),
+        join13(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join12(home, ".local", "bin", "hermes"),
+        join13(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join12(home, ".npm-global", "bin", "hermes"),
+        join13(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join12(home, ".local", "bin", "hermes");
+      ]) ?? join13(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join12(home, ".local", "bin", "pi"),
+        join13(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join12(home, ".npm-global", "bin", "pi"),
+        join13(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join12(home, ".local", "bin", "pi");
+      ]) ?? join13(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir10();
-var SKILLIFY_LOG = join13(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir11();
+var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync7(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1538,11 +1661,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join13(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join13(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join14(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1572,7 +1695,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join13(bundleDir, "skillify-worker.js");
+  const workerPath = join14(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1581,31 +1704,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync6, writeSync as writeSync3, mkdirSync as mkdirSync8, renameSync as renameSync5, existsSync as existsSync9, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir12 } from "node:os";
+import { homedir as homedir13 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join15, basename as basename2 } from "node:path";
+import { join as join16, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync8, renameSync as renameSync4 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { join as join14 } from "node:path";
+import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { join as join15 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join14(homedir11(), ".deeplake", "state");
-  const legacy = join14(root, "skilify");
-  const current = join14(root, "skillify");
+  const root = join15(homedir12(), ".deeplake", "state");
+  const legacy = join15(root, "skilify");
+  const current = join15(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
     return;
   try {
-    renameSync4(legacy, current);
+    renameSync5(legacy, current);
     dlog2(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -1619,17 +1742,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join15(homedir12(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join15(STATE_DIR2, `${projectKey}.json`);
+  return join16(STATE_DIR2, `${projectKey}.json`);
 }
-function lockPath2(projectKey) {
-  return join15(STATE_DIR2, `${projectKey}.lock`);
+function lockPath3(projectKey) {
+  return join16(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1678,35 +1801,35 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync7(p, "utf-8"));
+    return JSON.parse(readFileSync8(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
+  mkdirSync9(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync6(tmp, JSON.stringify(state, null, 2));
-  renameSync5(tmp, p);
+  writeFileSync7(tmp, JSON.stringify(state, null, 2));
+  renameSync6(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
-  const rmw = lockPath2(projectKey) + ".rmw";
+  mkdirSync9(STATE_DIR2, { recursive: true });
+  const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync3(rmw, "wx");
+      fd = openSync4(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmw);
+          unlinkSync4(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1718,9 +1841,9 @@ function withRmwLock2(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync3(fd);
+    closeSync4(fd);
     try {
-      unlinkSync3(rmw);
+      unlinkSync4(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1753,29 +1876,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
-  const p = lockPath2(projectKey);
+  mkdirSync9(STATE_DIR2, { recursive: true });
+  const p = lockPath3(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync3(p, "wx");
+    const fd = openSync4(p, "wx");
     try {
       writeSync3(fd, String(Date.now()));
     } finally {
-      closeSync3(fd);
+      closeSync4(fd);
     }
     return true;
   } catch {
@@ -1783,26 +1906,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath2(projectKey);
+  const p = lockPath3(projectKey);
   try {
-    unlinkSync3(p);
+    unlinkSync4(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
-var STATE_DIR3 = join16(homedir13(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join16(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { join as join17 } from "node:path";
+var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join17(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync8(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1853,9 +1976,9 @@ function tryStopCounterTrigger(opts) {
 }
 
 // dist/src/hooks/cursor/capture.js
-var log4 = (msg) => log("cursor-capture", msg);
+var log5 = (msg) => log("cursor-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1880,7 +2003,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log4("no config");
+    log5("no config");
     return;
   }
   const sessionId = input.conversation_id ?? `cursor-${Date.now()}`;
@@ -1899,10 +2022,10 @@ async function main() {
   };
   let entry = null;
   if (event === "beforeSubmitPrompt" && typeof input.prompt === "string") {
-    log4(`user session=${sessionId}`);
+    log5(`user session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "user_message", content: input.prompt };
   } else if (event === "postToolUse" && typeof input.tool_name === "string") {
-    log4(`tool=${input.tool_name} session=${sessionId}`);
+    log5(`tool=${input.tool_name} session=${sessionId}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1914,10 +2037,10 @@ async function main() {
       tool_response: typeof input.tool_output === "string" ? input.tool_output : JSON.stringify(input.tool_output)
     };
   } else if (event === "afterAgentResponse" && typeof input.text === "string") {
-    log4(`assistant session=${sessionId}`);
+    log5(`assistant session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "assistant_message", content: input.text };
   } else if (event === "stop") {
-    log4(`stop session=${sessionId} status=${input.status ?? "unknown"}`);
+    log5(`stop session=${sessionId} status=${input.status ?? "unknown"}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1926,12 +2049,12 @@ async function main() {
       loop_count: input.loop_count
     };
   } else {
-    log4(`unknown event: ${event}, skipping`);
+    log5(`unknown event: ${event}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, sessionId);
   const line = JSON.stringify(entry);
-  log4(`writing to ${sessionPath}`);
+  log5(`writing to ${sessionPath}`);
   const projectName = cwd.split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -1942,14 +2065,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log4("table missing, creating and retrying");
+      log5("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log4("capture ok \u2192 cloud");
+  log5("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(sessionId, cwd, config);
   if (event === "afterAgentResponse" && process.env.HIVEMIND_WIKI_WORKER !== "1" && process.env.HIVEMIND_SKILLIFY_WORKER !== "1") {
     tryStopCounterTrigger({
@@ -1970,7 +2093,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -1983,17 +2106,17 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log4(`periodic spawn failed: ${e.message}`);
+      log5(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch {
       }
     }
   } catch (e) {
-    log4(`periodic trigger error: ${e.message}`);
+    log5(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -469,13 +469,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -474,11 +474,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/cursor/bundle/commands/auth-login.js
+++ b/cursor/bundle/commands/auth-login.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -337,6 +337,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -344,7 +445,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -356,7 +457,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -365,8 +487,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -396,7 +518,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -467,8 +589,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -484,10 +606,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -508,7 +631,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -564,7 +687,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -654,13 +777,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -688,9 +811,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -701,9 +824,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -716,9 +839,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -741,9 +864,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -774,10 +897,10 @@ function parseArgs(argv) {
 }
 function confirm(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     rl.question(`${message} [y/N] `, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
+      resolve2(answer.trim().toLowerCase() === "y");
     });
   });
 }

--- a/cursor/bundle/pre-tool-use.js
+++ b/cursor/bundle/pre-tool-use.js
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -175,7 +175,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +205,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -1042,9 +1042,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1057,105 +1057,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -1165,7 +1431,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -1175,7 +1441,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -1193,11 +1459,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1276,397 +1542,13 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join7 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2019,9 +1901,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir6 } from "node:os";
+import { join as join8 } from "node:path";
+var MEMORY_PATH = join8(homedir6(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {
@@ -2032,7 +1914,7 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/cursor/pre-tool-use.js
-var log5 = (msg) => log("cursor-pre-tool-use", msg);
+var log4 = (msg) => log("cursor-pre-tool-use", msg);
 async function main() {
   const input = await readStdin();
   if (input.tool_name !== "Shell")
@@ -2048,17 +1930,17 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log5("no config \u2014 falling through to Cursor's bash");
+    log4("no config \u2014 falling through to Cursor's bash");
     return;
   }
   const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
   try {
     const result = await handleGrepDirect(api, config.tableName, config.sessionsTableName, grepParams);
     if (result === null) {
-      log5(`fallthrough \u2014 handleGrepDirect returned null for "${grepParams.pattern}"`);
+      log4(`fallthrough \u2014 handleGrepDirect returned null for "${grepParams.pattern}"`);
       return;
     }
-    log5(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
+    log4(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
     const echoCmd = `cat <<'__HIVEMIND_RESULT__'
 ${result}
 __HIVEMIND_RESULT__`;
@@ -2069,10 +1951,10 @@ __HIVEMIND_RESULT__`;
     }));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log5(`fast-path failed, falling through: ${msg}`);
+    log4(`fast-path failed, falling through: ${msg}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/cursor/bundle/pre-tool-use.js
+++ b/cursor/bundle/pre-tool-use.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -247,6 +247,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -283,11 +301,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -1165,9 +1193,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1181,7 +1209,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1372,7 +1400,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1385,11 +1413,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -1440,7 +1468,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -1457,7 +1485,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1476,7 +1504,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1549,15 +1577,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1569,7 +1597,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1583,9 +1611,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1635,7 +1663,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1667,11 +1695,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join9 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join9(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2024,9 +2052,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir8 } from "node:os";
+import { join as join10 } from "node:path";
+var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {

--- a/cursor/bundle/pre-tool-use.js
+++ b/cursor/bundle/pre-tool-use.js
@@ -296,13 +296,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/cursor/bundle/pre-tool-use.js
+++ b/cursor/bundle/pre-tool-use.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -146,6 +146,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -153,7 +254,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -165,7 +266,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -174,8 +296,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +327,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -276,8 +398,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -293,10 +415,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -317,7 +440,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -373,7 +496,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -463,13 +586,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -497,9 +620,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -510,9 +633,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -525,9 +648,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -550,9 +673,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -1042,9 +1165,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1058,8 +1181,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1135,7 +1258,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1144,7 +1267,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1191,7 +1314,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1200,13 +1323,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1249,7 +1372,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1259,14 +1382,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -1293,7 +1416,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1301,7 +1424,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1312,16 +1435,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -1331,10 +1454,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -1346,14 +1469,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1371,7 +1494,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -1383,7 +1506,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1398,7 +1521,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1415,7 +1538,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1426,15 +1549,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1446,7 +1569,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1460,10 +1583,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1512,7 +1635,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1544,11 +1667,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join8 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -1901,9 +2024,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir6 } from "node:os";
-import { join as join8 } from "node:path";
-var MEMORY_PATH = join8(homedir6(), ".deeplake", "memory");
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
+var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {
@@ -1914,7 +2037,7 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/cursor/pre-tool-use.js
-var log4 = (msg) => log("cursor-pre-tool-use", msg);
+var log5 = (msg) => log("cursor-pre-tool-use", msg);
 async function main() {
   const input = await readStdin();
   if (input.tool_name !== "Shell")
@@ -1930,17 +2053,17 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log4("no config \u2014 falling through to Cursor's bash");
+    log5("no config \u2014 falling through to Cursor's bash");
     return;
   }
   const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
   try {
     const result = await handleGrepDirect(api, config.tableName, config.sessionsTableName, grepParams);
     if (result === null) {
-      log4(`fallthrough \u2014 handleGrepDirect returned null for "${grepParams.pattern}"`);
+      log5(`fallthrough \u2014 handleGrepDirect returned null for "${grepParams.pattern}"`);
       return;
     }
-    log4(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
+    log5(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
     const echoCmd = `cat <<'__HIVEMIND_RESULT__'
 ${result}
 __HIVEMIND_RESULT__`;
@@ -1951,10 +2074,10 @@ __HIVEMIND_RESULT__`;
     }));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log4(`fast-path failed, falling through: ${msg}`);
+    log5(`fast-path failed, falling through: ${msg}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/cursor/bundle/session-start.js
+++ b/cursor/bundle/session-start.js
@@ -284,13 +284,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/cursor/bundle/session-start.js
+++ b/cursor/bundle/session-start.js
@@ -289,11 +289,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/cursor/bundle/session-start.js
+++ b/cursor/bundle/session-start.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -152,6 +152,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -159,7 +260,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -171,7 +272,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -180,8 +302,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -211,7 +333,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -282,8 +404,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -299,10 +421,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -323,7 +446,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -379,7 +502,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -469,13 +592,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -503,9 +626,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -516,9 +639,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -531,9 +654,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -556,9 +679,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -596,16 +719,16 @@ function renderSkillifyCommands() {
 }
 
 // dist/src/skillify/local-manifest.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var LOCAL_MANIFEST_PATH = join5(homedir4(), ".claude", "hivemind", "local-mined.json");
-var LOCAL_MINE_LOCK_PATH = join5(homedir4(), ".claude", "hivemind", "local-mined.lock");
+import { existsSync as existsSync3, mkdirSync as mkdirSync4, readFileSync as readFileSync5, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var LOCAL_MANIFEST_PATH = join6(homedir5(), ".claude", "hivemind", "local-mined.json");
+var LOCAL_MINE_LOCK_PATH = join6(homedir5(), ".claude", "hivemind", "local-mined.lock");
 function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
   if (!existsSync3(path))
     return null;
   try {
-    return JSON.parse(readFileSync4(path, "utf-8"));
+    return JSON.parse(readFileSync5(path, "utf-8"));
   } catch {
     return null;
   }
@@ -617,19 +740,19 @@ function countLocalManifestEntries(path = LOCAL_MANIFEST_PATH) {
 
 // dist/src/skillify/spawn-mine-local-worker.js
 import { execFileSync, spawn } from "node:child_process";
-import { closeSync, existsSync as existsSync4, mkdirSync as mkdirSync4, openSync, readdirSync, statSync, unlinkSync as unlinkSync2 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname2, join as join6 } from "node:path";
+import { closeSync as closeSync2, existsSync as existsSync4, mkdirSync as mkdirSync5, openSync as openSync2, readdirSync, statSync as statSync2, unlinkSync as unlinkSync3 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname2, join as join7 } from "node:path";
 import { fileURLToPath } from "node:url";
-var HOME = homedir5();
-var HIVEMIND_DIR = join6(HOME, ".claude", "hivemind");
-var LOG_PATH = join6(HOME, ".claude", "hooks", "mine-local.log");
-var CLAUDE_PROJECTS_DIR = join6(HOME, ".claude", "projects");
-var LOCK_STALE_MS = 15 * 60 * 1e3;
+var HOME = homedir6();
+var HIVEMIND_DIR = join7(HOME, ".claude", "hivemind");
+var LOG_PATH = join7(HOME, ".claude", "hooks", "mine-local.log");
+var CLAUDE_PROJECTS_DIR = join7(HOME, ".claude", "projects");
+var LOCK_STALE_MS2 = 15 * 60 * 1e3;
 function findBundledCliPath() {
   try {
     const thisDir = dirname2(fileURLToPath(import.meta.url));
-    const cliPath = join6(thisDir, "..", "..", "bundle", "cli.js");
+    const cliPath = join7(thisDir, "..", "..", "bundle", "cli.js");
     return existsSync4(cliPath) ? cliPath : null;
   } catch {
     return null;
@@ -662,7 +785,7 @@ function hasLocalClaudeSessions() {
   for (const sub of subdirs) {
     let files;
     try {
-      files = readdirSync(join6(CLAUDE_PROJECTS_DIR, sub));
+      files = readdirSync(join7(CLAUDE_PROJECTS_DIR, sub));
     } catch {
       continue;
     }
@@ -677,14 +800,14 @@ function maybeAutoMineLocal() {
   if (existsSync4(LOCAL_MINE_LOCK_PATH)) {
     let stale = false;
     try {
-      const stats = statSync(LOCAL_MINE_LOCK_PATH);
-      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS;
+      const stats = statSync2(LOCAL_MINE_LOCK_PATH);
+      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS2;
     } catch {
     }
     if (!stale)
       return { triggered: false, reason: "lock-exists" };
     try {
-      unlinkSync2(LOCAL_MINE_LOCK_PATH);
+      unlinkSync3(LOCAL_MINE_LOCK_PATH);
     } catch {
       return { triggered: false, reason: "lock-exists" };
     }
@@ -695,27 +818,27 @@ function maybeAutoMineLocal() {
   if (!launcher)
     return { triggered: false, reason: "no-hivemind-bin" };
   try {
-    mkdirSync4(HIVEMIND_DIR, { recursive: true });
-    const fd = openSync(LOCAL_MINE_LOCK_PATH, "wx");
-    closeSync(fd);
+    mkdirSync5(HIVEMIND_DIR, { recursive: true });
+    const fd = openSync2(LOCAL_MINE_LOCK_PATH, "wx");
+    closeSync2(fd);
   } catch {
     return { triggered: false, reason: "lock-acquire-failed" };
   }
   try {
-    mkdirSync4(join6(HOME, ".claude", "hooks"), { recursive: true });
-    const out = openSync(LOG_PATH, "a");
+    mkdirSync5(join7(HOME, ".claude", "hooks"), { recursive: true });
+    const out = openSync2(LOG_PATH, "a");
     const [cmd, args] = launcher.kind === "node-script" ? [process.execPath, [launcher.path, "skillify", "mine-local"]] : [launcher.path, ["skillify", "mine-local"]];
     const child = spawn(cmd, args, {
       detached: true,
       stdio: ["ignore", out, out],
       env: process.env
     });
-    closeSync(out);
+    closeSync2(out);
     child.unref();
     return { triggered: true };
   } catch {
     try {
-      unlinkSync2(LOCAL_MINE_LOCK_PATH);
+      unlinkSync3(LOCAL_MINE_LOCK_PATH);
     } catch {
     }
     return { triggered: false, reason: "spawn-failed" };
@@ -724,13 +847,13 @@ function maybeAutoMineLocal() {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -740,18 +863,18 @@ function readStdin() {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync5 } from "node:fs";
-import { dirname as dirname3, join as join7 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname3, join as join8 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
+    const pluginJson = join8(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync5(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join8(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -766,9 +889,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join7(dir, "package.json");
+    const candidate = join8(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -784,8 +907,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 // dist/src/hooks/shared/autoupdate.js
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join8 } from "node:path";
-var log3 = (msg) => log("autoupdate", msg);
+import { join as join9 } from "node:path";
+var log4 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn2(cmd, args, {
     detached: true,
@@ -800,7 +923,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join8(dir, "hivemind");
+    const candidate = join9(dir, "hivemind");
     if (existsSync5(candidate))
       return candidate;
   }
@@ -808,41 +931,41 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log3(`agent=${opts.agent} entered`);
+  log4(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log3(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log3(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log3(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log3(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync10, readFileSync as readFileSync8, writeFileSync as writeFileSync6, mkdirSync as mkdirSync7, renameSync as renameSync3, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync4 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { dirname as dirname5, join as join13 } from "node:path";
+import { existsSync as existsSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync7, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync5 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { dirname as dirname5, join as join14 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync6, mkdirSync as mkdirSync5, readFileSync as readFileSync6, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join9 } from "node:path";
+import { existsSync as existsSync6, mkdirSync as mkdirSync6, readFileSync as readFileSync7, readdirSync as readdirSync2, statSync as statSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join10 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -908,29 +1031,29 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync8, lstatSync, mkdirSync as mkdirSync6, readFileSync as readFileSync7, renameSync as renameSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { dirname as dirname4, join as join11 } from "node:path";
+import { existsSync as existsSync8, lstatSync, mkdirSync as mkdirSync7, readFileSync as readFileSync8, renameSync as renameSync3, unlinkSync as unlinkSync4, writeFileSync as writeFileSync6 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { dirname as dirname4, join as join12 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync7, renameSync } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join10 } from "node:path";
+import { existsSync as existsSync7, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join11 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join10(homedir7(), ".deeplake", "state");
-  const legacy = join10(root, "skilify");
-  const current = join10(root, "skillify");
+  const root = join11(homedir8(), ".deeplake", "state");
+  const legacy = join11(root, "skilify");
+  const current = join11(root, "skillify");
   if (!existsSync7(legacy))
     return;
   if (existsSync7(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -947,7 +1070,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join11(homedir8(), ".deeplake", "state", "skillify", "pulled.json");
+  return join12(homedir9(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -955,7 +1078,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync7(path, "utf-8");
+    raw = readFileSync8(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -1002,10 +1125,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync6(dirname4(path), { recursive: true });
+  mkdirSync7(dirname4(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync5(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  writeFileSync6(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -1030,7 +1153,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync3(path);
+      unlinkSync4(path);
     } catch {
     }
   }
@@ -1040,7 +1163,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync8(join11(e.installRoot, e.dirName))) {
+    if (existsSync8(join12(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -1054,25 +1177,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync9 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync9(join12(home, ".codex"));
-  const piInstalled = existsSync9(join12(home, ".pi", "agent"));
-  const hermesInstalled = existsSync9(join12(home, ".hermes"));
+  const codexInstalled = existsSync9(join13(home, ".codex"));
+  const piInstalled = existsSync9(join13(home, ".pi", "agent"));
+  const hermesInstalled = existsSync9(join13(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join12(home, ".agents", "skills"));
+    out.push(join13(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join12(home, ".hermes", "skills"));
+    out.push(join13(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join12(home, ".pi", "agent", "skills"));
+    out.push(join13(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir9()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir10()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -1116,15 +1239,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join13(homedir10(), ".claude", "skills");
+    return join14(homedir11(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join13(cwd, ".claude", "skills");
+  return join14(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join13(root, dirName);
+    const link = join14(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -1146,13 +1269,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync4(link);
+        unlinkSync5(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync7(dirname5(link), { recursive: true });
+      mkdirSync8(dirname5(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -1167,7 +1290,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join13(entry.installRoot, entry.dirName);
+    const canonical = join14(entry.installRoot, entry.dirName);
     if (!existsSync10(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -1281,7 +1404,7 @@ function readLocalVersion(path) {
   if (!existsSync10(path))
     return null;
   try {
-    const text = readFileSync8(path, "utf-8");
+    const text = readFileSync9(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1376,8 +1499,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join13(root, dirName);
-    const skillFile = join13(skillDir, "SKILL.md");
+    const skillDir = join14(root, dirName);
+    const skillFile = join14(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1388,14 +1511,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync7(skillDir, { recursive: true });
+      mkdirSync8(skillDir, { recursive: true });
       if (existsSync10(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync6(skillFile, renderSkillFile(row));
+      writeFileSync7(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -1437,7 +1560,7 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/auto-pull.js
-var log4 = (msg) => log("skillify-autopull", msg);
+var log5 = (msg) => log("skillify-autopull", msg);
 var DEFAULT_TIMEOUT_MS = 5e3;
 function withTimeout(p, ms) {
   let timer = null;
@@ -1453,13 +1576,13 @@ function withTimeout(p, ms) {
 }
 async function autoPullSkills(deps = {}) {
   if (process.env.HIVEMIND_AUTOPULL_DISABLED === "1") {
-    log4("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
+    log5("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
     return { pulled: 0, skipped: true, reason: "disabled" };
   }
   const loadFn = deps.loadConfigFn ?? loadConfig;
   const config = loadFn();
   if (!config) {
-    log4("skipped: not logged in");
+    log5("skipped: not logged in");
     return { pulled: 0, skipped: true, reason: "not-logged-in" };
   }
   let query;
@@ -1481,16 +1604,16 @@ async function autoPullSkills(deps = {}) {
       dryRun: false,
       force: false
     }), timeoutMs);
-    log4(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
+    log5(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
     return { pulled: summary.wrote, skipped: false };
   } catch (e) {
-    log4(`pull failed (swallowed): ${e?.message ?? e}`);
+    log5(`pull failed (swallowed): ${e?.message ?? e}`);
     return { pulled: 0, skipped: true, reason: "error" };
   }
 }
 
 // dist/src/hooks/cursor/session-start.js
-var log5 = (msg) => log("cursor-session-start", msg);
+var log6 = (msg) => log("cursor-session-start", msg);
 var __bundleDir = dirname6(fileURLToPath2(import.meta.url));
 var context = `DEEPLAKE MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
 
@@ -1556,11 +1679,11 @@ async function main() {
   const cwd = resolveCwd(input);
   const creds = loadCredentials();
   if (!creds?.token) {
-    log5("no credentials found");
+    log6("no credentials found");
     const auto = maybeAutoMineLocal();
-    log5(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
+    log6(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
-    log5(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    log6(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
   }
   await autoUpdate(creds, { agent: "cursor" });
   const current = getInstalledVersion(__bundleDir, ".claude-plugin");
@@ -1576,14 +1699,14 @@ async function main() {
         await api.ensureTable();
         await api.ensureSessionsTable(sessionsTable);
         await createPlaceholder(api, table, sessionId, cwd, config.userName, config.orgName, config.workspaceId, pluginVersion);
-        log5("placeholder created");
+        log6("placeholder created");
       }
     } catch (e) {
-      log5(`placeholder failed: ${e.message}`);
+      log6(`placeholder failed: ${e.message}`);
     }
   }
   const pullResult = await autoPullSkills();
-  log5(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
+  log6(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
   let versionNotice = "";
   if (current)
     versionNotice = `
@@ -1597,6 +1720,6 @@ Not logged in to Deeplake. Run: hivemind login${localMinedNote}${versionNotice}`
   console.log(JSON.stringify({ additional_context: additionalContext }));
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log6(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/cursor/bundle/shell/deeplake-shell.js
+++ b/cursor/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join12(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join12(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join12(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -66870,7 +66870,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms3) {
-  return new Promise((resolve6) => setTimeout(resolve6, ms3));
+  return new Promise((resolve5) => setTimeout(resolve5, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +66900,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve6) => this.waiting.push(resolve6));
+    await new Promise((resolve5) => this.waiting.push(resolve5));
   }
   release() {
     this.active--;
@@ -67259,7 +67259,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join10 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67689,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join7 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67704,105 +67704,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
-import { join as join7, resolve as resolve4 } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join7(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m26) => log("embed-client", m26);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path2, home) {
-  const r10 = resolve4(path2);
-  const h18 = resolve4(home);
-  return r10.startsWith(h18 + "/") || r10 === h18;
-}
-function writeQueue(q17) {
-  const path2 = queuePath();
-  const home = resolve4(homedir3());
-  if (!_isQueuePathInsideHome(path2, home)) {
-    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v27 = await this.embedAttempt(text, kind);
+    if (v27 !== "recycled")
+      return v27;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join7(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path2}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
-  renameSync(tmp, path2);
-}
-async function withQueueLock(fn4) {
-  const path2 = lockPath();
-  mkdirSync2(join7(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path2, "wx", 384);
-      break;
-    } catch (e6) {
-      const code = e6.code;
-      if (code !== "EEXIST")
-        throw e6;
-      try {
-        const age = Date.now() - statSync2(path2).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path2);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e6) {
+      const err = e6 instanceof Error ? e6.message : String(e6);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn4();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync4(this.socketPath))
+        return;
+      await new Promise((r10) => setTimeout(r10, 50));
+    }
   }
-  try {
-    return fn4();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e6) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      return false;
     }
-    try {
-      unlinkSync(path2);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a15, b26) {
-  if (a15.id !== b26.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
-}
-async function enqueueNotification(n24) {
-  await withQueueLock(() => {
-    const q17 = readQueue();
-    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s10 = await this.connectOnce();
+      s10.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s10 = await this.waitForSocket();
+        s10.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve5, reject) => {
+      const sock = connect(this.socketPath);
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to3);
+        resolve5(sock);
+      });
+      sock.once("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e6) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q17.queue.push(n24);
-    writeQueue(q17);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync4(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve5, reject) => {
+      let buf = "";
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl3 = buf.indexOf("\n");
+        if (nl3 === -1)
+          return;
+        const line = buf.slice(0, nl3);
+        clearTimeout(to3);
+        try {
+          resolve5(JSON.parse(line));
+        } catch (e6) {
+          reject(e6);
+        }
+      });
+      sock.on("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+      sock.on("end", () => {
+        clearTimeout(to3);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms3) {
+  return new Promise((r10) => setTimeout(r10, ms3));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v27 of vec) {
+    if (!Number.isFinite(v27))
+      return "NULL";
+    parts.push(String(v27));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -67812,7 +68091,7 @@ import { join as join9 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname as dirname4, join as join8 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
@@ -67822,7 +68101,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path2 = _configPath();
-  if (!existsSync4(path2)) {
+  if (!existsSync5(path2)) {
     _cache = {};
     return _cache;
   }
@@ -67840,11 +68119,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path2 = _configPath();
   const dir = dirname4(path2);
-  if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync5(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path2);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -67921,403 +68200,6 @@ function embeddingsStatus() {
 }
 function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
-}
-
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join10(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m26) => log("embed-client", m26);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync5(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v27 = await this.embedAttempt(text, kind);
-    if (v27 !== "recycled")
-      return v27;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e6) {
-      const err = e6 instanceof Error ? e6.message : String(e6);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync5(this.socketPath))
-        return;
-      await new Promise((r10) => setTimeout(r10, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e6) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync5(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e6) => {
-      log4(`enqueue embed-deps-missing failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync5(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s10 = await this.connectOnce();
-      s10.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s10 = await this.waitForSocket();
-        s10.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve6, reject) => {
-      const sock = connect(this.socketPath);
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to3);
-        resolve6(sock);
-      });
-      sock.once("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e6) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync5(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync5(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve6, reject) => {
-      let buf = "";
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl3 = buf.indexOf("\n");
-        if (nl3 === -1)
-          return;
-        const line = buf.slice(0, nl3);
-        clearTimeout(to3);
-        try {
-          resolve6(JSON.parse(line));
-        } catch (e6) {
-          reject(e6);
-        }
-      });
-      sock.on("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-      sock.on("end", () => {
-        clearTimeout(to3);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms3) {
-  return new Promise((r10) => setTimeout(r10, ms3));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v27 of vec) {
-    if (!Number.isFinite(v27))
-      return "NULL";
-    parts.push(String(v27));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/hooks/virtual-table-query.js
@@ -68412,7 +68294,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68978,7 +68860,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve5 } from "path";
+import { normalize, resolve as resolve4 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69916,7 +69798,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync5 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69938,12 +69820,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve5,
+  resolve: resolve4,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync5(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69963,11 +69845,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join11 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/cursor/bundle/shell/deeplake-shell.js
+++ b/cursor/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join14(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join14(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join14(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join7 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join8(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join7(getIndexMarkerDir(), `${markerKey}.json`);
+  return join8(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66942,6 +66942,24 @@ async function enqueueNotification(n24) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join7 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join7(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join7(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66978,11 +66996,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c15 = loadCredentials();
+    if (c15?.orgName && c15?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c15.orgName)}/workspace/${encodeURIComponent(c15.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -67382,7 +67410,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join12 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67812,9 +67840,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join8 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join9 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67828,7 +67856,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join9(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -68019,7 +68047,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -68032,11 +68060,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -68087,7 +68115,7 @@ var EmbedClient = class {
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -68104,7 +68132,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -68123,7 +68151,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68209,15 +68237,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname4, join as join9 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname4, join as join10 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join10(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68229,7 +68257,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path2, "utf-8");
+    const raw = readFileSync6(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68243,9 +68271,9 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path2);
   _cache = merged;
   return merged;
@@ -68295,7 +68323,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join11(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68417,7 +68445,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -69921,7 +69949,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync7 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69948,7 +69976,7 @@ var parser = new YargsParser({
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync7(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69968,11 +69996,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join13 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join13(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/cursor/bundle/shell/deeplake-shell.js
+++ b/cursor/bundle/shell/deeplake-shell.js
@@ -66991,13 +66991,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });

--- a/cursor/bundle/shell/deeplake-shell.js
+++ b/cursor/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join12(output, replacement);
+        return join13(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join12(output, rule.append(self2.options));
+          output = join13(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join12(output, replacement) {
+    function join13(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join6 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join6(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join6(getIndexMarkerDir(), `${markerKey}.json`);
+  return join7(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66841,6 +66841,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
+import { join as join6, resolve as resolve4 } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join6(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path2, home) {
+  const r10 = resolve4(path2);
+  const h18 = resolve4(home);
+  return r10.startsWith(h18 + "/") || r10 === h18;
+}
+function writeQueue(q17) {
+  const path2 = queuePath();
+  const home = resolve4(homedir3());
+  if (!_isQueuePathInsideHome(path2, home)) {
+    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  }
+  mkdirSync(join6(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path2}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
+  renameSync(tmp, path2);
+}
+async function withQueueLock(fn4) {
+  const path2 = lockPath();
+  mkdirSync(join6(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path2, "wx", 384);
+      break;
+    } catch (e6) {
+      const code = e6.code;
+      if (code !== "EEXIST")
+        throw e6;
+      try {
+        const age = Date.now() - statSync2(path2).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path2);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn4();
+  }
+  try {
+    return fn4();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path2);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a15, b26) {
+  if (a15.id !== b26.id)
+    return false;
+  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
+}
+async function enqueueNotification(n24) {
+  await withQueueLock(() => {
+    const q17 = readQueue();
+    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+      return;
+    }
+    q17.queue.push(n24);
+    writeQueue(q17);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66848,7 +66949,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -66860,7 +66961,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e6) => {
+    log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -66869,8 +66991,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms3) {
-  return new Promise((resolve5) => setTimeout(resolve5, ms3));
+function sleep2(ms3) {
+  return new Promise((resolve6) => setTimeout(resolve6, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +67022,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve5) => this.waiting.push(resolve5));
+    await new Promise((resolve6) => this.waiting.push(resolve6));
   }
   release() {
     this.active--;
@@ -66971,8 +67093,8 @@ var DeeplakeApi = class {
         lastError = e6 instanceof Error ? e6 : new Error(String(e6));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -66988,10 +67110,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -67012,7 +67135,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i11, i11 + CONCURRENCY);
       await Promise.allSettled(chunk.map((r10) => this.upsertRowSql(r10)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts3 = (/* @__PURE__ */ new Date()).toISOString();
@@ -67068,7 +67191,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e6.message}`);
+      log3(`index "${indexName}" skipped: ${e6.message}`);
     }
   }
   /**
@@ -67158,13 +67281,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -67192,9 +67315,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -67205,9 +67328,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -67220,9 +67343,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67245,9 +67368,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67259,7 +67382,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join10 } from "node:path";
+import { dirname as dirname5, join as join11 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67812,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join8 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67705,8 +67828,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m26) => log("embed-client", m26);
+var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -67782,7 +67905,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -67791,7 +67914,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e6) {
       const err = e6 instanceof Error ? e6.message : String(e6);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -67838,7 +67961,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e6) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
       return false;
     }
     const hello = resp;
@@ -67847,13 +67970,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -67896,7 +68019,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -67906,14 +68029,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -67940,7 +68063,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       const sock = connect(this.socketPath);
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -67948,7 +68071,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to3);
-        resolve5(sock);
+        resolve6(sock);
       });
       sock.once("error", (e6) => {
         clearTimeout(to3);
@@ -67959,16 +68082,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -67978,10 +68101,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -67993,14 +68116,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68018,7 +68141,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync4(this.socketPath))
         continue;
@@ -68030,7 +68153,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       let buf = "";
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -68045,7 +68168,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl3);
         clearTimeout(to3);
         try {
-          resolve5(JSON.parse(line));
+          resolve6(JSON.parse(line));
         } catch (e6) {
           reject(e6);
         }
@@ -68062,7 +68185,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms3) {
+function sleep3(ms3) {
   return new Promise((r10) => setTimeout(r10, ms3));
 }
 function isTransformersMissingError(err) {
@@ -68086,15 +68209,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join9 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join10 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname as dirname4, join as join8 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname as dirname4, join as join9 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68106,7 +68229,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path2, "utf-8");
+    const raw = readFileSync5(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68120,10 +68243,10 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path2);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -68172,7 +68295,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join9(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68294,7 +68417,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68860,7 +68983,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve4 } from "path";
+import { normalize, resolve as resolve5 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69798,7 +69921,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync5 } from "fs";
+import { readFileSync as readFileSync6 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69820,12 +69943,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve4,
+  resolve: resolve5,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync5(path2, "utf8"));
+      return JSON.parse(readFileSync6(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69845,11 +69968,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join11 } from "node:path";
+import { dirname as dirname6, join as join12 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/cursor/bundle/wiki-worker.js
+++ b/cursor/bundle/wiki-worker.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // dist/src/hooks/cursor/wiki-worker.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync4, rmSync } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync3, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join6 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // dist/src/hooks/summary-state.js
@@ -154,9 +154,9 @@ async function uploadSummary(query2, params) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync2, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync as writeSync2, unlinkSync as unlinkSync2, existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join3 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -169,105 +169,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, renameSync as renameSync2, mkdirSync as mkdirSync2, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join3, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
-var log2 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join3(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log2 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath2() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync2(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log2(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync2(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join3(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync2(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath2();
-  mkdirSync2(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync2(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log2(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log2(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep(delay);
     }
   }
-  if (fd === null) {
-    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync2(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync2(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log2(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log2(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync2(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log2(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync2(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync2(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log2(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync2(this.pidPath, "wx", 384);
+      writeSync2(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync2(this.pidPath, "wx", 384);
+          writeSync2(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync2(this.daemonEntry)) {
+      log2(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log2(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync2(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync2(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync2(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -277,7 +543,7 @@ import { join as join5 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync3, renameSync as renameSync3, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join4 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join4(homedir4(), ".deeplake", "config.json");
@@ -287,7 +553,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     _cache = {};
     return _cache;
   }
@@ -305,11 +571,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync2(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync3(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync3(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -388,390 +654,6 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync3(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log3(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync3(this.pidPath, "wx", 384);
-      writeSync2(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync3(this.pidPath, "wx", 384);
-          writeSync2(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync3(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep2(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync3(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep2(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/utils/client-header.js
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
@@ -783,13 +665,13 @@ function deeplakeClientHeader() {
 
 // dist/src/hooks/cursor/wiki-worker.js
 var dlog2 = (msg) => log("cursor-wiki-worker", msg);
-var cfg = JSON.parse(readFileSync5(process.argv[2], "utf-8"));
+var cfg = JSON.parse(readFileSync4(process.argv[2], "utf-8"));
 var tmpDir = cfg.tmpDir;
-var tmpJsonl = join7(tmpDir, "session.jsonl");
-var tmpSummary = join7(tmpDir, "summary.md");
+var tmpJsonl = join6(tmpDir, "session.jsonl");
+var tmpSummary = join6(tmpDir, "summary.md");
 function wlog(msg) {
   try {
-    mkdirSync4(cfg.hooksDir, { recursive: true });
+    mkdirSync3(cfg.hooksDir, { recursive: true });
     appendFileSync2(cfg.wikiLog, `[${(/* @__PURE__ */ new Date()).toISOString().replace("T", " ").slice(0, 19)}] wiki-worker(${cfg.sessionId}): ${msg}
 `);
   } catch {
@@ -821,7 +703,7 @@ async function query(sql, retries = 4) {
       const base = Math.min(3e4, 2e3 * Math.pow(2, attempt));
       const delay = base + Math.floor(Math.random() * 1e3);
       wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise((resolve2) => setTimeout(resolve2, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       continue;
     }
     throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
@@ -847,7 +729,7 @@ async function main() {
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc2(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
-    writeFileSync4(tmpJsonl, jsonlContent);
+    writeFileSync3(tmpJsonl, jsonlContent);
     wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
     let prevOffset = 0;
     try {
@@ -857,7 +739,7 @@ async function main() {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
-        writeFileSync4(tmpSummary, existing);
+        writeFileSync3(tmpSummary, existing);
         wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch {
@@ -883,14 +765,14 @@ async function main() {
       wlog(`cursor-agent --print failed: ${e.status ?? e.message}`);
     }
     if (existsSync4(tmpSummary)) {
-      const text = readFileSync5(tmpSummary, "utf-8");
+      const text = readFileSync4(tmpSummary, "utf-8");
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         let embedding = null;
         if (!embeddingsDisabled()) {
           try {
-            const daemonEntry = join7(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
+            const daemonEntry = join6(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
             embedding = await new EmbedClient({ daemonEntry }).embed(text, "document");
           } catch (e) {
             wlog(`summary embedding failed, writing NULL: ${e.message}`);

--- a/hermes/bundle/capture.js
+++ b/hermes/bundle/capture.js
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -175,7 +175,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +205,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -569,9 +569,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -584,105 +584,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v of vec) {
+    if (!Number.isFinite(v))
+      return "NULL";
+    parts.push(String(v));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -692,7 +971,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -702,7 +981,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -720,11 +999,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -803,414 +1082,17 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v of vec) {
-    if (!Number.isFinite(v))
-      return "NULL";
-    parts.push(String(v));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
-}
-
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { basename, dirname as dirname2, join as join7 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join7(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1231,7 +1113,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync2(link);
+      statSync(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1251,14 +1133,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync3(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync3(tmp, link);
+    renameSync2(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1267,53 +1149,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/hermes/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
+import { dirname as dirname6, join as join17 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join8(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+function lockPath(sessionId) {
+  return join8(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync5(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
-  renameSync4(tmp, p);
+  writeFileSync3(tmp, JSON.stringify(state));
+  renameSync3(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync4(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync3(rmwLock, "wx");
+      fd = openSync2(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync2(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1325,9 +1207,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync3(fd);
+    closeSync2(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync2(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1362,29 +1244,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
-  const p = lockPath2(sessionId);
+  mkdirSync4(STATE_DIR, { recursive: true });
+  const p = lockPath(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync2(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync3(p, "wx");
+    const fd = openSync2(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync3(fd);
+      closeSync2(fd);
     }
     return true;
   } catch (e) {
@@ -1395,7 +1277,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync2(lockPath(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1406,20 +1288,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/hermes/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join11 } from "node:path";
+import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
+import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join9 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join9(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync5(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1429,18 +1311,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname3, join as join10 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1455,9 +1337,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join10(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1471,8 +1353,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/hermes/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".hermes", "hooks"));
+var HOME = homedir8();
+var wikiLogger = makeWikiLogger(join11(HOME, ".hermes", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1534,11 +1416,11 @@ function findHermesBin() {
 function spawnHermesWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync6(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join11(tmpDir, "config.json");
+  writeFileSync4(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1554,11 +1436,11 @@ function spawnHermesWikiWorker(opts) {
     hermesProvider: process.env.HIVEMIND_HERMES_PROVIDER ?? "openrouter",
     hermesModel: process.env.HIVEMIND_HERMES_MODEL ?? "anthropic/claude-haiku-4-5",
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".hermes", "hooks"),
+    hooksDir: join11(HOME, ".hermes", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join11(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1572,15 +1454,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join14 } from "node:path";
-import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join13 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir10, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { homedir as homedir9 } from "node:os";
+import { join as join12 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1592,7 +1474,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir10();
+  const home = homedir9();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1601,54 +1483,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join13(home, ".claude", "local", "claude"),
+        join12(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join13(home, ".npm-global", "bin", "claude"),
-        join13(home, ".local", "bin", "claude"),
+        join12(home, ".npm-global", "bin", "claude"),
+        join12(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join13(home, ".claude", "local", "claude");
+      ]) ?? join12(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join13(home, ".npm-global", "bin", "codex"),
-        join13(home, ".local", "bin", "codex"),
+        join12(home, ".npm-global", "bin", "codex"),
+        join12(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join13(home, ".npm-global", "bin", "cursor-agent"),
-        join13(home, ".local", "bin", "cursor-agent"),
+        join12(home, ".npm-global", "bin", "cursor-agent"),
+        join12(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join13(home, ".local", "bin", "hermes"),
+        join12(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join13(home, ".npm-global", "bin", "hermes"),
+        join12(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join13(home, ".local", "bin", "hermes");
+      ]) ?? join12(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join13(home, ".local", "bin", "pi"),
+        join12(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join13(home, ".npm-global", "bin", "pi"),
+        join12(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join13(home, ".local", "bin", "pi");
+      ]) ?? join12(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir11();
-var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir10();
+var SKILLIFY_LOG = join13(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync7(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1656,11 +1538,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join13(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join14(tmpDir, "config.json");
-  writeFileSync6(configFile, JSON.stringify({
+  const configFile = join13(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1690,7 +1572,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join14(bundleDir, "skillify-worker.js");
+  const workerPath = join13(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1699,31 +1581,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync6, writeSync as writeSync3, mkdirSync as mkdirSync8, renameSync as renameSync5, existsSync as existsSync9, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir13 } from "node:os";
+import { homedir as homedir12 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join16, basename as basename2 } from "node:path";
+import { join as join15, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { existsSync as existsSync8, renameSync as renameSync4 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join15(homedir12(), ".deeplake", "state");
-  const legacy = join15(root, "skilify");
-  const current = join15(root, "skillify");
+  const root = join14(homedir11(), ".deeplake", "state");
+  const legacy = join14(root, "skilify");
+  const current = join14(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
     return;
   try {
-    renameSync5(legacy, current);
+    renameSync4(legacy, current);
     dlog2(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -1737,17 +1619,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join15(homedir12(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.json`);
+  return join15(STATE_DIR2, `${projectKey}.json`);
 }
-function lockPath3(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.lock`);
+function lockPath2(projectKey) {
+  return join15(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1796,35 +1678,35 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync8(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync8(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(state, null, 2));
-  renameSync6(tmp, p);
+  writeFileSync6(tmp, JSON.stringify(state, null, 2));
+  renameSync5(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
-  const rmw = lockPath3(projectKey) + ".rmw";
+  mkdirSync8(STATE_DIR2, { recursive: true });
+  const rmw = lockPath2(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync4(rmw, "wx");
+      fd = openSync3(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync4(rmw);
+          unlinkSync3(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1836,9 +1718,9 @@ function withRmwLock2(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync4(fd);
+    closeSync3(fd);
     try {
-      unlinkSync4(rmw);
+      unlinkSync3(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1871,29 +1753,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
-  const p = lockPath3(projectKey);
+  mkdirSync8(STATE_DIR2, { recursive: true });
+  const p = lockPath2(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync4(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync4(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync3(fd, String(Date.now()));
     } finally {
-      closeSync4(fd);
+      closeSync3(fd);
     }
     return true;
   } catch {
@@ -1901,26 +1783,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath3(projectKey);
+  const p = lockPath2(projectKey);
   try {
-    unlinkSync4(p);
+    unlinkSync3(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { join as join17 } from "node:path";
-var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join17(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync7 } from "node:fs";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
+var STATE_DIR3 = join16(homedir13(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join16(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync8(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1971,9 +1853,9 @@ function tryStopCounterTrigger(opts) {
 }
 
 // dist/src/hooks/hermes/capture.js
-var log5 = (msg) => log("hermes-capture", msg);
+var log4 = (msg) => log("hermes-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1997,7 +1879,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log5("no config");
+    log4("no config");
     return;
   }
   const sessionId = input.session_id ?? `hermes-${Date.now()}`;
@@ -2017,14 +1899,14 @@ async function main() {
   if (event === "pre_llm_call") {
     const prompt = pickString(extra.prompt, extra.user_message, extra.message?.content);
     if (!prompt) {
-      log5(`pre_llm_call: no prompt found in extra`);
+      log4(`pre_llm_call: no prompt found in extra`);
       return;
     }
-    log5(`user session=${sessionId}`);
+    log4(`user session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "user_message", content: prompt };
   } else if (event === "post_tool_call" && typeof input.tool_name === "string") {
     const toolResponse = extra.tool_result ?? extra.tool_output ?? extra.result ?? extra.output;
-    log5(`tool=${input.tool_name} session=${sessionId}`);
+    log4(`tool=${input.tool_name} session=${sessionId}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -2036,18 +1918,18 @@ async function main() {
   } else if (event === "post_llm_call") {
     const text = pickString(extra.response, extra.assistant_message, extra.message?.content);
     if (!text) {
-      log5(`post_llm_call: no response found in extra`);
+      log4(`post_llm_call: no response found in extra`);
       return;
     }
-    log5(`assistant session=${sessionId}`);
+    log4(`assistant session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "assistant_message", content: text };
   } else {
-    log5(`unknown/unhandled event: ${event}, skipping`);
+    log4(`unknown/unhandled event: ${event}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, sessionId);
   const line = JSON.stringify(entry);
-  log5(`writing to ${sessionPath}`);
+  log4(`writing to ${sessionPath}`);
   const projectName = cwd.split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -2058,14 +1940,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log5("table missing, creating and retrying");
+      log4("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log5("capture ok \u2192 cloud");
+  log4("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(sessionId, cwd, config);
   if (event === "post_llm_call" && process.env.HIVEMIND_WIKI_WORKER !== "1" && process.env.HIVEMIND_SKILLIFY_WORKER !== "1") {
     tryStopCounterTrigger({
@@ -2086,7 +1968,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -2099,17 +1981,17 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log5(`periodic spawn failed: ${e.message}`);
+      log4(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch {
       }
     }
   } catch (e) {
-    log5(`periodic trigger error: ${e.message}`);
+    log4(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/hermes/bundle/capture.js
+++ b/hermes/bundle/capture.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -247,6 +247,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -283,11 +301,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -692,9 +720,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -708,7 +736,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -899,7 +927,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -912,11 +940,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -967,7 +995,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -984,7 +1012,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1003,7 +1031,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1089,15 +1117,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1109,7 +1137,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1123,9 +1151,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1175,7 +1203,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1206,16 +1234,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { basename, dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync5, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { basename, dirname as dirname2, join as join9 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join9(homedir8(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join8(pluginDir, "node_modules");
+  const link = join9(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1256,7 +1284,7 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync4(parent, { recursive: true });
+      mkdirSync5(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
@@ -1272,40 +1300,40 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/hermes/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join18 } from "node:path";
+import { dirname as dirname6, join as join19 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { join as join9 } from "node:path";
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync5, writeSync as writeSync2, mkdirSync as mkdirSync6, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync4, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { join as join10 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join10(homedir9(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.json`);
+  return join10(STATE_DIR, `${sessionId}.json`);
 }
 function lockPath2(sessionId) {
-  return join9(STATE_DIR, `${sessionId}.lock`);
+  return join10(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync6(p, "utf-8"));
+    return JSON.parse(readFileSync7(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(state));
+  writeFileSync5(tmp, JSON.stringify(state));
   renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1318,7 +1346,7 @@ function withRmwLock(sessionId, fn) {
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmwLock);
+          unlinkSync4(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1332,7 +1360,7 @@ function withRmwLock(sessionId, fn) {
   } finally {
     closeSync3(fd);
     try {
-      unlinkSync3(rmwLock);
+      unlinkSync4(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1367,18 +1395,18 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync5(STATE_DIR, { recursive: true });
+  mkdirSync6(STATE_DIR, { recursive: true });
   const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
@@ -1400,7 +1428,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync3(lockPath2(sessionId));
+    unlinkSync4(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1411,20 +1439,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/hermes/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join12 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
-import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join13 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8 } from "node:fs";
+import { homedir as homedir10, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join10 } from "node:path";
+import { mkdirSync as mkdirSync7, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join11 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join10(hooksDir, filename);
+  const path = join11(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync6(hooksDir, { recursive: true });
+        mkdirSync7(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1434,18 +1462,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync7 } from "node:fs";
-import { dirname as dirname3, join as join11 } from "node:path";
+import { readFileSync as readFileSync8 } from "node:fs";
+import { dirname as dirname3, join as join12 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
+    const pluginJson = join12(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync8(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync8(join12(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1460,9 +1488,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join11(dir, "package.json");
+    const candidate = join12(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync8(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1476,8 +1504,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/hermes/spawn-wiki-worker.js
-var HOME = homedir9();
-var wikiLogger = makeWikiLogger(join12(HOME, ".hermes", "hooks"));
+var HOME = homedir10();
+var wikiLogger = makeWikiLogger(join13(HOME, ".hermes", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1539,11 +1567,11 @@ function findHermesBin() {
 function spawnHermesWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true });
+  const tmpDir = join13(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync8(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join12(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join13(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1559,11 +1587,11 @@ function spawnHermesWikiWorker(opts) {
     hermesProvider: process.env.HIVEMIND_HERMES_PROVIDER ?? "openrouter",
     hermesModel: process.env.HIVEMIND_HERMES_MODEL ?? "anthropic/claude-haiku-4-5",
     wikiLog: WIKI_LOG,
-    hooksDir: join12(HOME, ".hermes", "hooks"),
+    hooksDir: join13(HOME, ".hermes", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join12(bundleDir, "wiki-worker.js");
+  const workerPath = join13(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1577,15 +1605,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join14 } from "node:path";
-import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join15 } from "node:path";
+import { writeFileSync as writeFileSync7, mkdirSync as mkdirSync9, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir12, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir10 } from "node:os";
-import { join as join13 } from "node:path";
+import { homedir as homedir11 } from "node:os";
+import { join as join14 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1597,7 +1625,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir10();
+  const home = homedir11();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1606,54 +1634,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join13(home, ".claude", "local", "claude"),
+        join14(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join13(home, ".npm-global", "bin", "claude"),
-        join13(home, ".local", "bin", "claude"),
+        join14(home, ".npm-global", "bin", "claude"),
+        join14(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join13(home, ".claude", "local", "claude");
+      ]) ?? join14(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join13(home, ".npm-global", "bin", "codex"),
-        join13(home, ".local", "bin", "codex"),
+        join14(home, ".npm-global", "bin", "codex"),
+        join14(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join13(home, ".npm-global", "bin", "cursor-agent"),
-        join13(home, ".local", "bin", "cursor-agent"),
+        join14(home, ".npm-global", "bin", "cursor-agent"),
+        join14(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join13(home, ".local", "bin", "hermes"),
+        join14(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join13(home, ".npm-global", "bin", "hermes"),
+        join14(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join13(home, ".local", "bin", "hermes");
+      ]) ?? join14(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join13(home, ".local", "bin", "pi"),
+        join14(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join13(home, ".npm-global", "bin", "pi"),
+        join14(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join13(home, ".local", "bin", "pi");
+      ]) ?? join14(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir11();
-var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir12();
+var SKILLIFY_LOG = join15(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync9(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1661,11 +1689,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join15(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync9(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join14(tmpDir, "config.json");
-  writeFileSync6(configFile, JSON.stringify({
+  const configFile = join15(tmpDir, "config.json");
+  writeFileSync7(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1695,7 +1723,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join14(bundleDir, "skillify-worker.js");
+  const workerPath = join15(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1704,25 +1732,25 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
+import { readFileSync as readFileSync9, writeFileSync as writeFileSync8, writeSync as writeSync3, mkdirSync as mkdirSync10, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync5, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir13 } from "node:os";
+import { homedir as homedir14 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join16, basename as basename2 } from "node:path";
+import { join as join17, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
 import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
-import { homedir as homedir12 } from "node:os";
-import { join as join15 } from "node:path";
+import { homedir as homedir13 } from "node:os";
+import { join as join16 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join15(homedir12(), ".deeplake", "state");
-  const legacy = join15(root, "skilify");
-  const current = join15(root, "skillify");
+  const root = join16(homedir13(), ".deeplake", "state");
+  const legacy = join16(root, "skilify");
+  const current = join16(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
@@ -1742,17 +1770,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join17(homedir14(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.json`);
+  return join17(STATE_DIR2, `${projectKey}.json`);
 }
 function lockPath3(projectKey) {
-  return join16(STATE_DIR2, `${projectKey}.lock`);
+  return join17(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1801,22 +1829,22 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync8(p, "utf-8"));
+    return JSON.parse(readFileSync9(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync7(tmp, JSON.stringify(state, null, 2));
+  writeFileSync8(tmp, JSON.stringify(state, null, 2));
   renameSync6(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
@@ -1829,7 +1857,7 @@ function withRmwLock2(projectKey, fn) {
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync4(rmw);
+          unlinkSync5(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1843,7 +1871,7 @@ function withRmwLock2(projectKey, fn) {
   } finally {
     closeSync4(fd);
     try {
-      unlinkSync4(rmw);
+      unlinkSync5(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1876,18 +1904,18 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync9(STATE_DIR2, { recursive: true });
+  mkdirSync10(STATE_DIR2, { recursive: true });
   const p = lockPath3(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync9(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync4(p);
+      unlinkSync5(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
@@ -1908,24 +1936,24 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
 function releaseWorkerLock(projectKey) {
   const p = lockPath3(projectKey);
   try {
-    unlinkSync4(p);
+    unlinkSync5(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
-import { homedir as homedir14 } from "node:os";
-import { join as join17 } from "node:path";
-var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join17(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync11, readFileSync as readFileSync10, writeFileSync as writeFileSync9 } from "node:fs";
+import { homedir as homedir15 } from "node:os";
+import { join as join18 } from "node:path";
+var STATE_DIR3 = join18(homedir15(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join18(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync10(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1978,7 +2006,7 @@ function tryStopCounterTrigger(opts) {
 // dist/src/hooks/hermes/capture.js
 var log5 = (msg) => log("hermes-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join19(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";

--- a/hermes/bundle/capture.js
+++ b/hermes/bundle/capture.js
@@ -296,13 +296,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/hermes/bundle/capture.js
+++ b/hermes/bundle/capture.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -146,6 +146,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -153,7 +254,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -165,7 +266,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -174,8 +296,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +327,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -276,8 +398,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -293,10 +415,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -317,7 +440,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -373,7 +496,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -463,13 +586,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -497,9 +620,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -510,9 +633,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -525,9 +648,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -550,9 +673,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -569,9 +692,9 @@ function buildSessionPath(config, sessionId) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -585,8 +708,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -662,7 +785,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -671,7 +794,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -718,7 +841,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -727,13 +850,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -776,7 +899,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -786,14 +909,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -820,7 +943,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -828,7 +951,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -839,16 +962,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -858,10 +981,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -873,14 +996,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -898,7 +1021,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -910,7 +1033,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -925,7 +1048,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -942,7 +1065,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -966,15 +1089,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -986,7 +1109,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1000,10 +1123,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1052,7 +1175,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1083,16 +1206,16 @@ function embeddingsDisabled() {
 }
 
 // dist/src/embeddings/self-heal.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readlinkSync, renameSync as renameSync2, rmSync, symlinkSync, statSync } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { basename, dirname as dirname2, join as join7 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readlinkSync, renameSync as renameSync3, rmSync, symlinkSync, statSync as statSync2 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { basename, dirname as dirname2, join as join8 } from "node:path";
 function ensurePluginNodeModulesLink(opts) {
   if (basename(opts.bundleDir) !== "bundle") {
     return { kind: "not-bundle-layout", bundleDir: opts.bundleDir };
   }
-  const target = opts.sharedNodeModules ?? join7(homedir6(), ".hivemind", "embed-deps", "node_modules");
+  const target = opts.sharedNodeModules ?? join8(homedir7(), ".hivemind", "embed-deps", "node_modules");
   const pluginDir = dirname2(opts.bundleDir);
-  const link = join7(pluginDir, "node_modules");
+  const link = join8(pluginDir, "node_modules");
   if (!existsSync5(target)) {
     return { kind: "shared-deps-missing", target };
   }
@@ -1113,7 +1236,7 @@ function ensurePluginNodeModulesLink(opts) {
       return { kind: "already-linked", target, link };
     }
     try {
-      statSync(link);
+      statSync2(link);
       return { kind: "linked-elsewhere", link, existingTarget };
     } catch {
       try {
@@ -1133,14 +1256,14 @@ function createSymlinkAtomic(target, link) {
   try {
     const parent = dirname2(link);
     if (!existsSync5(parent))
-      mkdirSync3(parent, { recursive: true });
+      mkdirSync4(parent, { recursive: true });
     const tmp = `${link}.tmp.${process.pid}`;
     try {
       rmSync(tmp, { force: true });
     } catch {
     }
     symlinkSync(target, tmp);
-    renameSync2(tmp, link);
+    renameSync3(tmp, link);
     return { kind: "linked", target, link };
   } catch (e) {
     return { kind: "error", detail: e instanceof Error ? e.message : String(e) };
@@ -1149,53 +1272,53 @@ function createSymlinkAtomic(target, link) {
 
 // dist/src/hooks/hermes/capture.js
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname6, join as join17 } from "node:path";
+import { dirname as dirname6, join as join18 } from "node:path";
 
 // dist/src/hooks/summary-state.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync3, writeSync as writeSync2, mkdirSync as mkdirSync4, renameSync as renameSync3, existsSync as existsSync6, unlinkSync as unlinkSync2, openSync as openSync2, closeSync as closeSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join8 } from "node:path";
+import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, writeSync as writeSync2, mkdirSync as mkdirSync5, renameSync as renameSync4, existsSync as existsSync6, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join9 } from "node:path";
 var dlog = (msg) => log("summary-state", msg);
-var STATE_DIR = join8(homedir7(), ".claude", "hooks", "summary-state");
+var STATE_DIR = join9(homedir8(), ".claude", "hooks", "summary-state");
 var YIELD_BUF = new Int32Array(new SharedArrayBuffer(4));
 function statePath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.json`);
+  return join9(STATE_DIR, `${sessionId}.json`);
 }
-function lockPath(sessionId) {
-  return join8(STATE_DIR, `${sessionId}.lock`);
+function lockPath2(sessionId) {
+  return join9(STATE_DIR, `${sessionId}.lock`);
 }
 function readState(sessionId) {
   const p = statePath(sessionId);
   if (!existsSync6(p))
     return null;
   try {
-    return JSON.parse(readFileSync5(p, "utf-8"));
+    return JSON.parse(readFileSync6(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState(sessionId, state) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const p = statePath(sessionId);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(state));
-  renameSync3(tmp, p);
+  writeFileSync4(tmp, JSON.stringify(state));
+  renameSync4(tmp, p);
 }
 function withRmwLock(sessionId, fn) {
-  mkdirSync4(STATE_DIR, { recursive: true });
+  mkdirSync5(STATE_DIR, { recursive: true });
   const rmwLock = statePath(sessionId) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync2(rmwLock, "wx");
+      fd = openSync3(rmwLock, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog(`rmw lock deadline exceeded for ${sessionId}, reclaiming stale lock`);
         try {
-          unlinkSync2(rmwLock);
+          unlinkSync3(rmwLock);
         } catch (unlinkErr) {
           dlog(`stale rmw lock unlink failed for ${sessionId}: ${unlinkErr.message}`);
         }
@@ -1207,9 +1330,9 @@ function withRmwLock(sessionId, fn) {
   try {
     return fn();
   } finally {
-    closeSync2(fd);
+    closeSync3(fd);
     try {
-      unlinkSync2(rmwLock);
+      unlinkSync3(rmwLock);
     } catch (unlinkErr) {
       dlog(`rmw lock cleanup failed for ${sessionId}: ${unlinkErr.message}`);
     }
@@ -1244,29 +1367,29 @@ function shouldTrigger(state, cfg, now = Date.now()) {
   return false;
 }
 function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
-  mkdirSync4(STATE_DIR, { recursive: true });
-  const p = lockPath(sessionId);
+  mkdirSync5(STATE_DIR, { recursive: true });
+  const p = lockPath2(sessionId);
   if (existsSync6(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync5(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync6(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog(`lock file unreadable for ${sessionId}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync2(p);
+      unlinkSync3(p);
     } catch (unlinkErr) {
       dlog(`could not unlink stale lock for ${sessionId}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync2(p, "wx");
+    const fd = openSync3(p, "wx");
     try {
       writeSync2(fd, String(Date.now()));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
     return true;
   } catch (e) {
@@ -1277,7 +1400,7 @@ function tryAcquireLock(sessionId, maxAgeMs = 10 * 60 * 1e3) {
 }
 function releaseLock(sessionId) {
   try {
-    unlinkSync2(lockPath(sessionId));
+    unlinkSync3(lockPath2(sessionId));
   } catch (e) {
     if (e?.code !== "ENOENT") {
       dlog(`releaseLock unlink failed for ${sessionId}: ${e.message}`);
@@ -1288,20 +1411,20 @@ function releaseLock(sessionId) {
 // dist/src/hooks/hermes/spawn-wiki-worker.js
 import { spawn as spawn2, execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname4, join as join11 } from "node:path";
-import { writeFileSync as writeFileSync4, mkdirSync as mkdirSync6 } from "node:fs";
-import { homedir as homedir8, tmpdir as tmpdir2 } from "node:os";
+import { dirname as dirname4, join as join12 } from "node:path";
+import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7 } from "node:fs";
+import { homedir as homedir9, tmpdir as tmpdir2 } from "node:os";
 
 // dist/src/utils/wiki-log.js
-import { mkdirSync as mkdirSync5, appendFileSync as appendFileSync2 } from "node:fs";
-import { join as join9 } from "node:path";
+import { mkdirSync as mkdirSync6, appendFileSync as appendFileSync2 } from "node:fs";
+import { join as join10 } from "node:path";
 function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
-  const path = join9(hooksDir, filename);
+  const path = join10(hooksDir, filename);
   return {
     path,
     log(msg) {
       try {
-        mkdirSync5(hooksDir, { recursive: true });
+        mkdirSync6(hooksDir, { recursive: true });
         appendFileSync2(path, `[${utcTimestamp()}] ${msg}
 `);
       } catch {
@@ -1311,18 +1434,18 @@ function makeWikiLogger(hooksDir, filename = "deeplake-wiki.log") {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync6 } from "node:fs";
-import { dirname as dirname3, join as join10 } from "node:path";
+import { readFileSync as readFileSync7 } from "node:fs";
+import { dirname as dirname3, join as join11 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join10(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
+    const pluginJson = join11(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync7(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync6(join10(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync7(join11(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -1337,9 +1460,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join10(dir, "package.json");
+    const candidate = join11(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync7(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -1353,8 +1476,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 }
 
 // dist/src/hooks/hermes/spawn-wiki-worker.js
-var HOME = homedir8();
-var wikiLogger = makeWikiLogger(join11(HOME, ".hermes", "hooks"));
+var HOME = homedir9();
+var wikiLogger = makeWikiLogger(join12(HOME, ".hermes", "hooks"));
 var WIKI_LOG = wikiLogger.path;
 var WIKI_PROMPT_TEMPLATE = `You are building a personal wiki from a coding session. Your goal is to extract every piece of knowledge \u2014 entities, decisions, relationships, and facts \u2014 into a structured, searchable wiki entry.
 
@@ -1416,11 +1539,11 @@ function findHermesBin() {
 function spawnHermesWikiWorker(opts) {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
   const projectName = cwd.split("/").pop() || "unknown";
-  const tmpDir = join11(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
-  mkdirSync6(tmpDir, { recursive: true });
+  const tmpDir = join12(tmpdir2(), `deeplake-wiki-${sessionId}-${Date.now()}`);
+  mkdirSync7(tmpDir, { recursive: true });
   const pluginVersion = getInstalledVersion(bundleDir, ".claude-plugin") ?? "";
-  const configFile = join11(tmpDir, "config.json");
-  writeFileSync4(configFile, JSON.stringify({
+  const configFile = join12(tmpDir, "config.json");
+  writeFileSync5(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1436,11 +1559,11 @@ function spawnHermesWikiWorker(opts) {
     hermesProvider: process.env.HIVEMIND_HERMES_PROVIDER ?? "openrouter",
     hermesModel: process.env.HIVEMIND_HERMES_MODEL ?? "anthropic/claude-haiku-4-5",
     wikiLog: WIKI_LOG,
-    hooksDir: join11(HOME, ".hermes", "hooks"),
+    hooksDir: join12(HOME, ".hermes", "hooks"),
     promptTemplate: WIKI_PROMPT_TEMPLATE
   }));
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
-  const workerPath = join11(bundleDir, "wiki-worker.js");
+  const workerPath = join12(bundleDir, "wiki-worker.js");
   spawn2("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1454,15 +1577,15 @@ function bundleDirFromImportMeta(importMetaUrl) {
 // dist/src/skillify/spawn-skillify-worker.js
 import { spawn as spawn3 } from "node:child_process";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname5, join as join13 } from "node:path";
-import { writeFileSync as writeFileSync5, mkdirSync as mkdirSync7, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
-import { homedir as homedir10, tmpdir as tmpdir3 } from "node:os";
+import { dirname as dirname5, join as join14 } from "node:path";
+import { writeFileSync as writeFileSync6, mkdirSync as mkdirSync8, appendFileSync as appendFileSync3, chmodSync } from "node:fs";
+import { homedir as homedir11, tmpdir as tmpdir3 } from "node:os";
 
 // dist/src/skillify/gate-runner.js
 import { existsSync as existsSync7 } from "node:fs";
 import { createRequire as createRequire2 } from "node:module";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 var requireForCp = createRequire2(import.meta.url);
 var { execFileSync: runChildProcess } = requireForCp("node:child_process");
 var inheritedEnv = process;
@@ -1474,7 +1597,7 @@ function firstExistingPath(candidates) {
   return null;
 }
 function findAgentBin(agent) {
-  const home = homedir9();
+  const home = homedir10();
   switch (agent) {
     // /usr/bin/<name> is included in every candidate list — that's the
     // common Linux package-manager install path (apt, dnf, pacman). Old
@@ -1483,54 +1606,54 @@ function findAgentBin(agent) {
     // #170 caught the gap.
     case "claude_code":
       return firstExistingPath([
-        join12(home, ".claude", "local", "claude"),
+        join13(home, ".claude", "local", "claude"),
         "/usr/local/bin/claude",
         "/usr/bin/claude",
-        join12(home, ".npm-global", "bin", "claude"),
-        join12(home, ".local", "bin", "claude"),
+        join13(home, ".npm-global", "bin", "claude"),
+        join13(home, ".local", "bin", "claude"),
         "/opt/homebrew/bin/claude"
-      ]) ?? join12(home, ".claude", "local", "claude");
+      ]) ?? join13(home, ".claude", "local", "claude");
     case "codex":
       return firstExistingPath([
         "/usr/local/bin/codex",
         "/usr/bin/codex",
-        join12(home, ".npm-global", "bin", "codex"),
-        join12(home, ".local", "bin", "codex"),
+        join13(home, ".npm-global", "bin", "codex"),
+        join13(home, ".local", "bin", "codex"),
         "/opt/homebrew/bin/codex"
       ]) ?? "/usr/local/bin/codex";
     case "cursor":
       return firstExistingPath([
         "/usr/local/bin/cursor-agent",
         "/usr/bin/cursor-agent",
-        join12(home, ".npm-global", "bin", "cursor-agent"),
-        join12(home, ".local", "bin", "cursor-agent"),
+        join13(home, ".npm-global", "bin", "cursor-agent"),
+        join13(home, ".local", "bin", "cursor-agent"),
         "/opt/homebrew/bin/cursor-agent"
       ]) ?? "/usr/local/bin/cursor-agent";
     case "hermes":
       return firstExistingPath([
-        join12(home, ".local", "bin", "hermes"),
+        join13(home, ".local", "bin", "hermes"),
         "/usr/local/bin/hermes",
         "/usr/bin/hermes",
-        join12(home, ".npm-global", "bin", "hermes"),
+        join13(home, ".npm-global", "bin", "hermes"),
         "/opt/homebrew/bin/hermes"
-      ]) ?? join12(home, ".local", "bin", "hermes");
+      ]) ?? join13(home, ".local", "bin", "hermes");
     case "pi":
       return firstExistingPath([
-        join12(home, ".local", "bin", "pi"),
+        join13(home, ".local", "bin", "pi"),
         "/usr/local/bin/pi",
         "/usr/bin/pi",
-        join12(home, ".npm-global", "bin", "pi"),
+        join13(home, ".npm-global", "bin", "pi"),
         "/opt/homebrew/bin/pi"
-      ]) ?? join12(home, ".local", "bin", "pi");
+      ]) ?? join13(home, ".local", "bin", "pi");
   }
 }
 
 // dist/src/skillify/spawn-skillify-worker.js
-var HOME2 = homedir10();
-var SKILLIFY_LOG = join13(HOME2, ".claude", "hooks", "skillify.log");
+var HOME2 = homedir11();
+var SKILLIFY_LOG = join14(HOME2, ".claude", "hooks", "skillify.log");
 function skillifyLog(msg) {
   try {
-    mkdirSync7(dirname5(SKILLIFY_LOG), { recursive: true });
+    mkdirSync8(dirname5(SKILLIFY_LOG), { recursive: true });
     appendFileSync3(SKILLIFY_LOG, `[${utcTimestamp()}] ${msg}
 `);
   } catch {
@@ -1538,11 +1661,11 @@ function skillifyLog(msg) {
 }
 function spawnSkillifyWorker(opts) {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
-  const tmpDir = join13(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  mkdirSync7(tmpDir, { recursive: true, mode: 448 });
+  const tmpDir = join14(tmpdir3(), `deeplake-skillify-${projectKey}-${Date.now()}`);
+  mkdirSync8(tmpDir, { recursive: true, mode: 448 });
   const gateBin = findAgentBin(agent);
-  const configFile = join13(tmpDir, "config.json");
-  writeFileSync5(configFile, JSON.stringify({
+  const configFile = join14(tmpDir, "config.json");
+  writeFileSync6(configFile, JSON.stringify({
     apiUrl: config.apiUrl,
     token: config.token,
     orgId: config.orgId,
@@ -1572,7 +1695,7 @@ function spawnSkillifyWorker(opts) {
   } catch {
   }
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
-  const workerPath = join13(bundleDir, "skillify-worker.js");
+  const workerPath = join14(bundleDir, "skillify-worker.js");
   spawn3("nohup", ["node", workerPath, configFile], {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"]
@@ -1581,31 +1704,31 @@ function spawnSkillifyWorker(opts) {
 }
 
 // dist/src/skillify/state.js
-import { readFileSync as readFileSync7, writeFileSync as writeFileSync6, writeSync as writeSync3, mkdirSync as mkdirSync8, renameSync as renameSync5, existsSync as existsSync9, unlinkSync as unlinkSync3, openSync as openSync3, closeSync as closeSync3 } from "node:fs";
+import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, writeSync as writeSync3, mkdirSync as mkdirSync9, renameSync as renameSync6, existsSync as existsSync9, unlinkSync as unlinkSync4, openSync as openSync4, closeSync as closeSync4 } from "node:fs";
 import { execSync as execSync2 } from "node:child_process";
-import { homedir as homedir12 } from "node:os";
+import { homedir as homedir13 } from "node:os";
 import { createHash } from "node:crypto";
-import { join as join15, basename as basename2 } from "node:path";
+import { join as join16, basename as basename2 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync8, renameSync as renameSync4 } from "node:fs";
-import { homedir as homedir11 } from "node:os";
-import { join as join14 } from "node:path";
+import { existsSync as existsSync8, renameSync as renameSync5 } from "node:fs";
+import { homedir as homedir12 } from "node:os";
+import { join as join15 } from "node:path";
 var dlog2 = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join14(homedir11(), ".deeplake", "state");
-  const legacy = join14(root, "skilify");
-  const current = join14(root, "skillify");
+  const root = join15(homedir12(), ".deeplake", "state");
+  const legacy = join15(root, "skilify");
+  const current = join15(root, "skillify");
   if (!existsSync8(legacy))
     return;
   if (existsSync8(current))
     return;
   try {
-    renameSync4(legacy, current);
+    renameSync5(legacy, current);
     dlog2(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -1619,17 +1742,17 @@ function migrateLegacyStateDir() {
 
 // dist/src/skillify/state.js
 var dlog3 = (msg) => log("skillify-state", msg);
-var STATE_DIR2 = join15(homedir12(), ".deeplake", "state", "skillify");
+var STATE_DIR2 = join16(homedir13(), ".deeplake", "state", "skillify");
 var YIELD_BUF2 = new Int32Array(new SharedArrayBuffer(4));
 var TRIGGER_THRESHOLD = (() => {
   const n = Number(process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS ?? "");
   return Number.isInteger(n) && n > 0 ? n : 20;
 })();
 function statePath2(projectKey) {
-  return join15(STATE_DIR2, `${projectKey}.json`);
+  return join16(STATE_DIR2, `${projectKey}.json`);
 }
-function lockPath2(projectKey) {
-  return join15(STATE_DIR2, `${projectKey}.lock`);
+function lockPath3(projectKey) {
+  return join16(STATE_DIR2, `${projectKey}.lock`);
 }
 var DEFAULT_PORTS = {
   http: "80",
@@ -1678,35 +1801,35 @@ function readState2(projectKey) {
   if (!existsSync9(p))
     return null;
   try {
-    return JSON.parse(readFileSync7(p, "utf-8"));
+    return JSON.parse(readFileSync8(p, "utf-8"));
   } catch {
     return null;
   }
 }
 function writeState2(projectKey, state) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
+  mkdirSync9(STATE_DIR2, { recursive: true });
   const p = statePath2(projectKey);
   const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync6(tmp, JSON.stringify(state, null, 2));
-  renameSync5(tmp, p);
+  writeFileSync7(tmp, JSON.stringify(state, null, 2));
+  renameSync6(tmp, p);
 }
 function withRmwLock2(projectKey, fn) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
-  const rmw = lockPath2(projectKey) + ".rmw";
+  mkdirSync9(STATE_DIR2, { recursive: true });
+  const rmw = lockPath3(projectKey) + ".rmw";
   const deadline = Date.now() + 2e3;
   let fd = null;
   while (fd === null) {
     try {
-      fd = openSync3(rmw, "wx");
+      fd = openSync4(rmw, "wx");
     } catch (e) {
       if (e.code !== "EEXIST")
         throw e;
       if (Date.now() > deadline) {
         dlog3(`rmw lock deadline exceeded for ${projectKey}, reclaiming stale lock`);
         try {
-          unlinkSync3(rmw);
+          unlinkSync4(rmw);
         } catch (unlinkErr) {
           dlog3(`stale rmw lock unlink failed for ${projectKey}: ${unlinkErr.message}`);
         }
@@ -1718,9 +1841,9 @@ function withRmwLock2(projectKey, fn) {
   try {
     return fn();
   } finally {
-    closeSync3(fd);
+    closeSync4(fd);
     try {
-      unlinkSync3(rmw);
+      unlinkSync4(rmw);
     } catch (unlinkErr) {
       dlog3(`rmw lock cleanup failed for ${projectKey}: ${unlinkErr.message}`);
     }
@@ -1753,29 +1876,29 @@ function resetCounter(projectKey) {
 }
 function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   migrateLegacyStateDir();
-  mkdirSync8(STATE_DIR2, { recursive: true });
-  const p = lockPath2(projectKey);
+  mkdirSync9(STATE_DIR2, { recursive: true });
+  const p = lockPath3(projectKey);
   if (existsSync9(p)) {
     try {
-      const ageMs = Date.now() - parseInt(readFileSync7(p, "utf-8"), 10);
+      const ageMs = Date.now() - parseInt(readFileSync8(p, "utf-8"), 10);
       if (Number.isFinite(ageMs) && ageMs < maxAgeMs)
         return false;
     } catch (readErr) {
       dlog3(`worker lock unreadable for ${projectKey}, treating as stale: ${readErr.message}`);
     }
     try {
-      unlinkSync3(p);
+      unlinkSync4(p);
     } catch (unlinkErr) {
       dlog3(`could not unlink stale worker lock for ${projectKey}: ${unlinkErr.message}`);
       return false;
     }
   }
   try {
-    const fd = openSync3(p, "wx");
+    const fd = openSync4(p, "wx");
     try {
       writeSync3(fd, String(Date.now()));
     } finally {
-      closeSync3(fd);
+      closeSync4(fd);
     }
     return true;
   } catch {
@@ -1783,26 +1906,26 @@ function tryAcquireWorkerLock(projectKey, maxAgeMs = 10 * 60 * 1e3) {
   }
 }
 function releaseWorkerLock(projectKey) {
-  const p = lockPath2(projectKey);
+  const p = lockPath3(projectKey);
   try {
-    unlinkSync3(p);
+    unlinkSync4(p);
   } catch {
   }
 }
 
 // dist/src/skillify/scope-config.js
-import { existsSync as existsSync10, mkdirSync as mkdirSync9, readFileSync as readFileSync8, writeFileSync as writeFileSync7 } from "node:fs";
-import { homedir as homedir13 } from "node:os";
-import { join as join16 } from "node:path";
-var STATE_DIR3 = join16(homedir13(), ".deeplake", "state", "skillify");
-var CONFIG_PATH = join16(STATE_DIR3, "config.json");
+import { existsSync as existsSync10, mkdirSync as mkdirSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync8 } from "node:fs";
+import { homedir as homedir14 } from "node:os";
+import { join as join17 } from "node:path";
+var STATE_DIR3 = join17(homedir14(), ".deeplake", "state", "skillify");
+var CONFIG_PATH = join17(STATE_DIR3, "config.json");
 var DEFAULT = { scope: "me", team: [], install: "project" };
 function loadScopeConfig() {
   migrateLegacyStateDir();
   if (!existsSync10(CONFIG_PATH))
     return DEFAULT;
   try {
-    const raw = JSON.parse(readFileSync8(CONFIG_PATH, "utf-8"));
+    const raw = JSON.parse(readFileSync9(CONFIG_PATH, "utf-8"));
     const scope = raw.scope === "team" ? "team" : raw.scope === "org" ? "team" : "me";
     const team = Array.isArray(raw.team) ? raw.team.filter((s) => typeof s === "string") : [];
     const install = raw.install === "global" ? "global" : "project";
@@ -1853,9 +1976,9 @@ function tryStopCounterTrigger(opts) {
 }
 
 // dist/src/hooks/hermes/capture.js
-var log4 = (msg) => log("hermes-capture", msg);
+var log5 = (msg) => log("hermes-capture", msg);
 function resolveEmbedDaemonPath() {
-  return join17(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
+  return join18(dirname6(fileURLToPath3(import.meta.url)), "embeddings", "embed-daemon.js");
 }
 var __bundleDir = dirname6(fileURLToPath3(import.meta.url));
 var PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".claude-plugin") ?? "";
@@ -1879,7 +2002,7 @@ async function main() {
   const input = await readStdin();
   const config = loadConfig();
   if (!config) {
-    log4("no config");
+    log5("no config");
     return;
   }
   const sessionId = input.session_id ?? `hermes-${Date.now()}`;
@@ -1899,14 +2022,14 @@ async function main() {
   if (event === "pre_llm_call") {
     const prompt = pickString(extra.prompt, extra.user_message, extra.message?.content);
     if (!prompt) {
-      log4(`pre_llm_call: no prompt found in extra`);
+      log5(`pre_llm_call: no prompt found in extra`);
       return;
     }
-    log4(`user session=${sessionId}`);
+    log5(`user session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "user_message", content: prompt };
   } else if (event === "post_tool_call" && typeof input.tool_name === "string") {
     const toolResponse = extra.tool_result ?? extra.tool_output ?? extra.result ?? extra.output;
-    log4(`tool=${input.tool_name} session=${sessionId}`);
+    log5(`tool=${input.tool_name} session=${sessionId}`);
     entry = {
       id: crypto.randomUUID(),
       ...meta,
@@ -1918,18 +2041,18 @@ async function main() {
   } else if (event === "post_llm_call") {
     const text = pickString(extra.response, extra.assistant_message, extra.message?.content);
     if (!text) {
-      log4(`post_llm_call: no response found in extra`);
+      log5(`post_llm_call: no response found in extra`);
       return;
     }
-    log4(`assistant session=${sessionId}`);
+    log5(`assistant session=${sessionId}`);
     entry = { id: crypto.randomUUID(), ...meta, type: "assistant_message", content: text };
   } else {
-    log4(`unknown/unhandled event: ${event}, skipping`);
+    log5(`unknown/unhandled event: ${event}, skipping`);
     return;
   }
   const sessionPath = buildSessionPath(config, sessionId);
   const line = JSON.stringify(entry);
-  log4(`writing to ${sessionPath}`);
+  log5(`writing to ${sessionPath}`);
   const projectName = cwd.split("/").pop() || "unknown";
   const filename = sessionPath.split("/").pop() ?? "";
   const jsonForSql = line.replace(/'/g, "''");
@@ -1940,14 +2063,14 @@ async function main() {
     await api.query(insertSql);
   } catch (e) {
     if (e.message?.includes("permission denied") || e.message?.includes("does not exist")) {
-      log4("table missing, creating and retrying");
+      log5("table missing, creating and retrying");
       await api.ensureSessionsTable(sessionsTable);
       await api.query(insertSql);
     } else {
       throw e;
     }
   }
-  log4("capture ok \u2192 cloud");
+  log5("capture ok \u2192 cloud");
   maybeTriggerPeriodicSummary(sessionId, cwd, config);
   if (event === "post_llm_call" && process.env.HIVEMIND_WIKI_WORKER !== "1" && process.env.HIVEMIND_SKILLIFY_WORKER !== "1") {
     tryStopCounterTrigger({
@@ -1968,7 +2091,7 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
     if (!shouldTrigger(state, cfg))
       return;
     if (!tryAcquireLock(sessionId)) {
-      log4(`periodic trigger suppressed (lock held) session=${sessionId}`);
+      log5(`periodic trigger suppressed (lock held) session=${sessionId}`);
       return;
     }
     wikiLog(`Periodic: threshold hit (total=${state.totalCount}, since=${state.totalCount - state.lastSummaryCount}, N=${cfg.everyNMessages}, hours=${cfg.everyHours})`);
@@ -1981,17 +2104,17 @@ function maybeTriggerPeriodicSummary(sessionId, cwd, config) {
         reason: "Periodic"
       });
     } catch (e) {
-      log4(`periodic spawn failed: ${e.message}`);
+      log5(`periodic spawn failed: ${e.message}`);
       try {
         releaseLock(sessionId);
       } catch {
       }
     }
   } catch (e) {
-    log4(`periodic trigger error: ${e.message}`);
+    log5(`periodic trigger error: ${e.message}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -469,13 +469,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -474,11 +474,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/hermes/bundle/commands/auth-login.js
+++ b/hermes/bundle/commands/auth-login.js
@@ -17,21 +17,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -41,8 +41,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -337,6 +337,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -344,7 +445,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -356,7 +457,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -365,8 +487,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -396,7 +518,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -467,8 +589,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -484,10 +606,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -508,7 +631,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -564,7 +687,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -654,13 +777,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -688,9 +811,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -701,9 +824,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -716,9 +839,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -741,9 +864,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -774,10 +897,10 @@ function parseArgs(argv) {
 }
 function confirm(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
+  return new Promise((resolve2) => {
     rl.question(`${message} [y/N] `, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
+      resolve2(answer.trim().toLowerCase() === "y");
     });
   });
 }

--- a/hermes/bundle/pre-tool-use.js
+++ b/hermes/bundle/pre-tool-use.js
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve2(JSON.parse(data));
+        resolve(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -175,7 +175,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms) {
-  return new Promise((resolve2) => setTimeout(resolve2, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +205,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve2) => this.waiting.push(resolve2));
+    await new Promise((resolve) => this.waiting.push(resolve));
   }
   release() {
     this.active--;
@@ -1042,9 +1042,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join4 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1057,105 +1057,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync } from "node:fs";
-import { join as join4, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join4(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath();
-  mkdirSync2(join4(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync3(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync3(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -1165,7 +1431,7 @@ import { join as join6 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join5 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
@@ -1175,7 +1441,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync3(path)) {
+  if (!existsSync4(path)) {
     _cache = {};
     return _cache;
   }
@@ -1193,11 +1459,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync3(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync4(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1276,397 +1542,13 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync4(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log4(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync4(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join7 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2019,9 +1901,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir6 } from "node:os";
+import { join as join8 } from "node:path";
+var MEMORY_PATH = join8(homedir6(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {
@@ -2032,7 +1914,7 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/hermes/pre-tool-use.js
-var log5 = (msg) => log("hermes-pre-tool-use", msg);
+var log4 = (msg) => log("hermes-pre-tool-use", msg);
 async function main() {
   const input = await readStdin();
   if (input.tool_name !== "terminal")
@@ -2049,7 +1931,7 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log5("no config \u2014 falling through to Hermes");
+    log4("no config \u2014 falling through to Hermes");
     return;
   }
   const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
@@ -2057,7 +1939,7 @@ async function main() {
     const result = await handleGrepDirect(api, config.tableName, config.sessionsTableName, grepParams);
     if (result === null)
       return;
-    log5(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
+    log4(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
     const message = [
       result,
       "",
@@ -2066,10 +1948,10 @@ async function main() {
     process.stdout.write(JSON.stringify({ action: "block", message }));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log5(`fast-path failed, falling through: ${msg}`);
+    log4(`fast-path failed, falling through: ${msg}`);
   }
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log4(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/hermes/bundle/pre-tool-use.js
+++ b/hermes/bundle/pre-tool-use.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -247,6 +247,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -283,11 +301,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -1165,9 +1193,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1181,7 +1209,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join6(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -1372,7 +1400,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1385,11 +1413,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -1440,7 +1468,7 @@ var EmbedClient = class {
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -1457,7 +1485,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -1476,7 +1504,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1549,15 +1577,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join7(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1569,7 +1597,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path, "utf-8");
+    const raw = readFileSync6(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1583,9 +1611,9 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path);
   _cache = merged;
   return merged;
@@ -1635,7 +1663,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join8(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1667,11 +1695,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { dirname as dirname2, join as join9 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join9(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -2024,9 +2052,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir7 } from "node:os";
-import { join as join9 } from "node:path";
-var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
+import { homedir as homedir8 } from "node:os";
+import { join as join10 } from "node:path";
+var MEMORY_PATH = join10(homedir8(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {

--- a/hermes/bundle/pre-tool-use.js
+++ b/hermes/bundle/pre-tool-use.js
@@ -296,13 +296,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/hermes/bundle/pre-tool-use.js
+++ b/hermes/bundle/pre-tool-use.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -53,13 +53,13 @@ var init_index_marker_store = __esm({
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -146,6 +146,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -153,7 +254,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -165,7 +266,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -174,8 +296,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -205,7 +327,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -276,8 +398,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -293,10 +415,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -317,7 +440,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -373,7 +496,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -463,13 +586,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -497,9 +620,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -510,9 +633,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -525,9 +648,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -550,9 +673,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -1042,9 +1165,9 @@ function capOutputForClaude(output, options = {}) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -1058,8 +1181,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join4(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
+var SHARED_DAEMON_PATH = join5(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m) => log("embed-client", m);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -1135,7 +1258,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -1144,7 +1267,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e) {
       const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -1191,7 +1314,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
       return false;
     }
     const hello = resp;
@@ -1200,13 +1323,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -1249,7 +1372,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -1259,14 +1382,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -1293,7 +1416,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const sock = connect(this.socketPath);
       const to = setTimeout(() => {
         sock.destroy();
@@ -1301,7 +1424,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to);
-        resolve(sock);
+        resolve2(sock);
       });
       sock.once("error", (e) => {
         clearTimeout(to);
@@ -1312,16 +1435,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -1331,10 +1454,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -1346,14 +1469,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -1371,7 +1494,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync3(this.socketPath))
         continue;
@@ -1383,7 +1506,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       let buf = "";
       const to = setTimeout(() => {
         sock.destroy();
@@ -1398,7 +1521,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl);
         clearTimeout(to);
         try {
-          resolve(JSON.parse(line));
+          resolve2(JSON.parse(line));
         } catch (e) {
           reject(e);
         }
@@ -1415,7 +1538,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms) {
+function sleep3(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 function isTransformersMissingError(err) {
@@ -1426,15 +1549,15 @@ function isTransformersMissingError(err) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join5(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join6(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -1446,7 +1569,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path, "utf-8");
+    const raw = readFileSync5(path, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -1460,10 +1583,10 @@ function writeUserConfig(patch) {
   const path = _configPath();
   const dir = dirname(path);
   if (!existsSync4(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -1512,7 +1635,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join6(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join7(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -1544,11 +1667,11 @@ function embeddingsDisabled() {
 
 // dist/src/hooks/grep-direct.js
 import { fileURLToPath } from "node:url";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join8 } from "node:path";
 var SEMANTIC_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveDaemonPath() {
-  return join7(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join8(dirname2(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedEmbedClient = null;
 function getEmbedClient() {
@@ -1901,9 +2024,9 @@ async function handleGrepDirect(api, table, sessionsTable, params) {
 }
 
 // dist/src/hooks/memory-path-utils.js
-import { homedir as homedir6 } from "node:os";
-import { join as join8 } from "node:path";
-var MEMORY_PATH = join8(homedir6(), ".deeplake", "memory");
+import { homedir as homedir7 } from "node:os";
+import { join as join9 } from "node:path";
+var MEMORY_PATH = join9(homedir7(), ".deeplake", "memory");
 var TILDE_PATH = "~/.deeplake/memory";
 var HOME_VAR_PATH = "$HOME/.deeplake/memory";
 function touchesMemory(p) {
@@ -1914,7 +2037,7 @@ function rewritePaths(cmd) {
 }
 
 // dist/src/hooks/hermes/pre-tool-use.js
-var log4 = (msg) => log("hermes-pre-tool-use", msg);
+var log5 = (msg) => log("hermes-pre-tool-use", msg);
 async function main() {
   const input = await readStdin();
   if (input.tool_name !== "terminal")
@@ -1931,7 +2054,7 @@ async function main() {
     return;
   const config = loadConfig();
   if (!config) {
-    log4("no config \u2014 falling through to Hermes");
+    log5("no config \u2014 falling through to Hermes");
     return;
   }
   const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
@@ -1939,7 +2062,7 @@ async function main() {
     const result = await handleGrepDirect(api, config.tableName, config.sessionsTableName, grepParams);
     if (result === null)
       return;
-    log4(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
+    log5(`intercepted ${command.slice(0, 80)} \u2192 ${result.length} chars from SQL fast-path`);
     const message = [
       result,
       "",
@@ -1948,10 +2071,10 @@ async function main() {
     process.stdout.write(JSON.stringify({ action: "block", message }));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log4(`fast-path failed, falling through: ${msg}`);
+    log5(`fast-path failed, falling through: ${msg}`);
   }
 }
 main().catch((e) => {
-  log4(`fatal: ${e.message}`);
+  log5(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/hermes/bundle/session-start.js
+++ b/hermes/bundle/session-start.js
@@ -283,13 +283,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/hermes/bundle/session-start.js
+++ b/hermes/bundle/session-start.js
@@ -288,11 +288,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/hermes/bundle/session-start.js
+++ b/hermes/bundle/session-start.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -151,6 +151,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -158,7 +259,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -170,7 +271,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -179,8 +301,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -210,7 +332,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -281,8 +403,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -298,10 +420,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -322,7 +445,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -378,7 +501,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -468,13 +591,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -502,9 +625,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -515,9 +638,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -530,9 +653,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -555,9 +678,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -595,16 +718,16 @@ function renderSkillifyCommands() {
 }
 
 // dist/src/skillify/local-manifest.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname, join as join5 } from "node:path";
-var LOCAL_MANIFEST_PATH = join5(homedir4(), ".claude", "hivemind", "local-mined.json");
-var LOCAL_MINE_LOCK_PATH = join5(homedir4(), ".claude", "hivemind", "local-mined.lock");
+import { existsSync as existsSync3, mkdirSync as mkdirSync4, readFileSync as readFileSync5, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname, join as join6 } from "node:path";
+var LOCAL_MANIFEST_PATH = join6(homedir5(), ".claude", "hivemind", "local-mined.json");
+var LOCAL_MINE_LOCK_PATH = join6(homedir5(), ".claude", "hivemind", "local-mined.lock");
 function readLocalManifest(path = LOCAL_MANIFEST_PATH) {
   if (!existsSync3(path))
     return null;
   try {
-    return JSON.parse(readFileSync4(path, "utf-8"));
+    return JSON.parse(readFileSync5(path, "utf-8"));
   } catch {
     return null;
   }
@@ -616,19 +739,19 @@ function countLocalManifestEntries(path = LOCAL_MANIFEST_PATH) {
 
 // dist/src/skillify/spawn-mine-local-worker.js
 import { execFileSync, spawn } from "node:child_process";
-import { closeSync, existsSync as existsSync4, mkdirSync as mkdirSync4, openSync, readdirSync, statSync, unlinkSync as unlinkSync2 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname2, join as join6 } from "node:path";
+import { closeSync as closeSync2, existsSync as existsSync4, mkdirSync as mkdirSync5, openSync as openSync2, readdirSync, statSync as statSync2, unlinkSync as unlinkSync3 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname2, join as join7 } from "node:path";
 import { fileURLToPath } from "node:url";
-var HOME = homedir5();
-var HIVEMIND_DIR = join6(HOME, ".claude", "hivemind");
-var LOG_PATH = join6(HOME, ".claude", "hooks", "mine-local.log");
-var CLAUDE_PROJECTS_DIR = join6(HOME, ".claude", "projects");
-var LOCK_STALE_MS = 15 * 60 * 1e3;
+var HOME = homedir6();
+var HIVEMIND_DIR = join7(HOME, ".claude", "hivemind");
+var LOG_PATH = join7(HOME, ".claude", "hooks", "mine-local.log");
+var CLAUDE_PROJECTS_DIR = join7(HOME, ".claude", "projects");
+var LOCK_STALE_MS2 = 15 * 60 * 1e3;
 function findBundledCliPath() {
   try {
     const thisDir = dirname2(fileURLToPath(import.meta.url));
-    const cliPath = join6(thisDir, "..", "..", "bundle", "cli.js");
+    const cliPath = join7(thisDir, "..", "..", "bundle", "cli.js");
     return existsSync4(cliPath) ? cliPath : null;
   } catch {
     return null;
@@ -661,7 +784,7 @@ function hasLocalClaudeSessions() {
   for (const sub of subdirs) {
     let files;
     try {
-      files = readdirSync(join6(CLAUDE_PROJECTS_DIR, sub));
+      files = readdirSync(join7(CLAUDE_PROJECTS_DIR, sub));
     } catch {
       continue;
     }
@@ -676,14 +799,14 @@ function maybeAutoMineLocal() {
   if (existsSync4(LOCAL_MINE_LOCK_PATH)) {
     let stale = false;
     try {
-      const stats = statSync(LOCAL_MINE_LOCK_PATH);
-      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS;
+      const stats = statSync2(LOCAL_MINE_LOCK_PATH);
+      stale = Date.now() - stats.mtimeMs > LOCK_STALE_MS2;
     } catch {
     }
     if (!stale)
       return { triggered: false, reason: "lock-exists" };
     try {
-      unlinkSync2(LOCAL_MINE_LOCK_PATH);
+      unlinkSync3(LOCAL_MINE_LOCK_PATH);
     } catch {
       return { triggered: false, reason: "lock-exists" };
     }
@@ -694,27 +817,27 @@ function maybeAutoMineLocal() {
   if (!launcher)
     return { triggered: false, reason: "no-hivemind-bin" };
   try {
-    mkdirSync4(HIVEMIND_DIR, { recursive: true });
-    const fd = openSync(LOCAL_MINE_LOCK_PATH, "wx");
-    closeSync(fd);
+    mkdirSync5(HIVEMIND_DIR, { recursive: true });
+    const fd = openSync2(LOCAL_MINE_LOCK_PATH, "wx");
+    closeSync2(fd);
   } catch {
     return { triggered: false, reason: "lock-acquire-failed" };
   }
   try {
-    mkdirSync4(join6(HOME, ".claude", "hooks"), { recursive: true });
-    const out = openSync(LOG_PATH, "a");
+    mkdirSync5(join7(HOME, ".claude", "hooks"), { recursive: true });
+    const out = openSync2(LOG_PATH, "a");
     const [cmd, args] = launcher.kind === "node-script" ? [process.execPath, [launcher.path, "skillify", "mine-local"]] : [launcher.path, ["skillify", "mine-local"]];
     const child = spawn(cmd, args, {
       detached: true,
       stdio: ["ignore", out, out],
       env: process.env
     });
-    closeSync(out);
+    closeSync2(out);
     child.unref();
     return { triggered: true };
   } catch {
     try {
-      unlinkSync2(LOCAL_MINE_LOCK_PATH);
+      unlinkSync3(LOCAL_MINE_LOCK_PATH);
     } catch {
     }
     return { triggered: false, reason: "spawn-failed" };
@@ -723,13 +846,13 @@ function maybeAutoMineLocal() {
 
 // dist/src/utils/stdin.js
 function readStdin() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve2, reject) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => data += chunk);
     process.stdin.on("end", () => {
       try {
-        resolve(JSON.parse(data));
+        resolve2(JSON.parse(data));
       } catch (err) {
         reject(new Error(`Failed to parse hook input: ${err}`));
       }
@@ -739,18 +862,18 @@ function readStdin() {
 }
 
 // dist/src/utils/version-check.js
-import { readFileSync as readFileSync5 } from "node:fs";
-import { dirname as dirname3, join as join7 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname3, join as join8 } from "node:path";
 function getInstalledVersion(bundleDir, pluginManifestDir) {
   try {
-    const pluginJson = join7(bundleDir, "..", pluginManifestDir, "plugin.json");
-    const plugin = JSON.parse(readFileSync5(pluginJson, "utf-8"));
+    const pluginJson = join8(bundleDir, "..", pluginManifestDir, "plugin.json");
+    const plugin = JSON.parse(readFileSync6(pluginJson, "utf-8"));
     if (plugin.version)
       return plugin.version;
   } catch {
   }
   try {
-    const stamp = readFileSync5(join7(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
+    const stamp = readFileSync6(join8(bundleDir, "..", ".hivemind_version"), "utf-8").trim();
     if (stamp)
       return stamp;
   } catch {
@@ -765,9 +888,9 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
   ]);
   let dir = bundleDir;
   for (let i = 0; i < 5; i++) {
-    const candidate = join7(dir, "package.json");
+    const candidate = join8(dir, "package.json");
     try {
-      const pkg = JSON.parse(readFileSync5(candidate, "utf-8"));
+      const pkg = JSON.parse(readFileSync6(candidate, "utf-8"));
       if (HIVEMIND_PKG_NAMES.has(pkg.name) && pkg.version)
         return pkg.version;
     } catch {
@@ -783,8 +906,8 @@ function getInstalledVersion(bundleDir, pluginManifestDir) {
 // dist/src/hooks/shared/autoupdate.js
 import { spawn as spawn2 } from "node:child_process";
 import { existsSync as existsSync5 } from "node:fs";
-import { join as join8 } from "node:path";
-var log3 = (msg) => log("autoupdate", msg);
+import { join as join9 } from "node:path";
+var log4 = (msg) => log("autoupdate", msg);
 var defaultSpawn = (cmd, args) => {
   const child = spawn2(cmd, args, {
     detached: true,
@@ -799,7 +922,7 @@ function findHivemindOnPath() {
   const PATH = process.env.PATH ?? "";
   const dirs = PATH.split(":").filter(Boolean);
   for (const dir of dirs) {
-    const candidate = join8(dir, "hivemind");
+    const candidate = join9(dir, "hivemind");
     if (existsSync5(candidate))
       return candidate;
   }
@@ -807,41 +930,41 @@ function findHivemindOnPath() {
 }
 async function autoUpdate(creds, opts) {
   const t0 = Date.now();
-  log3(`agent=${opts.agent} entered`);
+  log4(`agent=${opts.agent} entered`);
   if (!creds?.token) {
-    log3(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`);
     return;
   }
   if (creds.autoupdate === false) {
-    log3(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`);
     return;
   }
   const binaryPath = opts.hivemindBinaryPath !== void 0 ? opts.hivemindBinaryPath : findHivemindOnPath();
   if (!binaryPath) {
-    log3(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} skip: hivemind binary not on PATH (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
+  log4(`agent=${opts.agent} binary=${binaryPath} \u2192 dispatching detached update`);
   const spawnFn = opts.spawn ?? defaultSpawn;
   let pid;
   try {
     pid = spawnFn(binaryPath, ["update"]).pid;
   } catch (e) {
-    log3(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
+    log4(`agent=${opts.agent} dispatch threw: ${e?.message ?? e} (${Date.now() - t0}ms)`);
     return;
   }
-  log3(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
+  log4(`agent=${opts.agent} dispatched (pid=${pid ?? "?"}) (${Date.now() - t0}ms total)`);
 }
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync10, readFileSync as readFileSync8, writeFileSync as writeFileSync6, mkdirSync as mkdirSync7, renameSync as renameSync3, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync4 } from "node:fs";
-import { homedir as homedir10 } from "node:os";
-import { dirname as dirname5, join as join13 } from "node:path";
+import { existsSync as existsSync10, readFileSync as readFileSync9, writeFileSync as writeFileSync7, mkdirSync as mkdirSync8, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync5 } from "node:fs";
+import { homedir as homedir11 } from "node:os";
+import { dirname as dirname5, join as join14 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync6, mkdirSync as mkdirSync5, readFileSync as readFileSync6, readdirSync as readdirSync2, statSync as statSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join9 } from "node:path";
+import { existsSync as existsSync6, mkdirSync as mkdirSync6, readFileSync as readFileSync7, readdirSync as readdirSync2, statSync as statSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { join as join10 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -907,29 +1030,29 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync8, lstatSync, mkdirSync as mkdirSync6, readFileSync as readFileSync7, renameSync as renameSync2, unlinkSync as unlinkSync3, writeFileSync as writeFileSync5 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { dirname as dirname4, join as join11 } from "node:path";
+import { existsSync as existsSync8, lstatSync, mkdirSync as mkdirSync7, readFileSync as readFileSync8, renameSync as renameSync3, unlinkSync as unlinkSync4, writeFileSync as writeFileSync6 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { dirname as dirname4, join as join12 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync7, renameSync } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join10 } from "node:path";
+import { existsSync as existsSync7, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { join as join11 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join10(homedir7(), ".deeplake", "state");
-  const legacy = join10(root, "skilify");
-  const current = join10(root, "skillify");
+  const root = join11(homedir8(), ".deeplake", "state");
+  const legacy = join11(root, "skilify");
+  const current = join11(root, "skillify");
   if (!existsSync7(legacy))
     return;
   if (existsSync7(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -946,7 +1069,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join11(homedir8(), ".deeplake", "state", "skillify", "pulled.json");
+  return join12(homedir9(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -954,7 +1077,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync7(path, "utf-8");
+    raw = readFileSync8(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -1001,10 +1124,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync6(dirname4(path), { recursive: true });
+  mkdirSync7(dirname4(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync5(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  writeFileSync6(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -1029,7 +1152,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync3(path);
+      unlinkSync4(path);
     } catch {
     }
   }
@@ -1039,7 +1162,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync8(join11(e.installRoot, e.dirName))) {
+    if (existsSync8(join12(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -1053,25 +1176,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync9 } from "node:fs";
-import { homedir as homedir9 } from "node:os";
-import { join as join12 } from "node:path";
+import { homedir as homedir10 } from "node:os";
+import { join as join13 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync9(join12(home, ".codex"));
-  const piInstalled = existsSync9(join12(home, ".pi", "agent"));
-  const hermesInstalled = existsSync9(join12(home, ".hermes"));
+  const codexInstalled = existsSync9(join13(home, ".codex"));
+  const piInstalled = existsSync9(join13(home, ".pi", "agent"));
+  const hermesInstalled = existsSync9(join13(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join12(home, ".agents", "skills"));
+    out.push(join13(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join12(home, ".hermes", "skills"));
+    out.push(join13(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join12(home, ".pi", "agent", "skills"));
+    out.push(join13(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir9()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir10()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -1115,15 +1238,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join13(homedir10(), ".claude", "skills");
+    return join14(homedir11(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join13(cwd, ".claude", "skills");
+  return join14(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join13(root, dirName);
+    const link = join14(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -1145,13 +1268,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync4(link);
+        unlinkSync5(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync7(dirname5(link), { recursive: true });
+      mkdirSync8(dirname5(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -1166,7 +1289,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join13(entry.installRoot, entry.dirName);
+    const canonical = join14(entry.installRoot, entry.dirName);
     if (!existsSync10(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -1280,7 +1403,7 @@ function readLocalVersion(path) {
   if (!existsSync10(path))
     return null;
   try {
-    const text = readFileSync8(path, "utf-8");
+    const text = readFileSync9(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1375,8 +1498,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join13(root, dirName);
-    const skillFile = join13(skillDir, "SKILL.md");
+    const skillDir = join14(root, dirName);
+    const skillFile = join14(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1387,14 +1510,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync7(skillDir, { recursive: true });
+      mkdirSync8(skillDir, { recursive: true });
       if (existsSync10(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync6(skillFile, renderSkillFile(row));
+      writeFileSync7(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -1436,7 +1559,7 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/auto-pull.js
-var log4 = (msg) => log("skillify-autopull", msg);
+var log5 = (msg) => log("skillify-autopull", msg);
 var DEFAULT_TIMEOUT_MS = 5e3;
 function withTimeout(p, ms) {
   let timer = null;
@@ -1452,13 +1575,13 @@ function withTimeout(p, ms) {
 }
 async function autoPullSkills(deps = {}) {
   if (process.env.HIVEMIND_AUTOPULL_DISABLED === "1") {
-    log4("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
+    log5("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
     return { pulled: 0, skipped: true, reason: "disabled" };
   }
   const loadFn = deps.loadConfigFn ?? loadConfig;
   const config = loadFn();
   if (!config) {
-    log4("skipped: not logged in");
+    log5("skipped: not logged in");
     return { pulled: 0, skipped: true, reason: "not-logged-in" };
   }
   let query;
@@ -1480,16 +1603,16 @@ async function autoPullSkills(deps = {}) {
       dryRun: false,
       force: false
     }), timeoutMs);
-    log4(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
+    log5(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
     return { pulled: summary.wrote, skipped: false };
   } catch (e) {
-    log4(`pull failed (swallowed): ${e?.message ?? e}`);
+    log5(`pull failed (swallowed): ${e?.message ?? e}`);
     return { pulled: 0, skipped: true, reason: "error" };
   }
 }
 
 // dist/src/hooks/hermes/session-start.js
-var log5 = (msg) => log("hermes-session-start", msg);
+var log6 = (msg) => log("hermes-session-start", msg);
 var __bundleDir = dirname6(fileURLToPath2(import.meta.url));
 var context = `DEEPLAKE MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
 
@@ -1560,14 +1683,14 @@ async function main() {
         await api.ensureTable();
         await api.ensureSessionsTable(config.sessionsTableName);
         await createPlaceholder(api, config.tableName, sessionId, cwd, config.userName, config.orgName, config.workspaceId, pluginVersion);
-        log5("placeholder created");
+        log6("placeholder created");
       }
     } catch (e) {
-      log5(`placeholder failed: ${e.message}`);
+      log6(`placeholder failed: ${e.message}`);
     }
   }
   const pullResult = await autoPullSkills();
-  log5(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
+  log6(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
   let versionNotice = "";
   if (current)
     versionNotice = `
@@ -1581,6 +1704,6 @@ Not logged in to Deeplake. Run: hivemind login${localMinedNote}${versionNotice}`
   console.log(JSON.stringify({ context: additional }));
 }
 main().catch((e) => {
-  log5(`fatal: ${e.message}`);
+  log6(`fatal: ${e.message}`);
   process.exit(0);
 });

--- a/hermes/bundle/shell/deeplake-shell.js
+++ b/hermes/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join12(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join12(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join12(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -66870,7 +66870,7 @@ function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
 function sleep(ms3) {
-  return new Promise((resolve6) => setTimeout(resolve6, ms3));
+  return new Promise((resolve5) => setTimeout(resolve5, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +66900,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve6) => this.waiting.push(resolve6));
+    await new Promise((resolve5) => this.waiting.push(resolve5));
   }
   release() {
     this.active--;
@@ -67259,7 +67259,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join10 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67689,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join7 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67704,105 +67704,384 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
-import { join as join7, resolve as resolve4 } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep2 } from "node:timers/promises";
-var log3 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join7(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log3 = (m26) => log("embed-client", m26);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync3(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log3(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync4(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path2, home) {
-  const r10 = resolve4(path2);
-  const h18 = resolve4(home);
-  return r10.startsWith(h18 + "/") || r10 === h18;
-}
-function writeQueue(q17) {
-  const path2 = queuePath();
-  const home = resolve4(homedir3());
-  if (!_isQueuePathInsideHome(path2, home)) {
-    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v27 = await this.embedAttempt(text, kind);
+    if (v27 !== "recycled")
+      return v27;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join7(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path2}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
-  renameSync(tmp, path2);
-}
-async function withQueueLock(fn4) {
-  const path2 = lockPath();
-  mkdirSync2(join7(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync(path2, "wx", 384);
-      break;
-    } catch (e6) {
-      const code = e6.code;
-      if (code !== "EEXIST")
-        throw e6;
-      try {
-        const age = Date.now() - statSync2(path2).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync(path2);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log3(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e6) {
+      const err = e6 instanceof Error ? e6.message : String(e6);
+      log3(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep2(delay);
     }
   }
-  if (fd === null) {
-    log3(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn4();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync4(this.socketPath))
+        return;
+      await new Promise((r10) => setTimeout(r10, 50));
+    }
   }
-  try {
-    return fn4();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e6) {
+      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      return false;
     }
-    try {
-      unlinkSync(path2);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a15, b26) {
-  if (a15.id !== b26.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log3(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
-}
-async function enqueueNotification(n24) {
-  await withQueueLock(() => {
-    const q17 = readQueue();
-    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync4(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s10 = await this.connectOnce();
+      s10.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s10 = await this.waitForSocket();
+        s10.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve5, reject) => {
+      const sock = connect(this.socketPath);
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to3);
+        resolve5(sock);
+      });
+      sock.once("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync(this.pidPath, "wx", 384);
+      writeSync(fd, String(process.pid));
+    } catch (e6) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync(this.pidPath, "wx", 384);
+          writeSync(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
+      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync(fd);
+        unlinkSync(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q17.queue.push(n24);
-    writeQueue(q17);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log3(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep2(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync4(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve5, reject) => {
+      let buf = "";
+      const to3 = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl3 = buf.indexOf("\n");
+        if (nl3 === -1)
+          return;
+        const line = buf.slice(0, nl3);
+        clearTimeout(to3);
+        try {
+          resolve5(JSON.parse(line));
+        } catch (e6) {
+          reject(e6);
+        }
+      });
+      sock.on("error", (e6) => {
+        clearTimeout(to3);
+        reject(e6);
+      });
+      sock.on("end", () => {
+        clearTimeout(to3);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep2(ms3) {
+  return new Promise((r10) => setTimeout(r10, ms3));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
+}
+
+// dist/src/embeddings/sql.js
+function embeddingSqlLiteral(vec) {
+  if (!vec || vec.length === 0)
+    return "NULL";
+  const parts = [];
+  for (const v27 of vec) {
+    if (!Number.isFinite(v27))
+      return "NULL";
+    parts.push(String(v27));
+  }
+  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/embeddings/disable.js
@@ -67812,7 +68091,7 @@ import { join as join9 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync4, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname as dirname4, join as join8 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
@@ -67822,7 +68101,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path2 = _configPath();
-  if (!existsSync4(path2)) {
+  if (!existsSync5(path2)) {
     _cache = {};
     return _cache;
   }
@@ -67840,11 +68119,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path2 = _configPath();
   const dir = dirname4(path2);
-  if (!existsSync4(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync5(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync2(tmp, path2);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -67921,403 +68200,6 @@ function embeddingsStatus() {
 }
 function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
-}
-
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join10(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log4 = (m26) => log("embed-client", m26);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync5(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v27 = await this.embedAttempt(text, kind);
-    if (v27 !== "recycled")
-      return v27;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log4(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e6) {
-      const err = e6 instanceof Error ? e6.message : String(e6);
-      log4(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync5(this.socketPath))
-        return;
-      await new Promise((r10) => setTimeout(r10, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e6) {
-      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log4(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync5(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e6) => {
-      log4(`enqueue embed-deps-missing failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync5(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync2(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync2(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s10 = await this.connectOnce();
-      s10.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s10 = await this.waitForSocket();
-        s10.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve6, reject) => {
-      const sock = connect(this.socketPath);
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to3);
-        resolve6(sock);
-      });
-      sock.once("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync2(this.pidPath, "wx", 384);
-      writeSync(fd, String(process.pid));
-    } catch (e6) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync2(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync2(this.pidPath, "wx", 384);
-          writeSync(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync5(this.daemonEntry)) {
-      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync2(fd);
-        unlinkSync2(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log4(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync2(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync5(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep3(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync5(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve6, reject) => {
-      let buf = "";
-      const to3 = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl3 = buf.indexOf("\n");
-        if (nl3 === -1)
-          return;
-        const line = buf.slice(0, nl3);
-        clearTimeout(to3);
-        try {
-          resolve6(JSON.parse(line));
-        } catch (e6) {
-          reject(e6);
-        }
-      });
-      sock.on("error", (e6) => {
-        clearTimeout(to3);
-        reject(e6);
-      });
-      sock.on("end", () => {
-        clearTimeout(to3);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep3(ms3) {
-  return new Promise((r10) => setTimeout(r10, ms3));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
-// dist/src/embeddings/sql.js
-function embeddingSqlLiteral(vec) {
-  if (!vec || vec.length === 0)
-    return "NULL";
-  const parts = [];
-  for (const v27 of vec) {
-    if (!Number.isFinite(v27))
-      return "NULL";
-    parts.push(String(v27));
-  }
-  return `ARRAY[${parts.join(",")}]::float4[]`;
 }
 
 // dist/src/hooks/virtual-table-query.js
@@ -68412,7 +68294,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68978,7 +68860,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve5 } from "path";
+import { normalize, resolve as resolve4 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69916,7 +69798,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync5 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69938,12 +69820,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve5,
+  resolve: resolve4,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync5(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69963,11 +69845,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join11 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/hermes/bundle/shell/deeplake-shell.js
+++ b/hermes/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join13(output, replacement);
+        return join14(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join13(output, rule.append(self2.options));
+          output = join14(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join13(output, replacement) {
+    function join14(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join7 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join8 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join8(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join7(getIndexMarkerDir(), `${markerKey}.json`);
+  return join8(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66942,6 +66942,24 @@ async function enqueueNotification(n24) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join7 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join7(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join7(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66978,11 +66996,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c15 = loadCredentials();
+    if (c15?.orgName && c15?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c15.orgName)}/workspace/${encodeURIComponent(c15.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -67382,7 +67410,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join11 } from "node:path";
+import { dirname as dirname5, join as join12 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67812,9 +67840,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join8 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync3, existsSync as existsSync4, readFileSync as readFileSync5 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join9 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67828,7 +67856,7 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var SHARED_DAEMON_PATH = join9(homedir5(), ".hivemind", "embed-deps", "embed-daemon.js");
 var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
@@ -68019,7 +68047,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync5(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -68032,11 +68060,11 @@ var EmbedClient = class {
       log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync2(this.socketPath);
+      unlinkSync3(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync2(this.pidPath);
+      unlinkSync3(this.pidPath);
     } catch {
     }
   }
@@ -68087,7 +68115,7 @@ var EmbedClient = class {
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync2(this.pidPath);
+          unlinkSync3(this.pidPath);
         } catch {
         }
         try {
@@ -68104,7 +68132,7 @@ var EmbedClient = class {
       log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
         closeSync2(fd);
-        unlinkSync2(this.pidPath);
+        unlinkSync3(this.pidPath);
       } catch {
       }
       return;
@@ -68123,7 +68151,7 @@ var EmbedClient = class {
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
+      const raw = readFileSync5(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68209,15 +68237,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir6 } from "node:os";
-import { join as join10 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join11 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname as dirname4, join as join9 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync4, readFileSync as readFileSync6, renameSync as renameSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname as dirname4, join as join10 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join10(homedir6(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68229,7 +68257,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync5(path2, "utf-8");
+    const raw = readFileSync6(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68243,9 +68271,9 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  writeFileSync4(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
   renameSync2(tmp, path2);
   _cache = merged;
   return merged;
@@ -68295,7 +68323,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
+  const sharedDir = join11(homedir7(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68417,7 +68445,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -69921,7 +69949,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync6 } from "fs";
+import { readFileSync as readFileSync7 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69948,7 +69976,7 @@ var parser = new YargsParser({
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync6(path2, "utf8"));
+      return JSON.parse(readFileSync7(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69968,11 +69996,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join12 } from "node:path";
+import { dirname as dirname6, join as join13 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join13(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/hermes/bundle/shell/deeplake-shell.js
+++ b/hermes/bundle/shell/deeplake-shell.js
@@ -66991,13 +66991,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e6) => {
     log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
   });

--- a/hermes/bundle/shell/deeplake-shell.js
+++ b/hermes/bundle/shell/deeplake-shell.js
@@ -46081,14 +46081,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self2, node);
         }
-        return join12(output, replacement);
+        return join13(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self2 = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join12(output, rule.append(self2.options));
+          output = join13(output, rule.append(self2.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -46100,7 +46100,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join12(output, replacement) {
+    function join13(output, replacement) {
       var s12 = trimTrailingNewlines(output);
       var s22 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s12.length, replacement.length - s22.length);
@@ -59941,21 +59941,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync3, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join6 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join7 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join6(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join7(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join6(getIndexMarkerDir(), `${markerKey}.json`);
+  return join7(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync3(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -59965,8 +59965,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -66841,6 +66841,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync as statSync2 } from "node:fs";
+import { join as join6, resolve as resolve4 } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join6(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path2, home) {
+  const r10 = resolve4(path2);
+  const h18 = resolve4(home);
+  return r10.startsWith(h18 + "/") || r10 === h18;
+}
+function writeQueue(q17) {
+  const path2 = queuePath();
+  const home = resolve4(homedir3());
+  if (!_isQueuePathInsideHome(path2, home)) {
+    throw new Error(`notifications-queue write blocked: ${path2} is outside ${home}`);
+  }
+  mkdirSync(join6(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path2}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q17, null, 2), { mode: 384 });
+  renameSync(tmp, path2);
+}
+async function withQueueLock(fn4) {
+  const path2 = lockPath();
+  mkdirSync(join6(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path2, "wx", 384);
+      break;
+    } catch (e6) {
+      const code = e6.code;
+      if (code !== "EEXIST")
+        throw e6;
+      try {
+        const age = Date.now() - statSync2(path2).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path2);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn4();
+  }
+  try {
+    return fn4();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path2);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a15, b26) {
+  if (a15.id !== b26.id)
+    return false;
+  return JSON.stringify(a15.dedupKey) === JSON.stringify(b26.dedupKey);
+}
+async function enqueueNotification(n24) {
+  await withQueueLock(() => {
+    const q17 = readQueue();
+    if (q17.queue.some((existing) => sameDedupKey(existing, n24))) {
+      return;
+    }
+    q17.queue.push(n24);
+    writeQueue(q17);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -66848,7 +66949,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -66860,7 +66961,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e6) => {
+    log3(`enqueue balance-exhausted failed: ${e6 instanceof Error ? e6.message : String(e6)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -66869,8 +66991,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms3) {
-  return new Promise((resolve5) => setTimeout(resolve5, ms3));
+function sleep2(ms3) {
+  return new Promise((resolve6) => setTimeout(resolve6, ms3));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -66900,7 +67022,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve5) => this.waiting.push(resolve5));
+    await new Promise((resolve6) => this.waiting.push(resolve6));
   }
   release() {
     this.active--;
@@ -66971,8 +67093,8 @@ var DeeplakeApi = class {
         lastError = e6 instanceof Error ? e6 : new Error(String(e6));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -66988,10 +67110,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -67012,7 +67135,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i11, i11 + CONCURRENCY);
       await Promise.allSettled(chunk.map((r10) => this.upsertRowSql(r10)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts3 = (/* @__PURE__ */ new Date()).toISOString();
@@ -67068,7 +67191,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e6.message}`);
+      log3(`index "${indexName}" skipped: ${e6.message}`);
     }
   }
   /**
@@ -67158,13 +67281,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -67192,9 +67315,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -67205,9 +67328,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -67220,9 +67343,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67245,9 +67368,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -67259,7 +67382,7 @@ var DeeplakeApi = class {
 import { basename as basename4, posix } from "node:path";
 import { randomUUID as randomUUID2 } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname as dirname5, join as join10 } from "node:path";
+import { dirname as dirname5, join as join11 } from "node:path";
 
 // dist/src/shell/grep-core.js
 var TOOL_INPUT_FIELDS = [
@@ -67689,9 +67812,9 @@ function refineGrepMatches(rows, params, forceMultiFilePrefix) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync, closeSync, writeSync, unlinkSync, existsSync as existsSync4, readFileSync as readFileSync3 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join7 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync, unlinkSync as unlinkSync2, existsSync as existsSync4, readFileSync as readFileSync4 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join8 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -67705,8 +67828,8 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
 }
 
 // dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join7(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m26) => log("embed-client", m26);
+var SHARED_DAEMON_PATH = join8(homedir4(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log4 = (m26) => log("embed-client", m26);
 function getUid() {
   const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
   return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
@@ -67782,7 +67905,7 @@ var EmbedClient = class {
       const resp = await this.sendAndWait(sock, req);
       if (resp.error || !("embedding" in resp) || !resp.embedding) {
         const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
+        log4(`embed err: ${err}`);
         if (isTransformersMissingError(err)) {
           this.handleTransformersMissing(err);
         }
@@ -67791,7 +67914,7 @@ var EmbedClient = class {
       return resp.embedding;
     } catch (e6) {
       const err = e6 instanceof Error ? e6.message : String(e6);
-      log3(`embed failed: ${err}`);
+      log4(`embed failed: ${err}`);
       return null;
     } finally {
       try {
@@ -67838,7 +67961,7 @@ var EmbedClient = class {
     try {
       resp = await this.sendAndWait(sock, req);
     } catch (e6) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
+      log4(`hello probe failed (inconclusive, will retry next connect): ${e6 instanceof Error ? e6.message : String(e6)}`);
       return false;
     }
     const hello = resp;
@@ -67847,13 +67970,13 @@ var EmbedClient = class {
     }
     if (!hello.daemonPath) {
       _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
+      log4(`daemon does not implement hello (older protocol); recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
     if (hello.daemonPath !== this.daemonEntry && !existsSync4(hello.daemonPath)) {
       _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      log4(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
       this.recycleDaemon(hello.pid);
       return true;
     }
@@ -67896,7 +68019,7 @@ var EmbedClient = class {
     let pid = reportedPid;
     if (pid === null) {
       try {
-        pid = Number.parseInt(readFileSync3(this.pidPath, "utf-8").trim(), 10);
+        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
       } catch {
       }
     }
@@ -67906,14 +68029,14 @@ var EmbedClient = class {
       } catch {
       }
     } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+      log4(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
     }
     try {
-      unlinkSync(this.socketPath);
+      unlinkSync2(this.socketPath);
     } catch {
     }
     try {
-      unlinkSync(this.pidPath);
+      unlinkSync2(this.pidPath);
     } catch {
     }
   }
@@ -67940,7 +68063,7 @@ var EmbedClient = class {
     }
   }
   connectOnce() {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       const sock = connect(this.socketPath);
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -67948,7 +68071,7 @@ var EmbedClient = class {
       }, this.timeoutMs);
       sock.once("connect", () => {
         clearTimeout(to3);
-        resolve5(sock);
+        resolve6(sock);
       });
       sock.once("error", (e6) => {
         clearTimeout(to3);
@@ -67959,16 +68082,16 @@ var EmbedClient = class {
   trySpawnDaemon() {
     let fd;
     try {
-      fd = openSync(this.pidPath, "wx", 384);
+      fd = openSync2(this.pidPath, "wx", 384);
       writeSync(fd, String(process.pid));
     } catch (e6) {
       if (this.isPidFileStale()) {
         try {
-          unlinkSync(this.pidPath);
+          unlinkSync2(this.pidPath);
         } catch {
         }
         try {
-          fd = openSync(this.pidPath, "wx", 384);
+          fd = openSync2(this.pidPath, "wx", 384);
           writeSync(fd, String(process.pid));
         } catch {
           return;
@@ -67978,10 +68101,10 @@ var EmbedClient = class {
       }
     }
     if (!this.daemonEntry || !existsSync4(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      log4(`daemonEntry not configured or missing: ${this.daemonEntry}`);
       try {
-        closeSync(fd);
-        unlinkSync(this.pidPath);
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
       } catch {
       }
       return;
@@ -67993,14 +68116,14 @@ var EmbedClient = class {
         env: process.env
       });
       child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
+      log4(`spawned daemon pid=${child.pid}`);
     } finally {
-      closeSync(fd);
+      closeSync2(fd);
     }
   }
   isPidFileStale() {
     try {
-      const raw = readFileSync3(this.pidPath, "utf-8").trim();
+      const raw = readFileSync4(this.pidPath, "utf-8").trim();
       const pid = Number(raw);
       if (!pid || Number.isNaN(pid))
         return true;
@@ -68018,7 +68141,7 @@ var EmbedClient = class {
     const deadline = Date.now() + this.spawnWaitMs;
     let delay = 30;
     while (Date.now() < deadline) {
-      await sleep2(delay);
+      await sleep3(delay);
       delay = Math.min(delay * 1.5, 300);
       if (!existsSync4(this.socketPath))
         continue;
@@ -68030,7 +68153,7 @@ var EmbedClient = class {
     throw new Error("daemon did not become ready within spawnWaitMs");
   }
   sendAndWait(sock, req) {
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       let buf = "";
       const to3 = setTimeout(() => {
         sock.destroy();
@@ -68045,7 +68168,7 @@ var EmbedClient = class {
         const line = buf.slice(0, nl3);
         clearTimeout(to3);
         try {
-          resolve5(JSON.parse(line));
+          resolve6(JSON.parse(line));
         } catch (e6) {
           reject(e6);
         }
@@ -68062,7 +68185,7 @@ var EmbedClient = class {
     });
   }
 };
-function sleep2(ms3) {
+function sleep3(ms3) {
   return new Promise((r10) => setTimeout(r10, ms3));
 }
 function isTransformersMissingError(err) {
@@ -68086,15 +68209,15 @@ function embeddingSqlLiteral(vec) {
 
 // dist/src/embeddings/disable.js
 import { createRequire } from "node:module";
-import { homedir as homedir5 } from "node:os";
-import { join as join9 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join10 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync5, mkdirSync as mkdirSync2, readFileSync as readFileSync4, renameSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { dirname as dirname4, join as join8 } from "node:path";
-var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join8(homedir4(), ".deeplake", "config.json");
+import { existsSync as existsSync5, mkdirSync as mkdirSync3, readFileSync as readFileSync5, renameSync as renameSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { dirname as dirname4, join as join9 } from "node:path";
+var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join9(homedir5(), ".deeplake", "config.json");
 var _cache = null;
 var _migrated = false;
 function readUserConfig() {
@@ -68106,7 +68229,7 @@ function readUserConfig() {
     return _cache;
   }
   try {
-    const raw = readFileSync4(path2, "utf-8");
+    const raw = readFileSync5(path2, "utf-8");
     const parsed = JSON.parse(raw);
     _cache = isPlainObject(parsed) ? parsed : {};
   } catch {
@@ -68120,10 +68243,10 @@ function writeUserConfig(patch) {
   const path2 = _configPath();
   const dir = dirname4(path2);
   if (!existsSync5(dir))
-    mkdirSync2(dir, { recursive: true });
+    mkdirSync3(dir, { recursive: true });
   const tmp = `${path2}.tmp.${process.pid}`;
-  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync(tmp, path2);
+  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path2);
   _cache = merged;
   return merged;
 }
@@ -68172,7 +68295,7 @@ function deepMerge(base, patch) {
 // dist/src/embeddings/disable.js
 var cachedStatus = null;
 function defaultResolveTransformers() {
-  const sharedDir = join9(homedir5(), ".hivemind", "embed-deps");
+  const sharedDir = join10(homedir6(), ".hivemind", "embed-deps");
   try {
     createRequire(pathToFileURL(`${sharedDir}/`).href).resolve("@huggingface/transformers");
     return;
@@ -68294,7 +68417,7 @@ function normalizeSessionMessage(path2, message) {
   return normalizeContent(path2, raw);
 }
 function resolveEmbedDaemonPath() {
-  return join10(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join11(dirname5(fileURLToPath(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 function joinSessionMessages(path2, messages) {
   return messages.map((message) => normalizeSessionMessage(path2, message)).join("\n");
@@ -68860,7 +68983,7 @@ var DeeplakeFs = class _DeeplakeFs {
 
 // node_modules/yargs-parser/build/lib/index.js
 import { format } from "util";
-import { normalize, resolve as resolve4 } from "path";
+import { normalize, resolve as resolve5 } from "path";
 
 // node_modules/yargs-parser/build/lib/string-utils.js
 function camelCase2(str) {
@@ -69798,7 +69921,7 @@ function stripQuotes(val) {
 }
 
 // node_modules/yargs-parser/build/lib/index.js
-import { readFileSync as readFileSync5 } from "fs";
+import { readFileSync as readFileSync6 } from "fs";
 import { createRequire as createRequire2 } from "node:module";
 var _a3;
 var _b;
@@ -69820,12 +69943,12 @@ var parser = new YargsParser({
   },
   format,
   normalize,
-  resolve: resolve4,
+  resolve: resolve5,
   require: (path2) => {
     if (typeof require2 !== "undefined") {
       return require2(path2);
     } else if (path2.match(/\.json$/)) {
-      return JSON.parse(readFileSync5(path2, "utf8"));
+      return JSON.parse(readFileSync6(path2, "utf8"));
     } else {
       throw Error("only .json config files are supported in ESM");
     }
@@ -69845,11 +69968,11 @@ var lib_default = yargsParser;
 
 // dist/src/shell/grep-interceptor.js
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { dirname as dirname6, join as join11 } from "node:path";
+import { dirname as dirname6, join as join12 } from "node:path";
 var SEMANTIC_SEARCH_ENABLED = process.env.HIVEMIND_SEMANTIC_SEARCH !== "false" && !embeddingsDisabled();
 var SEMANTIC_EMBED_TIMEOUT_MS = Number(process.env.HIVEMIND_SEMANTIC_EMBED_TIMEOUT_MS ?? "500");
 function resolveGrepEmbedDaemonPath() {
-  return join11(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
+  return join12(dirname6(fileURLToPath2(import.meta.url)), "..", "embeddings", "embed-daemon.js");
 }
 var sharedGrepEmbedClient = null;
 function getGrepEmbedClient() {

--- a/hermes/bundle/wiki-worker.js
+++ b/hermes/bundle/wiki-worker.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // dist/src/hooks/hermes/wiki-worker.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync4, rmSync } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync3, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { dirname as dirname2, join as join7 } from "node:path";
+import { dirname as dirname2, join as join6 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // dist/src/hooks/summary-state.js
@@ -154,9 +154,9 @@ async function uploadSummary(query2, params) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync2, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync as writeSync2, unlinkSync as unlinkSync2, existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join3 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -169,105 +169,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, renameSync as renameSync2, mkdirSync as mkdirSync2, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join3, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
-var log2 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join3(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log2 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath2() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync2(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log2(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync2(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join3(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync2(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath2();
-  mkdirSync2(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync2(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log2(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log2(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep(delay);
     }
   }
-  if (fd === null) {
-    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync2(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync2(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log2(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log2(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync2(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log2(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync2(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync2(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log2(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync2(this.pidPath, "wx", 384);
+      writeSync2(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync2(this.pidPath, "wx", 384);
+          writeSync2(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync2(this.daemonEntry)) {
+      log2(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log2(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync2(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync2(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync2(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -277,7 +543,7 @@ import { join as join5 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync3, renameSync as renameSync3, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join4 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join4(homedir4(), ".deeplake", "config.json");
@@ -287,7 +553,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     _cache = {};
     return _cache;
   }
@@ -305,11 +571,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync2(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync3(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync3(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -388,390 +654,6 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync3(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log3(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync3(this.pidPath, "wx", 384);
-      writeSync2(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync3(this.pidPath, "wx", 384);
-          writeSync2(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync3(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep2(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync3(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep2(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/utils/client-header.js
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
@@ -783,13 +665,13 @@ function deeplakeClientHeader() {
 
 // dist/src/hooks/hermes/wiki-worker.js
 var dlog2 = (msg) => log("hermes-wiki-worker", msg);
-var cfg = JSON.parse(readFileSync5(process.argv[2], "utf-8"));
+var cfg = JSON.parse(readFileSync4(process.argv[2], "utf-8"));
 var tmpDir = cfg.tmpDir;
-var tmpJsonl = join7(tmpDir, "session.jsonl");
-var tmpSummary = join7(tmpDir, "summary.md");
+var tmpJsonl = join6(tmpDir, "session.jsonl");
+var tmpSummary = join6(tmpDir, "summary.md");
 function wlog(msg) {
   try {
-    mkdirSync4(cfg.hooksDir, { recursive: true });
+    mkdirSync3(cfg.hooksDir, { recursive: true });
     appendFileSync2(cfg.wikiLog, `[${(/* @__PURE__ */ new Date()).toISOString().replace("T", " ").slice(0, 19)}] wiki-worker(${cfg.sessionId}): ${msg}
 `);
   } catch {
@@ -821,7 +703,7 @@ async function query(sql, retries = 4) {
       const base = Math.min(3e4, 2e3 * Math.pow(2, attempt));
       const delay = base + Math.floor(Math.random() * 1e3);
       wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise((resolve2) => setTimeout(resolve2, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       continue;
     }
     throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
@@ -847,7 +729,7 @@ async function main() {
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc2(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
-    writeFileSync4(tmpJsonl, jsonlContent);
+    writeFileSync3(tmpJsonl, jsonlContent);
     wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
     let prevOffset = 0;
     try {
@@ -857,7 +739,7 @@ async function main() {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
-        writeFileSync4(tmpSummary, existing);
+        writeFileSync3(tmpSummary, existing);
         wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch {
@@ -884,14 +766,14 @@ async function main() {
       wlog(`hermes -z failed: ${e.status ?? e.message}`);
     }
     if (existsSync4(tmpSummary)) {
-      const text = readFileSync5(tmpSummary, "utf-8");
+      const text = readFileSync4(tmpSummary, "utf-8");
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         let embedding = null;
         if (!embeddingsDisabled()) {
           try {
-            const daemonEntry = join7(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
+            const daemonEntry = join6(dirname2(fileURLToPath(import.meta.url)), "embeddings", "embed-daemon.js");
             embedding = await new EmbedClient({ daemonEntry }).embed(text, "document");
           } catch (e) {
             wlog(`summary embedding failed, writing NULL: ${e.message}`);

--- a/mcp/bundle/server.js
+++ b/mcp/bundle/server.js
@@ -23501,11 +23501,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date: date4 }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;

--- a/mcp/bundle/server.js
+++ b/mcp/bundle/server.js
@@ -23496,13 +23496,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date4 = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date: date4 }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/mcp/bundle/server.js
+++ b/mcp/bundle/server.js
@@ -2983,7 +2983,7 @@ var require_compile = __commonJS({
       const schOrFunc = root.refs[ref];
       if (schOrFunc)
         return schOrFunc;
-      let _sch = resolve.call(this, root, ref);
+      let _sch = resolve2.call(this, root, ref);
       if (_sch === void 0) {
         const schema = (_a2 = root.localRefs) === null || _a2 === void 0 ? void 0 : _a2[ref];
         const { schemaId } = this.opts;
@@ -3010,7 +3010,7 @@ var require_compile = __commonJS({
     function sameSchemaEnv(s1, s2) {
       return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
     }
-    function resolve(root, ref) {
+    function resolve2(root, ref) {
       let sch;
       while (typeof (sch = this.refs[ref]) == "string")
         ref = sch;
@@ -3585,7 +3585,7 @@ var require_fast_uri = __commonJS({
       }
       return uri;
     }
-    function resolve(baseURI, relativeURI, options) {
+    function resolve2(baseURI, relativeURI, options) {
       const schemelessOptions = options ? Object.assign({ scheme: "null" }, options) : { scheme: "null" };
       const resolved = resolveComponent(parse3(baseURI, schemelessOptions), parse3(relativeURI, schemelessOptions), schemelessOptions, true);
       schemelessOptions.skipEscape = true;
@@ -3812,7 +3812,7 @@ var require_fast_uri = __commonJS({
     var fastUri = {
       SCHEMES,
       normalize,
-      resolve,
+      resolve: resolve2,
       resolveComponent,
       equal,
       serialize,
@@ -4316,11 +4316,11 @@ var require_core = __commonJS({
     Ajv2.ValidationError = validation_error_1.default;
     Ajv2.MissingRefError = ref_error_1.default;
     exports.default = Ajv2;
-    function checkOptions(checkOpts, options, msg, log3 = "error") {
+    function checkOptions(checkOpts, options, msg, log4 = "error") {
       for (const key in checkOpts) {
         const opt = key;
         if (opt in options)
-          this.logger[log3](`${msg}: option ${key}. ${checkOpts[opt]}`);
+          this.logger[log4](`${msg}: option ${key}. ${checkOpts[opt]}`);
       }
     }
     function getSchEnv(keyRef) {
@@ -6809,21 +6809,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -6833,8 +6833,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -21144,7 +21144,7 @@ var Protocol = class {
           return;
         }
         const pollInterval = task2.pollInterval ?? this._options?.defaultTaskPollInterval ?? 1e3;
-        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        await new Promise((resolve2) => setTimeout(resolve2, pollInterval));
         options?.signal?.throwIfAborted();
       }
     } catch (error2) {
@@ -21161,7 +21161,7 @@ var Protocol = class {
    */
   request(request, resultSchema, options) {
     const { relatedRequestId, resumptionToken, onresumptiontoken, task, relatedTask } = options ?? {};
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       const earlyReject = (error2) => {
         reject(error2);
       };
@@ -21239,7 +21239,7 @@ var Protocol = class {
           if (!parseResult.success) {
             reject(parseResult.error);
           } else {
-            resolve(parseResult.data);
+            resolve2(parseResult.data);
           }
         } catch (error2) {
           reject(error2);
@@ -21500,12 +21500,12 @@ var Protocol = class {
       }
     } catch {
     }
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve2, reject) => {
       if (signal.aborted) {
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
         return;
       }
-      const timeoutId = setTimeout(resolve, interval);
+      const timeoutId = setTimeout(resolve2, interval);
       signal.addEventListener("abort", () => {
         clearTimeout(timeoutId);
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
@@ -22605,7 +22605,7 @@ var McpServer = class {
     let task = createTaskResult.task;
     const pollInterval = task.pollInterval ?? 5e3;
     while (task.status !== "completed" && task.status !== "failed" && task.status !== "cancelled") {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      await new Promise((resolve2) => setTimeout(resolve2, pollInterval));
       const updatedTask = await extra.taskStore.getTask(taskId);
       if (!updatedTask) {
         throw new McpError(ErrorCode.InternalError, `Task ${taskId} not found during polling`);
@@ -23254,12 +23254,12 @@ var StdioServerTransport = class {
     this.onclose?.();
   }
   send(message) {
-    return new Promise((resolve) => {
+    return new Promise((resolve2) => {
       const json2 = serializeMessage(message);
       if (this._stdout.write(json2)) {
-        resolve();
+        resolve2();
       } else {
-        this._stdout.once("drain", resolve);
+        this._stdout.once("drain", resolve2);
       }
     });
   }
@@ -23364,6 +23364,107 @@ function sqlIdent(name) {
 var SUMMARY_EMBEDDING_COL = "summary_embedding";
 var MESSAGE_EMBEDDING_COL = "message_embedding";
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, renameSync, mkdirSync as mkdirSync2, openSync, closeSync, unlinkSync as unlinkSync2, statSync } from "node:fs";
+import { join as join4, resolve } from "node:path";
+import { homedir as homedir4 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join4(homedir4(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync3(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir4());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync2(join4(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync2(join4(homedir4(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync2(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync2(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -23371,7 +23472,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -23383,7 +23484,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date4 = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date: date4 }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -23392,8 +23514,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error2) {
   const name = error2 instanceof Error ? error2.name.toLowerCase() : "";
@@ -23423,7 +23545,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -23494,8 +23616,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -23511,10 +23633,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -23535,7 +23658,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -23591,7 +23714,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -23681,13 +23804,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -23715,9 +23838,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -23728,9 +23851,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -23743,9 +23866,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -23768,9 +23891,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -24153,20 +24276,20 @@ function buildContentFilter(column, likeOp, patterns) {
 }
 
 // dist/src/cli/version.js
-import { readFileSync as readFileSync5 } from "node:fs";
-import { join as join6 } from "node:path";
+import { readFileSync as readFileSync6 } from "node:fs";
+import { join as join7 } from "node:path";
 
 // dist/src/cli/util.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3, cpSync, symlinkSync, unlinkSync as unlinkSync2, lstatSync } from "node:fs";
-import { join as join5, dirname } from "node:path";
-import { homedir as homedir4 } from "node:os";
+import { existsSync as existsSync3, mkdirSync as mkdirSync4, readFileSync as readFileSync5, writeFileSync as writeFileSync4, cpSync, symlinkSync, unlinkSync as unlinkSync3, lstatSync } from "node:fs";
+import { join as join6, dirname } from "node:path";
+import { homedir as homedir5 } from "node:os";
 import { fileURLToPath } from "node:url";
-var HOME = homedir4();
+var HOME = homedir5();
 function pkgRoot() {
   let dir = fileURLToPath(new URL(".", import.meta.url));
   for (let i = 0; i < 8; i++) {
     try {
-      const pkg = JSON.parse(readFileSync4(join5(dir, "package.json"), "utf-8"));
+      const pkg = JSON.parse(readFileSync5(join6(dir, "package.json"), "utf-8"));
       if (pkg.name === "@deeplake/hivemind" || pkg.name === "hivemind")
         return dir;
     } catch {
@@ -24179,21 +24302,21 @@ function pkgRoot() {
   return fileURLToPath(new URL("..", import.meta.url));
 }
 var PLATFORM_MARKERS = [
-  { id: "claude", markerDir: join5(HOME, ".claude") },
-  { id: "codex", markerDir: join5(HOME, ".codex") },
-  { id: "claw", markerDir: join5(HOME, ".openclaw") },
-  { id: "cursor", markerDir: join5(HOME, ".cursor") },
-  { id: "hermes", markerDir: join5(HOME, ".hermes") },
+  { id: "claude", markerDir: join6(HOME, ".claude") },
+  { id: "codex", markerDir: join6(HOME, ".codex") },
+  { id: "claw", markerDir: join6(HOME, ".openclaw") },
+  { id: "cursor", markerDir: join6(HOME, ".cursor") },
+  { id: "hermes", markerDir: join6(HOME, ".hermes") },
   // pi (badlogic/pi-mono coding-agent) — config at ~/.pi/agent/. pi exposes
   // a rich extension event API (session_start / input / tool_call /
   // tool_result / message_end / session_shutdown / etc.) — Tier 1 capable.
-  { id: "pi", markerDir: join5(HOME, ".pi") }
+  { id: "pi", markerDir: join6(HOME, ".pi") }
 ];
 
 // dist/src/cli/version.js
 function getVersion() {
   try {
-    const pkg = JSON.parse(readFileSync5(join6(pkgRoot(), "package.json"), "utf-8"));
+    const pkg = JSON.parse(readFileSync6(join7(pkgRoot(), "package.json"), "utf-8"));
     return pkg.version ?? "0.0.0";
   } catch {
     return "0.0.0";

--- a/pi/bundle/autopull-worker.js
+++ b/pi/bundle/autopull-worker.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync4, writeFileSync as writeFileSync3 } from "node:fs";
+import { join as join5 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join5(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join4(getIndexMarkerDir(), `${markerKey}.json`);
+  return join5(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync4(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync2(getIndexMarkerDir(), { recursive: true });
-  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync3(getIndexMarkerDir(), { recursive: true });
+  writeFileSync3(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -227,6 +227,24 @@ async function enqueueNotification(n) {
   });
 }
 
+// dist/src/commands/auth-creds.js
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4 } from "node:path";
+import { homedir as homedir4 } from "node:os";
+function configDir() {
+  return join4(homedir4(), ".deeplake");
+}
+function credsPath() {
+  return join4(configDir(), "credentials.json");
+}
+function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync3(credsPath(), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -263,11 +281,21 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+function billingUrl() {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch {
+  }
+  return "https://deeplake.ai";
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -664,14 +692,14 @@ var DeeplakeApi = class {
 };
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync5, mkdirSync as mkdirSync5, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync3 } from "node:fs";
-import { homedir as homedir8 } from "node:os";
-import { dirname as dirname2, join as join9 } from "node:path";
+import { existsSync as existsSync7, readFileSync as readFileSync7, writeFileSync as writeFileSync6, mkdirSync as mkdirSync6, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync4 } from "node:fs";
+import { homedir as homedir9 } from "node:os";
+import { dirname as dirname2, join as join10 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, readdirSync, statSync as statSync2, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync4, readFileSync as readFileSync5, readdirSync, statSync as statSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -737,23 +765,23 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readFileSync as readFileSync5, renameSync as renameSync3, unlinkSync as unlinkSync2, writeFileSync as writeFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { dirname, join as join7 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync5, readFileSync as readFileSync6, renameSync as renameSync3, unlinkSync as unlinkSync3, writeFileSync as writeFileSync5 } from "node:fs";
+import { homedir as homedir7 } from "node:os";
+import { dirname, join as join8 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
 import { existsSync as existsSync4, renameSync as renameSync2 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { join as join6 } from "node:path";
+import { homedir as homedir6 } from "node:os";
+import { join as join7 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join6(homedir5(), ".deeplake", "state");
-  const legacy = join6(root, "skilify");
-  const current = join6(root, "skillify");
+  const root = join7(homedir6(), ".deeplake", "state");
+  const legacy = join7(root, "skilify");
+  const current = join7(root, "skillify");
   if (!existsSync4(legacy))
     return;
   if (existsSync4(current))
@@ -776,7 +804,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join7(homedir6(), ".deeplake", "state", "skillify", "pulled.json");
+  return join8(homedir7(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -784,7 +812,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync5(path, "utf-8");
+    raw = readFileSync6(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -831,9 +859,9 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync4(dirname(path), { recursive: true });
+  mkdirSync5(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync4(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  writeFileSync5(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
   renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
@@ -859,7 +887,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync2(path);
+      unlinkSync3(path);
     } catch {
     }
   }
@@ -869,7 +897,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync5(join7(e.installRoot, e.dirName))) {
+    if (existsSync5(join8(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -883,25 +911,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync6 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { join as join8 } from "node:path";
+import { homedir as homedir8 } from "node:os";
+import { join as join9 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync6(join8(home, ".codex"));
-  const piInstalled = existsSync6(join8(home, ".pi", "agent"));
-  const hermesInstalled = existsSync6(join8(home, ".hermes"));
+  const codexInstalled = existsSync6(join9(home, ".codex"));
+  const piInstalled = existsSync6(join9(home, ".pi", "agent"));
+  const hermesInstalled = existsSync6(join9(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join8(home, ".agents", "skills"));
+    out.push(join9(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join8(home, ".hermes", "skills"));
+    out.push(join9(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join8(home, ".pi", "agent", "skills"));
+    out.push(join9(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir7()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir8()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -945,15 +973,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join9(homedir8(), ".claude", "skills");
+    return join10(homedir9(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join9(cwd, ".claude", "skills");
+  return join10(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join9(root, dirName);
+    const link = join10(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -975,13 +1003,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync3(link);
+        unlinkSync4(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync5(dirname2(link), { recursive: true });
+      mkdirSync6(dirname2(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -996,7 +1024,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join9(entry.installRoot, entry.dirName);
+    const canonical = join10(entry.installRoot, entry.dirName);
     if (!existsSync7(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -1110,7 +1138,7 @@ function readLocalVersion(path) {
   if (!existsSync7(path))
     return null;
   try {
-    const text = readFileSync6(path, "utf-8");
+    const text = readFileSync7(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1205,8 +1233,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join9(root, dirName);
-    const skillFile = join9(skillDir, "SKILL.md");
+    const skillDir = join10(root, dirName);
+    const skillFile = join10(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1217,14 +1245,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync5(skillDir, { recursive: true });
+      mkdirSync6(skillDir, { recursive: true });
       if (existsSync7(skillFile)) {
         try {
           renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync5(skillFile, renderSkillFile(row));
+      writeFileSync6(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({

--- a/pi/bundle/autopull-worker.js
+++ b/pi/bundle/autopull-worker.js
@@ -276,13 +276,13 @@ function maybeSignalBalanceExhausted(status, bodyText) {
     return;
   _signalledBalanceExhausted = true;
   log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted \u2014 top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date }
+    dedupKey: { reason: "balance-zero" }
   }).catch((e) => {
     log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/pi/bundle/autopull-worker.js
+++ b/pi/bundle/autopull-worker.js
@@ -16,21 +16,21 @@ __export(index_marker_store_exports, {
   hasFreshIndexMarker: () => hasFreshIndexMarker,
   writeIndexMarker: () => writeIndexMarker
 });
-import { existsSync as existsSync2, mkdirSync, readFileSync as readFileSync2, writeFileSync } from "node:fs";
-import { join as join3 } from "node:path";
+import { existsSync as existsSync2, mkdirSync as mkdirSync2, readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "node:fs";
+import { join as join4 } from "node:path";
 import { tmpdir } from "node:os";
 function getIndexMarkerDir() {
-  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join3(tmpdir(), "hivemind-deeplake-indexes");
+  return process.env.HIVEMIND_INDEX_MARKER_DIR ?? join4(tmpdir(), "hivemind-deeplake-indexes");
 }
 function buildIndexMarkerPath(workspaceId, orgId, table, suffix) {
   const markerKey = [workspaceId, orgId, table, suffix].join("__").replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return join3(getIndexMarkerDir(), `${markerKey}.json`);
+  return join4(getIndexMarkerDir(), `${markerKey}.json`);
 }
 function hasFreshIndexMarker(markerPath) {
   if (!existsSync2(markerPath))
     return false;
   try {
-    const raw = JSON.parse(readFileSync2(markerPath, "utf-8"));
+    const raw = JSON.parse(readFileSync3(markerPath, "utf-8"));
     const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).getTime() : NaN;
     if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > INDEX_MARKER_TTL_MS)
       return false;
@@ -40,8 +40,8 @@ function hasFreshIndexMarker(markerPath) {
   }
 }
 function writeIndexMarker(markerPath) {
-  mkdirSync(getIndexMarkerDir(), { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
+  mkdirSync2(getIndexMarkerDir(), { recursive: true });
+  writeFileSync2(markerPath, JSON.stringify({ updatedAt: (/* @__PURE__ */ new Date()).toISOString() }), "utf-8");
 }
 var INDEX_MARKER_TTL_MS;
 var init_index_marker_store = __esm({
@@ -126,6 +126,107 @@ function deeplakeClientHeader() {
   return { [DEEPLAKE_CLIENT_HEADER]: deeplakeClientValue() };
 }
 
+// dist/src/notifications/queue.js
+import { readFileSync as readFileSync2, writeFileSync, renameSync, mkdirSync, openSync, closeSync, unlinkSync, statSync } from "node:fs";
+import { join as join3, resolve } from "node:path";
+import { homedir as homedir3 } from "node:os";
+import { setTimeout as sleep } from "node:timers/promises";
+var log2 = (msg) => log("notifications-queue", msg);
+var LOCK_RETRY_MAX = 50;
+var LOCK_RETRY_BASE_MS = 5;
+var LOCK_STALE_MS = 5e3;
+function queuePath() {
+  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+}
+function lockPath() {
+  return `${queuePath()}.lock`;
+}
+function readQueue() {
+  try {
+    const raw = readFileSync2(queuePath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.queue)) {
+      log2(`queue malformed \u2192 treating as empty`);
+      return { queue: [] };
+    }
+    return { queue: parsed.queue };
+  } catch {
+    return { queue: [] };
+  }
+}
+function _isQueuePathInsideHome(path, home) {
+  const r = resolve(path);
+  const h = resolve(home);
+  return r.startsWith(h + "/") || r === h;
+}
+function writeQueue(q) {
+  const path = queuePath();
+  const home = resolve(homedir3());
+  if (!_isQueuePathInsideHome(path, home)) {
+    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  }
+  mkdirSync(join3(home, ".deeplake"), { recursive: true, mode: 448 });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(q, null, 2), { mode: 384 });
+  renameSync(tmp, path);
+}
+async function withQueueLock(fn) {
+  const path = lockPath();
+  mkdirSync(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
+  let fd = null;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    try {
+      fd = openSync(path, "wx", 384);
+      break;
+    } catch (e) {
+      const code = e.code;
+      if (code !== "EEXIST")
+        throw e;
+      try {
+        const age = Date.now() - statSync(path).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(path);
+          continue;
+        }
+      } catch {
+      }
+      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
+      await sleep(delay);
+    }
+  }
+  if (fd === null) {
+    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+    }
+    try {
+      unlinkSync(path);
+    } catch {
+    }
+  }
+}
+function sameDedupKey(a, b) {
+  if (a.id !== b.id)
+    return false;
+  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
+}
+async function enqueueNotification(n) {
+  await withQueueLock(() => {
+    const q = readQueue();
+    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+      return;
+    }
+    q.queue.push(n);
+    writeQueue(q);
+  });
+}
+
 // dist/src/deeplake-api.js
 var indexMarkerStorePromise = null;
 function getIndexMarkerStore() {
@@ -133,7 +234,7 @@ function getIndexMarkerStore() {
     indexMarkerStorePromise = Promise.resolve().then(() => (init_index_marker_store(), index_marker_store_exports));
   return indexMarkerStorePromise;
 }
-var log2 = (msg) => log("sdk", msg);
+var log3 = (msg) => log("sdk", msg);
 function summarizeSql(sql, maxLen = 220) {
   const compact = sql.replace(/\s+/g, " ").trim();
   return compact.length > maxLen ? `${compact.slice(0, maxLen)}...` : compact;
@@ -145,7 +246,28 @@ function traceSql(msg) {
   process.stderr.write(`[deeplake-sql] ${msg}
 `);
   if (process.env.HIVEMIND_DEBUG === "1")
-    log2(msg);
+    log3(msg);
+}
+var _signalledBalanceExhausted = false;
+function maybeSignalBalanceExhausted(status, bodyText) {
+  if (status !== 402)
+    return;
+  if (!bodyText.includes("balance_cents"))
+    return;
+  if (_signalledBalanceExhausted)
+    return;
+  _signalledBalanceExhausted = true;
+  log3(`balance exhausted \u2014 enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted \u2014 top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date }
+  }).catch((e) => {
+    log3(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 var RETRYABLE_CODES = /* @__PURE__ */ new Set([429, 500, 502, 503, 504]);
 var MAX_RETRIES = 3;
@@ -154,8 +276,8 @@ var MAX_CONCURRENCY = 5;
 function getQueryTimeoutMs() {
   return Number(process.env.HIVEMIND_QUERY_TIMEOUT_MS ?? 1e4);
 }
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep2(ms) {
+  return new Promise((resolve2) => setTimeout(resolve2, ms));
 }
 function isTimeoutError(error) {
   const name = error instanceof Error ? error.name.toLowerCase() : "";
@@ -185,7 +307,7 @@ var Semaphore = class {
       this.active++;
       return;
     }
-    await new Promise((resolve) => this.waiting.push(resolve));
+    await new Promise((resolve2) => this.waiting.push(resolve2));
   }
   release() {
     this.active--;
@@ -256,8 +378,8 @@ var DeeplakeApi = class {
         lastError = e instanceof Error ? e : new Error(String(e));
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-          log2(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay);
+          log3(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
+          await sleep2(delay);
           continue;
         }
         throw lastError;
@@ -273,10 +395,11 @@ var DeeplakeApi = class {
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
       if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
-        log2(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay);
+        log3(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
+        await sleep2(delay);
         continue;
       }
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -297,7 +420,7 @@ var DeeplakeApi = class {
       const chunk = rows.slice(i, i + CONCURRENCY);
       await Promise.allSettled(chunk.map((r) => this.upsertRowSql(r)));
     }
-    log2(`commit: ${rows.length} rows`);
+    log3(`commit: ${rows.length} rows`);
   }
   async upsertRowSql(row) {
     const ts = (/* @__PURE__ */ new Date()).toISOString();
@@ -353,7 +476,7 @@ var DeeplakeApi = class {
         markers.writeIndexMarker(markerPath);
         return;
       }
-      log2(`index "${indexName}" skipped: ${e.message}`);
+      log3(`index "${indexName}" skipped: ${e.message}`);
     }
   }
   /**
@@ -443,13 +566,13 @@ var DeeplakeApi = class {
           };
         }
         if (attempt < MAX_RETRIES && RETRYABLE_CODES.has(resp.status)) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200);
           continue;
         }
         return { tables: [], cacheable: false };
       } catch {
         if (attempt < MAX_RETRIES) {
-          await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
+          await sleep2(BASE_DELAY_MS * Math.pow(2, attempt));
           continue;
         }
         return { tables: [], cacheable: false };
@@ -477,9 +600,9 @@ var DeeplakeApi = class {
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        log2(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
+        log3(`CREATE TABLE "${label}" attempt ${attempt + 1}/${OUTER_BACKOFFS_MS.length + 1} failed: ${msg}`);
         if (attempt < OUTER_BACKOFFS_MS.length) {
-          await sleep(OUTER_BACKOFFS_MS[attempt]);
+          await sleep2(OUTER_BACKOFFS_MS[attempt]);
         }
       }
     }
@@ -490,9 +613,9 @@ var DeeplakeApi = class {
     const tbl = sqlIdent(name ?? this.tableName);
     const tables = await this.listTables();
     if (!tables.includes(tbl)) {
-      log2(`table "${tbl}" not found, creating`);
+      log3(`table "${tbl}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${tbl}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, tbl);
-      log2(`table "${tbl}" created`);
+      log3(`table "${tbl}" created`);
       if (!tables.includes(tbl))
         this._tablesCache = [...tables, tbl];
     }
@@ -505,9 +628,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '', filename TEXT NOT NULL DEFAULT '', message JSONB, message_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -530,9 +653,9 @@ var DeeplakeApi = class {
     const safe = sqlIdent(name);
     const tables = await this.listTables();
     if (!tables.includes(safe)) {
-      log2(`table "${safe}" not found, creating`);
+      log3(`table "${safe}" not found, creating`);
       await this.createTableWithRetry(`CREATE TABLE IF NOT EXISTS "${safe}" (id TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '', project TEXT NOT NULL DEFAULT '', project_key TEXT NOT NULL DEFAULT '', local_path TEXT NOT NULL DEFAULT '', install TEXT NOT NULL DEFAULT 'project', source_sessions TEXT NOT NULL DEFAULT '[]', source_agent TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT 'me', author TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', trigger_text TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '', version BIGINT NOT NULL DEFAULT 1, created_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '') USING deeplake`, safe);
-      log2(`table "${safe}" created`);
+      log3(`table "${safe}" created`);
       if (!tables.includes(safe))
         this._tablesCache = [...tables, safe];
     }
@@ -541,14 +664,14 @@ var DeeplakeApi = class {
 };
 
 // dist/src/skillify/pull.js
-import { existsSync as existsSync7, readFileSync as readFileSync5, writeFileSync as writeFileSync4, mkdirSync as mkdirSync4, renameSync as renameSync3, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync2 } from "node:fs";
-import { homedir as homedir7 } from "node:os";
-import { dirname as dirname2, join as join8 } from "node:path";
+import { existsSync as existsSync7, readFileSync as readFileSync6, writeFileSync as writeFileSync5, mkdirSync as mkdirSync5, renameSync as renameSync4, lstatSync as lstatSync2, readlinkSync, symlinkSync, unlinkSync as unlinkSync3 } from "node:fs";
+import { homedir as homedir8 } from "node:os";
+import { dirname as dirname2, join as join9 } from "node:path";
 
 // dist/src/skillify/skill-writer.js
-import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, readdirSync, statSync, writeFileSync as writeFileSync2 } from "node:fs";
-import { homedir as homedir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { existsSync as existsSync3, mkdirSync as mkdirSync3, readFileSync as readFileSync4, readdirSync, statSync as statSync2, writeFileSync as writeFileSync3 } from "node:fs";
+import { homedir as homedir4 } from "node:os";
+import { join as join5 } from "node:path";
 function assertValidSkillName(name) {
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`invalid skill name: empty or non-string`);
@@ -614,29 +737,29 @@ function parseFrontmatter(text) {
 }
 
 // dist/src/skillify/manifest.js
-import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync3, readFileSync as readFileSync4, renameSync as renameSync2, unlinkSync, writeFileSync as writeFileSync3 } from "node:fs";
-import { homedir as homedir5 } from "node:os";
-import { dirname, join as join6 } from "node:path";
+import { existsSync as existsSync5, lstatSync, mkdirSync as mkdirSync4, readFileSync as readFileSync5, renameSync as renameSync3, unlinkSync as unlinkSync2, writeFileSync as writeFileSync4 } from "node:fs";
+import { homedir as homedir6 } from "node:os";
+import { dirname, join as join7 } from "node:path";
 
 // dist/src/skillify/legacy-migration.js
-import { existsSync as existsSync4, renameSync } from "node:fs";
-import { homedir as homedir4 } from "node:os";
-import { join as join5 } from "node:path";
+import { existsSync as existsSync4, renameSync as renameSync2 } from "node:fs";
+import { homedir as homedir5 } from "node:os";
+import { join as join6 } from "node:path";
 var dlog = (msg) => log("skillify-migrate", msg);
 var attempted = false;
 function migrateLegacyStateDir() {
   if (attempted)
     return;
   attempted = true;
-  const root = join5(homedir4(), ".deeplake", "state");
-  const legacy = join5(root, "skilify");
-  const current = join5(root, "skillify");
+  const root = join6(homedir5(), ".deeplake", "state");
+  const legacy = join6(root, "skilify");
+  const current = join6(root, "skillify");
   if (!existsSync4(legacy))
     return;
   if (existsSync4(current))
     return;
   try {
-    renameSync(legacy, current);
+    renameSync2(legacy, current);
     dlog(`migrated ${legacy} -> ${current}`);
   } catch (err) {
     const code = err.code;
@@ -653,7 +776,7 @@ function emptyManifest() {
   return { version: 1, entries: [] };
 }
 function manifestPath() {
-  return join6(homedir5(), ".deeplake", "state", "skillify", "pulled.json");
+  return join7(homedir6(), ".deeplake", "state", "skillify", "pulled.json");
 }
 function loadManifest(path = manifestPath()) {
   migrateLegacyStateDir();
@@ -661,7 +784,7 @@ function loadManifest(path = manifestPath()) {
     return emptyManifest();
   let raw;
   try {
-    raw = readFileSync4(path, "utf-8");
+    raw = readFileSync5(path, "utf-8");
   } catch {
     return emptyManifest();
   }
@@ -708,10 +831,10 @@ function loadManifest(path = manifestPath()) {
 }
 function saveManifest(m, path = manifestPath()) {
   migrateLegacyStateDir();
-  mkdirSync3(dirname(path), { recursive: true });
+  mkdirSync4(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  writeFileSync3(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
-  renameSync2(tmp, path);
+  writeFileSync4(tmp, JSON.stringify(m, null, 2) + "\n", { mode: 384 });
+  renameSync3(tmp, path);
 }
 function recordPull(entry, path = manifestPath()) {
   const m = loadManifest(path);
@@ -736,7 +859,7 @@ function unlinkSymlinks(paths) {
     if (!st.isSymbolicLink())
       continue;
     try {
-      unlinkSync(path);
+      unlinkSync2(path);
     } catch {
     }
   }
@@ -746,7 +869,7 @@ function pruneOrphanedEntries(path = manifestPath()) {
   const live = [];
   let pruned = 0;
   for (const e of m.entries) {
-    if (existsSync5(join6(e.installRoot, e.dirName))) {
+    if (existsSync5(join7(e.installRoot, e.dirName))) {
       live.push(e);
       continue;
     }
@@ -760,25 +883,25 @@ function pruneOrphanedEntries(path = manifestPath()) {
 
 // dist/src/skillify/agent-roots.js
 import { existsSync as existsSync6 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join7 } from "node:path";
+import { homedir as homedir7 } from "node:os";
+import { join as join8 } from "node:path";
 function resolveDetected(home) {
   const out = [];
-  const codexInstalled = existsSync6(join7(home, ".codex"));
-  const piInstalled = existsSync6(join7(home, ".pi", "agent"));
-  const hermesInstalled = existsSync6(join7(home, ".hermes"));
+  const codexInstalled = existsSync6(join8(home, ".codex"));
+  const piInstalled = existsSync6(join8(home, ".pi", "agent"));
+  const hermesInstalled = existsSync6(join8(home, ".hermes"));
   if (codexInstalled || piInstalled) {
-    out.push(join7(home, ".agents", "skills"));
+    out.push(join8(home, ".agents", "skills"));
   }
   if (hermesInstalled) {
-    out.push(join7(home, ".hermes", "skills"));
+    out.push(join8(home, ".hermes", "skills"));
   }
   if (piInstalled) {
-    out.push(join7(home, ".pi", "agent", "skills"));
+    out.push(join8(home, ".pi", "agent", "skills"));
   }
   return out;
 }
-function detectAgentSkillsRoots(canonicalRoot, home = homedir6()) {
+function detectAgentSkillsRoots(canonicalRoot, home = homedir7()) {
   return resolveDetected(home).filter((p) => p !== canonicalRoot);
 }
 
@@ -822,15 +945,15 @@ function isMissingTableError(message) {
 }
 function resolvePullDestination(install, cwd) {
   if (install === "global")
-    return join8(homedir7(), ".claude", "skills");
+    return join9(homedir8(), ".claude", "skills");
   if (!cwd)
     throw new Error("install=project requires a cwd");
-  return join8(cwd, ".claude", "skills");
+  return join9(cwd, ".claude", "skills");
 }
 function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
   const out = [];
   for (const root of agentRoots) {
-    const link = join8(root, dirName);
+    const link = join9(root, dirName);
     let existing;
     try {
       existing = lstatSync2(link);
@@ -852,13 +975,13 @@ function fanOutSymlinks(canonicalDir, dirName, agentRoots) {
         continue;
       }
       try {
-        unlinkSync2(link);
+        unlinkSync3(link);
       } catch {
         continue;
       }
     }
     try {
-      mkdirSync4(dirname2(link), { recursive: true });
+      mkdirSync5(dirname2(link), { recursive: true });
       symlinkSync(canonicalDir, link, "dir");
       out.push(link);
     } catch {
@@ -873,7 +996,7 @@ function backfillSymlinks(installRoot) {
     return;
   const detected = detectAgentSkillsRoots(installRoot);
   for (const entry of entries) {
-    const canonical = join8(entry.installRoot, entry.dirName);
+    const canonical = join9(entry.installRoot, entry.dirName);
     if (!existsSync7(canonical))
       continue;
     const fresh = fanOutSymlinks(canonical, entry.dirName, detected);
@@ -987,7 +1110,7 @@ function readLocalVersion(path) {
   if (!existsSync7(path))
     return null;
   try {
-    const text = readFileSync5(path, "utf-8");
+    const text = readFileSync6(path, "utf-8");
     const parsed = parseFrontmatter(text);
     if (!parsed)
       return null;
@@ -1082,8 +1205,8 @@ async function runPull(opts) {
       summary.skipped++;
       continue;
     }
-    const skillDir = join8(root, dirName);
-    const skillFile = join8(skillDir, "SKILL.md");
+    const skillDir = join9(root, dirName);
+    const skillFile = join9(skillDir, "SKILL.md");
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -1094,14 +1217,14 @@ async function runPull(opts) {
     });
     let manifestError;
     if (action === "wrote") {
-      mkdirSync4(skillDir, { recursive: true });
+      mkdirSync5(skillDir, { recursive: true });
       if (existsSync7(skillFile)) {
         try {
-          renameSync3(skillFile, `${skillFile}.bak`);
+          renameSync4(skillFile, `${skillFile}.bak`);
         } catch {
         }
       }
-      writeFileSync4(skillFile, renderSkillFile(row));
+      writeFileSync5(skillFile, renderSkillFile(row));
       const symlinks = opts.install === "global" ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root)) : [];
       try {
         recordPull({
@@ -1143,7 +1266,7 @@ async function runPull(opts) {
 }
 
 // dist/src/skillify/auto-pull.js
-var log3 = (msg) => log("skillify-autopull", msg);
+var log4 = (msg) => log("skillify-autopull", msg);
 var DEFAULT_TIMEOUT_MS = 5e3;
 function withTimeout(p, ms) {
   let timer = null;
@@ -1159,13 +1282,13 @@ function withTimeout(p, ms) {
 }
 async function autoPullSkills(deps = {}) {
   if (process.env.HIVEMIND_AUTOPULL_DISABLED === "1") {
-    log3("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
+    log4("disabled via HIVEMIND_AUTOPULL_DISABLED=1");
     return { pulled: 0, skipped: true, reason: "disabled" };
   }
   const loadFn = deps.loadConfigFn ?? loadConfig;
   const config = loadFn();
   if (!config) {
-    log3("skipped: not logged in");
+    log4("skipped: not logged in");
     return { pulled: 0, skipped: true, reason: "not-logged-in" };
   }
   let query;
@@ -1187,10 +1310,10 @@ async function autoPullSkills(deps = {}) {
       dryRun: false,
       force: false
     }), timeoutMs);
-    log3(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
+    log4(`pulled scanned=${summary.scanned} wrote=${summary.wrote} skipped=${summary.skipped}`);
     return { pulled: summary.wrote, skipped: false };
   } catch (e) {
-    log3(`pull failed (swallowed): ${e?.message ?? e}`);
+    log4(`pull failed (swallowed): ${e?.message ?? e}`);
     return { pulled: 0, skipped: true, reason: "error" };
   }
 }

--- a/pi/bundle/wiki-worker.js
+++ b/pi/bundle/wiki-worker.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // dist/src/hooks/pi/wiki-worker.js
-import { readFileSync as readFileSync5, writeFileSync as writeFileSync4, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync4, rmSync } from "node:fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync4, appendFileSync as appendFileSync2, mkdirSync as mkdirSync3, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { join as join7 } from "node:path";
+import { join as join6 } from "node:path";
 
 // dist/src/hooks/summary-state.js
 import { readFileSync, writeFileSync, writeSync, mkdirSync, renameSync, existsSync, unlinkSync, openSync, closeSync } from "node:fs";
@@ -153,9 +153,9 @@ async function uploadSummary(query2, params) {
 // dist/src/embeddings/client.js
 import { connect } from "node:net";
 import { spawn } from "node:child_process";
-import { openSync as openSync3, closeSync as closeSync3, writeSync as writeSync2, unlinkSync as unlinkSync3, existsSync as existsSync3, readFileSync as readFileSync4 } from "node:fs";
-import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { openSync as openSync2, closeSync as closeSync2, writeSync as writeSync2, unlinkSync as unlinkSync2, existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join3 } from "node:path";
 
 // dist/src/embeddings/protocol.js
 var DEFAULT_SOCKET_DIR = "/tmp";
@@ -168,105 +168,371 @@ function pidPathFor(uid, dir = DEFAULT_SOCKET_DIR) {
   return `${dir}/hivemind-embed-${uid}.pid`;
 }
 
-// dist/src/notifications/queue.js
-import { readFileSync as readFileSync2, writeFileSync as writeFileSync2, renameSync as renameSync2, mkdirSync as mkdirSync2, openSync as openSync2, closeSync as closeSync2, unlinkSync as unlinkSync2, statSync } from "node:fs";
-import { join as join3, resolve } from "node:path";
-import { homedir as homedir3 } from "node:os";
-import { setTimeout as sleep } from "node:timers/promises";
-var log2 = (msg) => log("notifications-queue", msg);
-var LOCK_RETRY_MAX = 50;
-var LOCK_RETRY_BASE_MS = 5;
-var LOCK_STALE_MS = 5e3;
-function queuePath() {
-  return join3(homedir3(), ".deeplake", "notifications-queue.json");
+// dist/src/embeddings/client.js
+var SHARED_DAEMON_PATH = join3(homedir3(), ".hivemind", "embed-deps", "embed-daemon.js");
+var log2 = (m) => log("embed-client", m);
+function getUid() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
+  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
 }
-function lockPath2() {
-  return `${queuePath()}.lock`;
-}
-function readQueue() {
-  try {
-    const raw = readFileSync2(queuePath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || !Array.isArray(parsed.queue)) {
-      log2(`queue malformed \u2192 treating as empty`);
-      return { queue: [] };
-    }
-    return { queue: parsed.queue };
-  } catch {
-    return { queue: [] };
+var _recycledStuckDaemon = false;
+var EmbedClient = class {
+  socketPath;
+  pidPath;
+  timeoutMs;
+  daemonEntry;
+  autoSpawn;
+  spawnWaitMs;
+  nextId = 0;
+  helloVerified = false;
+  constructor(opts = {}) {
+    const uid = getUid();
+    const dir = opts.socketDir ?? "/tmp";
+    this.socketPath = socketPathFor(uid, dir);
+    this.pidPath = pidPathFor(uid, dir);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
+    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync2(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
+    this.autoSpawn = opts.autoSpawn ?? true;
+    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
   }
-}
-function _isQueuePathInsideHome(path, home) {
-  const r = resolve(path);
-  const h = resolve(home);
-  return r.startsWith(h + "/") || r === h;
-}
-function writeQueue(q) {
-  const path = queuePath();
-  const home = resolve(homedir3());
-  if (!_isQueuePathInsideHome(path, home)) {
-    throw new Error(`notifications-queue write blocked: ${path} is outside ${home}`);
+  /**
+   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
+   * null as "skip embedding column" — never block the write path on us.
+   *
+   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
+   * null AND kicks off a background spawn. The next call finds a ready daemon.
+   *
+   * Stuck-daemon recycle: if the daemon returns a transformers-missing
+   * error (typical after a marketplace upgrade left an older daemon process
+   * alive but with no node_modules accessible from its bundle path), we
+   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
+   * daemon from the current bundle. Without this, the stuck daemon would
+   * keep poisoning every session until its 10-minute idle-out fires.
+   */
+  async embed(text, kind = "document") {
+    const v = await this.embedAttempt(text, kind);
+    if (v !== "recycled")
+      return v;
+    if (!this.autoSpawn)
+      return null;
+    this.trySpawnDaemon();
+    await this.waitForDaemonReady();
+    const retry = await this.embedAttempt(text, kind);
+    return retry === "recycled" ? null : retry;
   }
-  mkdirSync2(join3(home, ".deeplake"), { recursive: true, mode: 448 });
-  const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync2(tmp, JSON.stringify(q, null, 2), { mode: 384 });
-  renameSync2(tmp, path);
-}
-async function withQueueLock(fn) {
-  const path = lockPath2();
-  mkdirSync2(join3(homedir3(), ".deeplake"), { recursive: true, mode: 448 });
-  let fd = null;
-  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+  /**
+   * One round-trip: connect → verify → embed. Returns:
+   *  - number[]  : embedding vector (happy path)
+   *  - null      : timeout / daemon error / transformers-missing
+   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
+   *                caller should respawn and retry once.
+   */
+  async embedAttempt(text, kind) {
+    let sock;
     try {
-      fd = openSync2(path, "wx", 384);
-      break;
-    } catch (e) {
-      const code = e.code;
-      if (code !== "EEXIST")
-        throw e;
-      try {
-        const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          unlinkSync2(path);
-          continue;
+      sock = await this.connectOnce();
+    } catch {
+      if (this.autoSpawn)
+        this.trySpawnDaemon();
+      return null;
+    }
+    try {
+      const recycled = await this.verifyDaemonOnce(sock);
+      if (recycled) {
+        return "recycled";
+      }
+      const id = String(++this.nextId);
+      const req = { op: "embed", id, kind, text };
+      const resp = await this.sendAndWait(sock, req);
+      if (resp.error || !("embedding" in resp) || !resp.embedding) {
+        const err = resp.error ?? "no embedding";
+        log2(`embed err: ${err}`);
+        if (isTransformersMissingError(err)) {
+          this.handleTransformersMissing(err);
         }
+        return null;
+      }
+      return resp.embedding;
+    } catch (e) {
+      const err = e instanceof Error ? e.message : String(e);
+      log2(`embed failed: ${err}`);
+      return null;
+    } finally {
+      try {
+        sock.end();
       } catch {
       }
-      const delay = LOCK_RETRY_BASE_MS * (attempt + 1);
-      await sleep(delay);
     }
   }
-  if (fd === null) {
-    log2(`lock acquisition gave up after ${LOCK_RETRY_MAX} attempts \u2014 proceeding unlocked (last-writer-wins)`);
-    return fn();
+  /**
+   * Poll for the sock file to come back after `trySpawnDaemon` — used by
+   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
+   * returns regardless so the retry attempt can run.
+   */
+  async waitForDaemonReady() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    while (Date.now() < deadline) {
+      if (existsSync2(this.socketPath))
+        return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
   }
-  try {
-    return fn();
-  } finally {
+  /**
+   * Send a `hello` on first successful connect per EmbedClient instance.
+   * If the daemon answers with a path that doesn't match our configured
+   * daemonEntry — typical after a marketplace upgrade replaced the bundle
+   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
+   * current bundle.
+   *
+   * `helloVerified` is set ONLY after we've seen a compatible response,
+   * so a transient probe failure or a recycle-triggering mismatch leaves
+   * the flag false; the next reconnect re-runs verification against
+   * whatever daemon is then live (typically the fresh spawn).
+   */
+  async verifyDaemonOnce(sock) {
+    if (this.helloVerified)
+      return false;
+    if (!this.daemonEntry) {
+      this.helloVerified = true;
+      return false;
+    }
+    const id = String(++this.nextId);
+    const req = { op: "hello", id };
+    let resp;
     try {
-      closeSync2(fd);
-    } catch {
+      resp = await this.sendAndWait(sock, req);
+    } catch (e) {
+      log2(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
+      return false;
     }
-    try {
-      unlinkSync2(path);
-    } catch {
+    const hello = resp;
+    if (_recycledStuckDaemon) {
+      return false;
     }
-  }
-}
-function sameDedupKey(a, b) {
-  if (a.id !== b.id)
+    if (!hello.daemonPath) {
+      _recycledStuckDaemon = true;
+      log2(`daemon does not implement hello (older protocol); recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    if (hello.daemonPath !== this.daemonEntry && !existsSync2(hello.daemonPath)) {
+      _recycledStuckDaemon = true;
+      log2(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
+      this.recycleDaemon(hello.pid);
+      return true;
+    }
+    this.helloVerified = true;
     return false;
-  return JSON.stringify(a.dedupKey) === JSON.stringify(b.dedupKey);
-}
-async function enqueueNotification(n) {
-  await withQueueLock(() => {
-    const q = readQueue();
-    if (q.queue.some((existing) => sameDedupKey(existing, n))) {
+  }
+  /**
+   * On a transformers-missing error from the daemon, SIGTERM the stuck
+   * daemon (the bundle daemon that can't find its deps) and clear
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
+   */
+  handleTransformersMissing(_detail) {
+    if (!_recycledStuckDaemon) {
+      _recycledStuckDaemon = true;
+      this.recycleDaemon(null);
+    }
+  }
+  /**
+   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
+   * combination and dead-PID cases.
+   *
+   * Identity check: gate the SIGTERM on the daemon's socket file still
+   * existing. We know the daemon was alive moments ago (we either just
+   * got a hello response or the caller saw a transformers-missing error
+   * the daemon emitted), but if the socket file is gone by the time we
+   * try to kill, the daemon process is also gone and the PID we
+   * captured may already have been recycled by the OS to an unrelated
+   * user process. Mirrors the gate added to `killEmbedDaemon` in the
+   * CLI — same failure mode, rarer trigger.
+   */
+  recycleDaemon(reportedPid) {
+    let pid = reportedPid;
+    if (pid === null) {
+      try {
+        pid = Number.parseInt(readFileSync2(this.pidPath, "utf-8").trim(), 10);
+      } catch {
+      }
+    }
+    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync2(this.socketPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+      }
+    } else if (pid !== null) {
+      log2(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
+    }
+    try {
+      unlinkSync2(this.socketPath);
+    } catch {
+    }
+    try {
+      unlinkSync2(this.pidPath);
+    } catch {
+    }
+  }
+  /**
+   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
+   * necessary. Meant for SessionStart / long-running batches — not the hot path.
+   */
+  async warmup() {
+    try {
+      const s = await this.connectOnce();
+      s.end();
+      return true;
+    } catch {
+      if (!this.autoSpawn)
+        return false;
+      this.trySpawnDaemon();
+      try {
+        const s = await this.waitForSocket();
+        s.end();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+  connectOnce() {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.socketPath);
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("connect timeout"));
+      }, this.timeoutMs);
+      sock.once("connect", () => {
+        clearTimeout(to);
+        resolve(sock);
+      });
+      sock.once("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+    });
+  }
+  trySpawnDaemon() {
+    let fd;
+    try {
+      fd = openSync2(this.pidPath, "wx", 384);
+      writeSync2(fd, String(process.pid));
+    } catch (e) {
+      if (this.isPidFileStale()) {
+        try {
+          unlinkSync2(this.pidPath);
+        } catch {
+        }
+        try {
+          fd = openSync2(this.pidPath, "wx", 384);
+          writeSync2(fd, String(process.pid));
+        } catch {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+    if (!this.daemonEntry || !existsSync2(this.daemonEntry)) {
+      log2(`daemonEntry not configured or missing: ${this.daemonEntry}`);
+      try {
+        closeSync2(fd);
+        unlinkSync2(this.pidPath);
+      } catch {
+      }
       return;
     }
-    q.queue.push(n);
-    writeQueue(q);
-  });
+    try {
+      const child = spawn(process.execPath, [this.daemonEntry], {
+        detached: true,
+        stdio: "ignore",
+        env: process.env
+      });
+      child.unref();
+      log2(`spawned daemon pid=${child.pid}`);
+    } finally {
+      closeSync2(fd);
+    }
+  }
+  isPidFileStale() {
+    try {
+      const raw = readFileSync2(this.pidPath, "utf-8").trim();
+      const pid = Number(raw);
+      if (!pid || Number.isNaN(pid))
+        return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+  async waitForSocket() {
+    const deadline = Date.now() + this.spawnWaitMs;
+    let delay = 30;
+    while (Date.now() < deadline) {
+      await sleep(delay);
+      delay = Math.min(delay * 1.5, 300);
+      if (!existsSync2(this.socketPath))
+        continue;
+      try {
+        return await this.connectOnce();
+      } catch {
+      }
+    }
+    throw new Error("daemon did not become ready within spawnWaitMs");
+  }
+  sendAndWait(sock, req) {
+    return new Promise((resolve, reject) => {
+      let buf = "";
+      const to = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("request timeout"));
+      }, this.timeoutMs);
+      sock.setEncoding("utf-8");
+      sock.on("data", (chunk) => {
+        buf += chunk;
+        const nl = buf.indexOf("\n");
+        if (nl === -1)
+          return;
+        const line = buf.slice(0, nl);
+        clearTimeout(to);
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e);
+        }
+      });
+      sock.on("error", (e) => {
+        clearTimeout(to);
+        reject(e);
+      });
+      sock.on("end", () => {
+        clearTimeout(to);
+        reject(new Error("connection closed without response"));
+      });
+      sock.write(JSON.stringify(req) + "\n");
+    });
+  }
+};
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+function isTransformersMissingError(err) {
+  if (/hivemind embeddings install/i.test(err))
+    return true;
+  return /@huggingface\/transformers/i.test(err);
 }
 
 // dist/src/embeddings/disable.js
@@ -276,7 +542,7 @@ import { join as join5 } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // dist/src/user-config.js
-import { existsSync as existsSync2, mkdirSync as mkdirSync3, readFileSync as readFileSync3, renameSync as renameSync3, writeFileSync as writeFileSync3 } from "node:fs";
+import { existsSync as existsSync3, mkdirSync as mkdirSync2, readFileSync as readFileSync3, renameSync as renameSync2, writeFileSync as writeFileSync2 } from "node:fs";
 import { homedir as homedir4 } from "node:os";
 import { dirname, join as join4 } from "node:path";
 var _configPath = () => process.env.HIVEMIND_CONFIG_PATH ?? join4(homedir4(), ".deeplake", "config.json");
@@ -286,7 +552,7 @@ function readUserConfig() {
   if (_cache !== null)
     return _cache;
   const path = _configPath();
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     _cache = {};
     return _cache;
   }
@@ -304,11 +570,11 @@ function writeUserConfig(patch) {
   const merged = deepMerge(current, patch);
   const path = _configPath();
   const dir = dirname(path);
-  if (!existsSync2(dir))
-    mkdirSync3(dir, { recursive: true });
+  if (!existsSync3(dir))
+    mkdirSync2(dir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync3(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
-  renameSync3(tmp, path);
+  writeFileSync2(tmp, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  renameSync2(tmp, path);
   _cache = merged;
   return merged;
 }
@@ -387,390 +653,6 @@ function embeddingsDisabled() {
   return embeddingsStatus() !== "enabled";
 }
 
-// dist/src/embeddings/client.js
-var SHARED_DAEMON_PATH = join6(homedir6(), ".hivemind", "embed-deps", "embed-daemon.js");
-var log3 = (m) => log("embed-client", m);
-function getUid() {
-  const uid = typeof process.getuid === "function" ? process.getuid() : void 0;
-  return uid !== void 0 ? String(uid) : process.env.USER ?? "default";
-}
-var _signalledMissingDeps = false;
-var _recycledStuckDaemon = false;
-var EmbedClient = class {
-  socketPath;
-  pidPath;
-  timeoutMs;
-  daemonEntry;
-  autoSpawn;
-  spawnWaitMs;
-  nextId = 0;
-  helloVerified = false;
-  constructor(opts = {}) {
-    const uid = getUid();
-    const dir = opts.socketDir ?? "/tmp";
-    this.socketPath = socketPathFor(uid, dir);
-    this.pidPath = pidPathFor(uid, dir);
-    this.timeoutMs = opts.timeoutMs ?? DEFAULT_CLIENT_TIMEOUT_MS;
-    this.daemonEntry = opts.daemonEntry ?? process.env.HIVEMIND_EMBED_DAEMON ?? (existsSync3(SHARED_DAEMON_PATH) ? SHARED_DAEMON_PATH : void 0);
-    this.autoSpawn = opts.autoSpawn ?? true;
-    this.spawnWaitMs = opts.spawnWaitMs ?? 5e3;
-  }
-  /**
-   * Returns an embedding vector, or null on timeout/failure. Hooks MUST treat
-   * null as "skip embedding column" — never block the write path on us.
-   *
-   * Fire-and-forget spawn on miss: if the daemon isn't up, this call returns
-   * null AND kicks off a background spawn. The next call finds a ready daemon.
-   *
-   * Stuck-daemon recycle: if the daemon returns a transformers-missing
-   * error (typical after a marketplace upgrade left an older daemon process
-   * alive but with no node_modules accessible from its bundle path), we
-   * SIGTERM it and clear its sock/pid so the very next call spawns a fresh
-   * daemon from the current bundle. Without this, the stuck daemon would
-   * keep poisoning every session until its 10-minute idle-out fires.
-   */
-  async embed(text, kind = "document") {
-    const v = await this.embedAttempt(text, kind);
-    if (v !== "recycled")
-      return v;
-    if (!this.autoSpawn)
-      return null;
-    this.trySpawnDaemon();
-    await this.waitForDaemonReady();
-    const retry = await this.embedAttempt(text, kind);
-    return retry === "recycled" ? null : retry;
-  }
-  /**
-   * One round-trip: connect → verify → embed. Returns:
-   *  - number[]  : embedding vector (happy path)
-   *  - null      : timeout / daemon error / transformers-missing
-   *  - "recycled": verifyDaemonOnce killed the daemon mid-call;
-   *                caller should respawn and retry once.
-   */
-  async embedAttempt(text, kind) {
-    let sock;
-    try {
-      sock = await this.connectOnce();
-    } catch {
-      if (this.autoSpawn)
-        this.trySpawnDaemon();
-      return null;
-    }
-    try {
-      const recycled = await this.verifyDaemonOnce(sock);
-      if (recycled) {
-        return "recycled";
-      }
-      const id = String(++this.nextId);
-      const req = { op: "embed", id, kind, text };
-      const resp = await this.sendAndWait(sock, req);
-      if (resp.error || !("embedding" in resp) || !resp.embedding) {
-        const err = resp.error ?? "no embedding";
-        log3(`embed err: ${err}`);
-        if (isTransformersMissingError(err)) {
-          this.handleTransformersMissing(err);
-        }
-        return null;
-      }
-      return resp.embedding;
-    } catch (e) {
-      const err = e instanceof Error ? e.message : String(e);
-      log3(`embed failed: ${err}`);
-      return null;
-    } finally {
-      try {
-        sock.end();
-      } catch {
-      }
-    }
-  }
-  /**
-   * Poll for the sock file to come back after `trySpawnDaemon` — used by
-   * the recycle retry path. Best-effort: caps at `spawnWaitMs` and
-   * returns regardless so the retry attempt can run.
-   */
-  async waitForDaemonReady() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    while (Date.now() < deadline) {
-      if (existsSync3(this.socketPath))
-        return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  }
-  /**
-   * Send a `hello` on first successful connect per EmbedClient instance.
-   * If the daemon answers with a path that doesn't match our configured
-   * daemonEntry — typical after a marketplace upgrade replaced the bundle
-   * — SIGTERM the daemon + clear sock/pid so the next call spawns from the
-   * current bundle.
-   *
-   * `helloVerified` is set ONLY after we've seen a compatible response,
-   * so a transient probe failure or a recycle-triggering mismatch leaves
-   * the flag false; the next reconnect re-runs verification against
-   * whatever daemon is then live (typically the fresh spawn).
-   */
-  async verifyDaemonOnce(sock) {
-    if (this.helloVerified)
-      return false;
-    if (!this.daemonEntry) {
-      this.helloVerified = true;
-      return false;
-    }
-    const id = String(++this.nextId);
-    const req = { op: "hello", id };
-    let resp;
-    try {
-      resp = await this.sendAndWait(sock, req);
-    } catch (e) {
-      log3(`hello probe failed (inconclusive, will retry next connect): ${e instanceof Error ? e.message : String(e)}`);
-      return false;
-    }
-    const hello = resp;
-    if (_recycledStuckDaemon) {
-      return false;
-    }
-    if (!hello.daemonPath) {
-      _recycledStuckDaemon = true;
-      log3(`daemon does not implement hello (older protocol); recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    if (hello.daemonPath !== this.daemonEntry && !existsSync3(hello.daemonPath)) {
-      _recycledStuckDaemon = true;
-      log3(`daemon path no longer on disk \u2014 running=${hello.daemonPath} (gone) expected=${this.daemonEntry}; recycling`);
-      this.recycleDaemon(hello.pid);
-      return true;
-    }
-    this.helloVerified = true;
-    return false;
-  }
-  /**
-   * On a transformers-missing error from the daemon, SIGTERM the stuck
-   * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
-   */
-  handleTransformersMissing(detail) {
-    if (!_recycledStuckDaemon) {
-      _recycledStuckDaemon = true;
-      this.recycleDaemon(null);
-    }
-    if (_signalledMissingDeps)
-      return;
-    _signalledMissingDeps = true;
-    let status;
-    try {
-      status = embeddingsStatus();
-    } catch {
-      status = "enabled";
-    }
-    if (status === "user-disabled")
-      return;
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled \u2014 deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) }
-    }).catch((e) => {
-      log3(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
-  }
-  /**
-   * Best-effort SIGTERM + sock/pid cleanup. Tolerant of every missing-file
-   * combination and dead-PID cases.
-   *
-   * Identity check: gate the SIGTERM on the daemon's socket file still
-   * existing. We know the daemon was alive moments ago (we either just
-   * got a hello response or the caller saw a transformers-missing error
-   * the daemon emitted), but if the socket file is gone by the time we
-   * try to kill, the daemon process is also gone and the PID we
-   * captured may already have been recycled by the OS to an unrelated
-   * user process. Mirrors the gate added to `killEmbedDaemon` in the
-   * CLI — same failure mode, rarer trigger.
-   */
-  recycleDaemon(reportedPid) {
-    let pid = reportedPid;
-    if (pid === null) {
-      try {
-        pid = Number.parseInt(readFileSync4(this.pidPath, "utf-8").trim(), 10);
-      } catch {
-      }
-    }
-    if (Number.isFinite(pid) && pid !== null && pid > 0 && existsSync3(this.socketPath)) {
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-      }
-    } else if (pid !== null) {
-      log3(`recycle: socket gone, skipping SIGTERM on possibly-stale pid ${pid}`);
-    }
-    try {
-      unlinkSync3(this.socketPath);
-    } catch {
-    }
-    try {
-      unlinkSync3(this.pidPath);
-    } catch {
-    }
-  }
-  /**
-   * Wait up to spawnWaitMs for the daemon to accept connections, spawning if
-   * necessary. Meant for SessionStart / long-running batches — not the hot path.
-   */
-  async warmup() {
-    try {
-      const s = await this.connectOnce();
-      s.end();
-      return true;
-    } catch {
-      if (!this.autoSpawn)
-        return false;
-      this.trySpawnDaemon();
-      try {
-        const s = await this.waitForSocket();
-        s.end();
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-  connectOnce() {
-    return new Promise((resolve2, reject) => {
-      const sock = connect(this.socketPath);
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("connect timeout"));
-      }, this.timeoutMs);
-      sock.once("connect", () => {
-        clearTimeout(to);
-        resolve2(sock);
-      });
-      sock.once("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-    });
-  }
-  trySpawnDaemon() {
-    let fd;
-    try {
-      fd = openSync3(this.pidPath, "wx", 384);
-      writeSync2(fd, String(process.pid));
-    } catch (e) {
-      if (this.isPidFileStale()) {
-        try {
-          unlinkSync3(this.pidPath);
-        } catch {
-        }
-        try {
-          fd = openSync3(this.pidPath, "wx", 384);
-          writeSync2(fd, String(process.pid));
-        } catch {
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-    if (!this.daemonEntry || !existsSync3(this.daemonEntry)) {
-      log3(`daemonEntry not configured or missing: ${this.daemonEntry}`);
-      try {
-        closeSync3(fd);
-        unlinkSync3(this.pidPath);
-      } catch {
-      }
-      return;
-    }
-    try {
-      const child = spawn(process.execPath, [this.daemonEntry], {
-        detached: true,
-        stdio: "ignore",
-        env: process.env
-      });
-      child.unref();
-      log3(`spawned daemon pid=${child.pid}`);
-    } finally {
-      closeSync3(fd);
-    }
-  }
-  isPidFileStale() {
-    try {
-      const raw = readFileSync4(this.pidPath, "utf-8").trim();
-      const pid = Number(raw);
-      if (!pid || Number.isNaN(pid))
-        return true;
-      try {
-        process.kill(pid, 0);
-        return false;
-      } catch {
-        return true;
-      }
-    } catch {
-      return true;
-    }
-  }
-  async waitForSocket() {
-    const deadline = Date.now() + this.spawnWaitMs;
-    let delay = 30;
-    while (Date.now() < deadline) {
-      await sleep2(delay);
-      delay = Math.min(delay * 1.5, 300);
-      if (!existsSync3(this.socketPath))
-        continue;
-      try {
-        return await this.connectOnce();
-      } catch {
-      }
-    }
-    throw new Error("daemon did not become ready within spawnWaitMs");
-  }
-  sendAndWait(sock, req) {
-    return new Promise((resolve2, reject) => {
-      let buf = "";
-      const to = setTimeout(() => {
-        sock.destroy();
-        reject(new Error("request timeout"));
-      }, this.timeoutMs);
-      sock.setEncoding("utf-8");
-      sock.on("data", (chunk) => {
-        buf += chunk;
-        const nl = buf.indexOf("\n");
-        if (nl === -1)
-          return;
-        const line = buf.slice(0, nl);
-        clearTimeout(to);
-        try {
-          resolve2(JSON.parse(line));
-        } catch (e) {
-          reject(e);
-        }
-      });
-      sock.on("error", (e) => {
-        clearTimeout(to);
-        reject(e);
-      });
-      sock.on("end", () => {
-        clearTimeout(to);
-        reject(new Error("connection closed without response"));
-      });
-      sock.write(JSON.stringify(req) + "\n");
-    });
-  }
-};
-function sleep2(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-function isTransformersMissingError(err) {
-  if (/hivemind embeddings install/i.test(err))
-    return true;
-  return /@huggingface\/transformers/i.test(err);
-}
-
 // dist/src/utils/client-header.js
 var DEEPLAKE_CLIENT_HEADER = "X-Deeplake-Client";
 function deeplakeClientValue() {
@@ -782,13 +664,13 @@ function deeplakeClientHeader() {
 
 // dist/src/hooks/pi/wiki-worker.js
 var dlog2 = (msg) => log("pi-wiki-worker", msg);
-var cfg = JSON.parse(readFileSync5(process.argv[2], "utf-8"));
+var cfg = JSON.parse(readFileSync4(process.argv[2], "utf-8"));
 var tmpDir = cfg.tmpDir;
-var tmpJsonl = join7(tmpDir, "session.jsonl");
-var tmpSummary = join7(tmpDir, "summary.md");
+var tmpJsonl = join6(tmpDir, "session.jsonl");
+var tmpSummary = join6(tmpDir, "summary.md");
 function wlog(msg) {
   try {
-    mkdirSync4(cfg.hooksDir, { recursive: true });
+    mkdirSync3(cfg.hooksDir, { recursive: true });
     appendFileSync2(cfg.wikiLog, `[${(/* @__PURE__ */ new Date()).toISOString().replace("T", " ").slice(0, 19)}] wiki-worker(${cfg.sessionId}): ${msg}
 `);
   } catch {
@@ -820,7 +702,7 @@ async function query(sql, retries = 4) {
       const base = Math.min(3e4, 2e3 * Math.pow(2, attempt));
       const delay = base + Math.floor(Math.random() * 1e3);
       wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise((resolve2) => setTimeout(resolve2, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       continue;
     }
     throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
@@ -846,7 +728,7 @@ async function main() {
     const jsonlLines = rows.length;
     const pathRows = await query(`SELECT DISTINCT path FROM "${cfg.sessionsTable}" WHERE path LIKE '${esc2(`/sessions/%${cfg.sessionId}%`)}' LIMIT 1`);
     const jsonlServerPath = pathRows.length > 0 ? pathRows[0].path : `/sessions/unknown/${cfg.sessionId}.jsonl`;
-    writeFileSync4(tmpJsonl, jsonlContent);
+    writeFileSync3(tmpJsonl, jsonlContent);
     wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
     let prevOffset = 0;
     try {
@@ -856,7 +738,7 @@ async function main() {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match)
           prevOffset = parseInt(match[1], 10);
-        writeFileSync4(tmpSummary, existing);
+        writeFileSync3(tmpSummary, existing);
         wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch {
@@ -881,7 +763,7 @@ async function main() {
       wlog(`pi --print failed: ${e.status ?? e.message}`);
     }
     if (existsSync4(tmpSummary)) {
-      const text = readFileSync5(tmpSummary, "utf-8");
+      const text = readFileSync4(tmpSummary, "utf-8");
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -4,6 +4,7 @@ import { sqlStr, sqlIdent } from "./utils/sql.js";
 import { SUMMARY_EMBEDDING_COL, MESSAGE_EMBEDDING_COL } from "./embeddings/columns.js";
 import { deeplakeClientHeader } from "./utils/client-header.js";
 import { enqueueNotification } from "./notifications/queue.js";
+import { loadCredentials } from "./commands/auth-creds.js";
 
 // index-marker-store touches node:fs. Load it lazily so bundlers that split
 // chunks (e.g. the openclaw plugin build) can put fs operations in a separate
@@ -68,11 +69,31 @@ function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
     id: "balance-exhausted",
     severity: "warn",
     title: "Hivemind credits exhausted — top up to keep capturing",
-    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
     dedupKey: { reason: "balance-zero", date },
   }).catch((e: unknown) => {
     log(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });
+}
+
+/**
+ * Construct the org-scoped billing URL from persisted credentials. The
+ * canonical shape is `https://deeplake.ai/{orgName}/workspace/{workspaceId}/billing`
+ * — the org and workspace come from `~/.deeplake/credentials.json`. Falls
+ * back to the bare host when creds are missing or malformed (better to
+ * point at *something* than at a URL with literal `undefined` segments).
+ */
+function billingUrl(): string {
+  try {
+    const c = loadCredentials();
+    if (c?.orgName && c?.workspaceId) {
+      // URI-encode in case anyone has an org/workspace name with reserved chars.
+      // workspaceId is typically a UUID; orgName is typically a slug, but
+      // encodeURIComponent is a cheap guard against future weirdness.
+      return `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch { /* fall through to default */ }
+  return "https://deeplake.ai";
 }
 
 // ── Retry & concurrency primitives ──────────────────────────────────────────

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -64,13 +64,18 @@ function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
   if (_signalledBalanceExhausted) return;
   _signalledBalanceExhausted = true;
   log(`balance exhausted — enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
-  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+  // transient: true → the drain shows it but doesn't record in state.shown.
+  // The enqueue path is itself the rate limit: only fires on a real 402,
+  // so once balance is restored no fresh enqueue happens and the banner
+  // silences naturally. dedupKey is stable so concurrent hook processes
+  // within one session collapse to one queue entry.
   enqueueNotification({
     id: "balance-exhausted",
     severity: "warn",
+    transient: true,
     title: "Hivemind credits exhausted — top up to keep capturing",
     body: `Sessions are not being saved and memory recall is returning empty. Top up at ${billingUrl()} to restore capture and recall.`,
-    dedupKey: { reason: "balance-zero", date },
+    dedupKey: { reason: "balance-zero" },
   }).catch((e: unknown) => {
     log(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
   });

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -3,6 +3,7 @@ import { log as _log } from "./utils/debug.js";
 import { sqlStr, sqlIdent } from "./utils/sql.js";
 import { SUMMARY_EMBEDDING_COL, MESSAGE_EMBEDDING_COL } from "./embeddings/columns.js";
 import { deeplakeClientHeader } from "./utils/client-header.js";
+import { enqueueNotification } from "./notifications/queue.js";
 
 // index-marker-store touches node:fs. Load it lazily so bundlers that split
 // chunks (e.g. the openclaw plugin build) can put fs operations in a separate
@@ -33,6 +34,45 @@ function traceSql(msg: string): void {
   if (!traceEnabled) return;
   process.stderr.write(`[deeplake-sql] ${msg}\n`);
   if (process.env.HIVEMIND_DEBUG === "1") log(msg);
+}
+
+// Process-local flag so the balance-exhausted notification is enqueued at
+// most once per process. Cross-process dedup (so dozens of concurrent hook
+// processes don't pile up duplicate queue entries) is handled by
+// queue.ts's sameDedupKey check.
+let _signalledBalanceExhausted = false;
+
+/**
+ * If the response is the server's "out of credits" 402
+ * (`{"balance_cents":0,"error":"insufficient balance, please top up"}`),
+ * enqueue a session-start banner so the user actually finds out. Without
+ * this, captures and memory recalls fail silently — the agent reads empty
+ * memory and confidently reasons from no data, never telling the user
+ * why. See logs at ~/.deeplake/hook-debug.log when HIVEMIND_DEBUG=1.
+ *
+ * Fire-and-forget — the caller's existing throw path is unchanged so any
+ * upstream `try/catch` keeps working. Process-local dedup prevents
+ * re-enqueueing on every retry within the same hook process.
+ *
+ * DedupKey carries the UTC date so the banner re-fires daily until the
+ * user tops up, rather than firing once-ever and then going quiet.
+ */
+function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
+  if (status !== 402) return;
+  if (!bodyText.includes("balance_cents")) return;
+  if (_signalledBalanceExhausted) return;
+  _signalledBalanceExhausted = true;
+  log(`balance exhausted — enqueuing session-start banner (body=${bodyText.slice(0, 120)})`);
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+  enqueueNotification({
+    id: "balance-exhausted",
+    severity: "warn",
+    title: "Hivemind credits exhausted — top up to keep capturing",
+    body: "Sessions are not being saved and memory recall is returning empty. Top up at https://app.deeplake.ai/billing to restore capture and recall.",
+    dedupKey: { reason: "balance-zero", date },
+  }).catch((e: unknown) => {
+    log(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 
 // ── Retry & concurrency primitives ──────────────────────────────────────────
@@ -202,6 +242,9 @@ export class DeeplakeApi {
         await sleep(delay);
         continue;
       }
+      // Surface a session-start banner for the "out of credits" case before
+      // throwing — see maybeSignalBalanceExhausted's docstring for why.
+      maybeSignalBalanceExhausted(resp.status, text);
       throw new Error(`Query failed: ${resp.status}: ${text.slice(0, 200)}`);
     }
     throw lastError ?? new Error("Query failed: max retries exceeded");
@@ -575,3 +618,11 @@ export class DeeplakeApi {
     await this.ensureLookupIndex(safe, "project_key_name", `("project_key", "name")`);
   }
 }
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+/** Reset module-local flags so tests start clean. Not for production use. */
+export function _resetSdkStateForTesting(): void {
+  _signalledBalanceExhausted = false;
+}
+

--- a/src/embeddings/client.ts
+++ b/src/embeddings/client.ts
@@ -18,8 +18,6 @@ import {
   type HelloResponse,
 } from "./protocol.js";
 import { log as _log } from "../utils/debug.js";
-import { enqueueNotification } from "../notifications/queue.js";
-import { embeddingsStatus } from "./disable.js";
 
 // Canonical location for the standalone daemon bundle, deposited by
 // `hivemind embeddings install`. Used as the auto-spawn fallback when
@@ -43,10 +41,8 @@ export interface ClientOptions {
   spawnWaitMs?: number;
 }
 
-// Process-local flags so an embed-deps-missing notification fires at most
-// once per process AND the stuck-daemon kill+recycle path runs at most once
-// per process (it's idempotent but the SIGTERM is wasted on every retry).
-let _signalledMissingDeps = false;
+// Process-local flag so the stuck-daemon kill+recycle path runs at most
+// once per process (it's idempotent but the SIGTERM is wasted on every retry).
 let _recycledStuckDaemon = false;
 // Hello handshake runs at most once per (process, EmbedClient instance).
 // Stored on the instance, not module-global, because tests construct
@@ -252,35 +248,21 @@ export class EmbedClient {
   /**
    * On a transformers-missing error from the daemon, SIGTERM the stuck
    * daemon (the bundle daemon that can't find its deps) and clear
-   * sock/pid so the next call spawns fresh. Also enqueue a one-time
-   * notification telling the user to run `hivemind embeddings install`
-   * — but only when the user has opted in. Suppressed when
-   * embeddingsStatus() === "user-disabled" so we don't nag users who
-   * explicitly chose to turn embeddings off.
+   * sock/pid so the next call spawns fresh.
+   *
+   * Previously this also enqueued a user-visible "Hivemind embeddings
+   * disabled — deps missing" notification telling the user to run
+   * `hivemind embeddings install`. The notification was removed because
+   * (a) the recycle alone often fixes the issue silently, and (b) the
+   * warning kept stacking on top of the primary session-start banner
+   * which clashed with the single-slot priority model. The `detail`
+   * argument is retained for future telemetry / debug logging.
    */
-  private handleTransformersMissing(detail: string): void {
+  private handleTransformersMissing(_detail: string): void {
     if (!_recycledStuckDaemon) {
       _recycledStuckDaemon = true;
       this.recycleDaemon(null);
     }
-    if (_signalledMissingDeps) return;
-    _signalledMissingDeps = true;
-    let status: string;
-    try { status = embeddingsStatus(); } catch { status = "enabled"; }
-    if (status === "user-disabled") return; // user said no, don't nag
-    // Fire-and-forget. `enqueueNotification` is now async (it may yield
-    // the event loop on lock contention); we don't await it so we never
-    // block the capture hot path on a notification write. Errors land in
-    // the .catch instead of being swallowed silently by the outer caller.
-    enqueueNotification({
-      id: "embed-deps-missing",
-      severity: "warn",
-      title: "Hivemind embeddings disabled — deps missing",
-      body: `Semantic memory search is off because @huggingface/transformers is not installed where the daemon can find it. Run \`hivemind embeddings install\` to enable.`,
-      dedupKey: { reason: "transformers-missing", detail: detail.slice(0, 200) },
-    }).catch((e: unknown) => {
-      log(`enqueue embed-deps-missing failed: ${e instanceof Error ? e.message : String(e)}`);
-    });
   }
 
   /**
@@ -493,7 +475,6 @@ export function isTransformersMissingError(err: string): boolean {
 // ── Test helpers ────────────────────────────────────────────────────────────
 
 export function _resetClientStateForTesting(): void {
-  _signalledMissingDeps = false;
   _recycledStuckDaemon = false;
 }
 

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -28,6 +28,8 @@ import { embeddingsDisabled } from "../embeddings/disable.js";
 import { ensurePluginNodeModulesLink } from "../embeddings/self-heal.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { getInstalledVersion } from "../utils/version-check.js";
 const log = (msg: string) => _log("capture", msg);
 
@@ -218,4 +220,60 @@ function maybeTriggerPeriodicSummary(sessionId: string, cwd: string, config: Con
   }
 }
 
-main().catch((e) => { log(`fatal: ${e.message}`); process.exit(0); });
+main().catch((e) => {
+  const msg: string = e?.message ?? String(e);
+  log(`fatal: ${msg}`);
+  // Mid-session signal: if this capture failed because the org ran out of
+  // credits (server returns 402 with `balance_cents` in the body), surface
+  // it INLINE so the user sees it on the very tool call that triggered the
+  // failure — not at the next session-start. The same notification is also
+  // enqueued by the SDK for the session-start banner (deeplake-api.ts's
+  // maybeSignalBalanceExhausted) so users get reminded on every fresh
+  // session too. Both are intentional: this is a critical error.
+  if (msg.includes("402") && msg.includes("balance_cents")) {
+    try {
+      emitBalanceExhaustedInline();
+    } catch (emitErr: any) {
+      log(`inline emit failed: ${emitErr?.message ?? String(emitErr)}`);
+    }
+  }
+  process.exit(0);
+});
+
+/**
+ * Write a hook response JSON to stdout that Claude Code renders as a
+ * user-visible banner mid-session (`systemMessage`) AND surfaces to the
+ * model as additional context (`additionalContext`). The model can then
+ * mention the issue in its next turn if it's relevant to the user's task.
+ *
+ * Reads creds for the org/workspace-scoped billing URL, falling back to
+ * the bare host when creds are missing/malformed. Mirrors the URL logic
+ * in deeplake-api.ts's billingUrl() so the session-start banner and the
+ * mid-session signal point at the same place.
+ */
+function emitBalanceExhaustedInline(): void {
+  let url = "https://deeplake.ai";
+  try {
+    const credsPath = join(homedir(), ".deeplake", "credentials.json");
+    const c = JSON.parse(readFileSync(credsPath, "utf-8")) as { orgName?: string; workspaceId?: string };
+    if (c.orgName && c.workspaceId) {
+      url = `https://deeplake.ai/${encodeURIComponent(c.orgName)}/workspace/${encodeURIComponent(c.workspaceId)}/billing`;
+    }
+  } catch { /* fall back to bare host */ }
+
+  // additionalContext is the model-facing channel — Claude Code injects
+  // it as a system reminder for the next turn. The model will then
+  // surface the issue to the user (verified live: claude wrote
+  // "Hivemind credits are exhausted, so live memory recalls are
+  // failing — top up at <url>" in its response).
+  //
+  // systemMessage is intentionally OMITTED. We tested it: Claude Code
+  // only renders systemMessage for SessionStart hooks. For PostToolUse /
+  // UserPromptSubmit / Stop, the value is silently dropped. Including
+  // it would just be dead weight in the response payload.
+  const msg = `⚠️ HIVEMIND ALERT: This capture failed because the org is out of Deeplake credits (balance is 0). Memory recall is also returning empty. Tell the user clearly: "Hivemind credits are exhausted — sessions are not being saved and memory recall is empty. Top up at ${url} to restore."`;
+  const payload = {
+    hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: msg },
+  };
+  process.stdout.write(JSON.stringify(payload));
+}

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -17,7 +17,7 @@ import type { Credentials } from "../commands/auth-creds.js";
 import type { Agent, Notification, NotificationContext } from "./types.js";
 import { evaluateRules } from "./rules/registry.js";
 import { readQueue, writeQueue } from "./queue.js";
-import { readState, writeState, alreadyShown, markShown, tryClaim } from "./state.js";
+import { readState, writeState, alreadyShown, markShown, tryClaim, releaseClaim } from "./state.js";
 import { renderNotifications } from "./format.js";
 import { emit } from "./delivery/index.js";
 import { fetchBackendNotifications } from "./sources/backend.js";
@@ -102,8 +102,17 @@ export async function drainSessionStart(opts: DrainOptions): Promise<void> {
     const rendered = renderNotifications(claimed);
     emit(opts.agent, rendered);
 
+    // Persist state for non-transient notifications. Transient ones (see
+    // Notification.transient docstring) are self-clearing — their enqueue
+    // is the rate limit, so recording them in state.shown would block the
+    // next session's refire. We also release their claim file so the next
+    // session's tryClaim() succeeds (the claim file is the OTHER cross-
+    // session blocker, separate from state.shown).
     let nextState = state;
-    for (const n of claimed) nextState = markShown(nextState, n);
+    for (const n of claimed) {
+      if (n.transient) releaseClaim(n);
+      else nextState = markShown(nextState, n);
+    }
     writeState(nextState);
 
     // Queue is fully drained whether or not its items were dedup-skipped:

--- a/src/notifications/queue.ts
+++ b/src/notifications/queue.ts
@@ -160,11 +160,10 @@ function sameDedupKey(a: Notification, b: Notification): boolean {
  * Idempotent under (id, dedupKey): if an equivalent notification is
  * already queued (i.e. a previous hook enqueued the same warning but the
  * SessionStart drain hasn't run yet), the second call is a no-op. Without
- * this, every hook process that hits an `embed-deps-missing` would pile
- * another copy onto the queue between drains — the in-process
- * `_signalledMissingDeps` flag in client.ts only dedups inside one
- * process. The drain layer already dedups against the *shown* state in
- * state.ts; this guard prevents redundant queue growth between drains.
+ * this, every hook process that produced the same notification would pile
+ * another copy onto the queue between drains. The drain layer already
+ * dedups against the *shown* state in state.ts; this guard prevents
+ * redundant queue growth between drains.
  */
 export async function enqueueNotification(n: Notification): Promise<void> {
   await withQueueLock(() => {

--- a/src/notifications/state.ts
+++ b/src/notifications/state.ts
@@ -13,7 +13,7 @@
  * accidental absolute-path injection cannot reach the real ~/.deeplake/.
  */
 
-import { closeSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -100,9 +100,7 @@ export function tryClaim(n: Notification): boolean {
     log(`tryClaim mkdir failed: ${e?.message ?? String(e)}`);
     return true;
   }
-  const keyHash = createHash("sha256").update(JSON.stringify(n.dedupKey)).digest("hex").slice(0, 12);
-  const safeId = n.id.replace(/[^a-zA-Z0-9_.:-]/g, "_");
-  const claimPath = join(claimsDir, `${safeId}-${keyHash}`);
+  const claimPath = claimPathFor(claimsDir, n);
   try {
     const fd = openSync(claimPath, "wx", 0o600);
     closeSync(fd);
@@ -112,4 +110,34 @@ export function tryClaim(n: Notification): boolean {
     log(`tryClaim open failed: ${e?.message ?? String(e)}`);
     return true;
   }
+}
+
+/**
+ * Release a claim by unlinking the claim file. Called after a transient
+ * notification is delivered so the NEXT session's enqueue+drain can win a
+ * fresh claim. Non-transient notifications keep their claim files
+ * (matching the persistent state.shown contract — same (id, dedupKey)
+ * pair won't be re-emitted later).
+ *
+ * Best-effort: any unlink error is swallowed. A stale claim file just
+ * means the next session-start drain skips that notification, which is
+ * the existing fail-OPEN posture taken elsewhere in this module.
+ */
+export function releaseClaim(n: Notification): void {
+  const home = resolve(homedir());
+  const claimsDir = join(home, ".deeplake", "notifications-claims");
+  const claimPath = claimPathFor(claimsDir, n);
+  try {
+    unlinkSync(claimPath);
+  } catch (e: any) {
+    if (e?.code !== "ENOENT") {
+      log(`releaseClaim unlink failed: ${e?.message ?? String(e)}`);
+    }
+  }
+}
+
+function claimPathFor(claimsDir: string, n: Notification): string {
+  const keyHash = createHash("sha256").update(JSON.stringify(n.dedupKey)).digest("hex").slice(0, 12);
+  const safeId = n.id.replace(/[^a-zA-Z0-9_.:-]/g, "_");
+  return join(claimsDir, `${safeId}-${keyHash}`);
 }

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -26,6 +26,17 @@ export interface Notification {
    * version-upgrade-0.7.6 tomorrow). State stores `{ id → JSON.stringify(dedupKey) }`.
    */
   dedupKey: Record<string, unknown>;
+  /**
+   * When true, the drain shows the notification but does NOT record it in
+   * `state.shown`. Use for self-clearing error notifications where the
+   * enqueue itself is the rate limit — e.g. a 402 from the SDK keeps
+   * enqueuing while the error persists, and once it's resolved no fresh
+   * enqueue happens. State.shown would block the second-session refire.
+   *
+   * Default (omitted/false) keeps the existing dedup-across-sessions
+   * behavior used by welcome, savings recap, backend pushes, etc.
+   */
+  transient?: boolean;
 }
 
 export interface NotificationContext {

--- a/tests/claude-code/deeplake-api-balance-exhausted.test.ts
+++ b/tests/claude-code/deeplake-api-balance-exhausted.test.ts
@@ -94,9 +94,14 @@ describe("DeeplakeApi — 402 balance-exhausted handling", () => {
     // Org-scoped billing URL: deeplake.ai/{orgName}/workspace/{workspaceId}/billing
     expect(arg.body).toContain("https://deeplake.ai/acme/workspace/default/billing");
     expect(arg.dedupKey.reason).toBe("balance-zero");
-    // Date is included so the banner re-fires daily until the user tops up
-    // rather than firing once-ever and going quiet.
-    expect(arg.dedupKey.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // No date — transient mode means refire every session-start while the
+    // 402 keeps re-enqueuing. Daily-rotation logic was unnecessary.
+    expect(arg.dedupKey.date).toBeUndefined();
+    // transient: true → the drain shows it but does NOT record in
+    // state.shown, so the next session's drain re-fires the freshly-
+    // enqueued copy. Required for "fire every session until topped up"
+    // semantics without re-enqueuing logic in deeplake-api.ts.
+    expect(arg.transient).toBe(true);
   });
 
   it("process-local dedup: a second 402 in the same process does not re-enqueue", async () => {

--- a/tests/claude-code/deeplake-api-balance-exhausted.test.ts
+++ b/tests/claude-code/deeplake-api-balance-exhausted.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Tests for the balance-exhausted notification path in DeeplakeApi.
@@ -31,15 +34,41 @@ function bodyResp(status: number, body: string): Response {
   return new Response(body, { status, headers: { "Content-Type": "application/json" } });
 }
 
+let TEMP_HOME = "";
+let ORIGINAL_HOME: string | undefined;
+
 beforeEach(async () => {
   fetchMock.mockReset();
   enqueueNotificationMock.mockReset();
   enqueueNotificationMock.mockResolvedValue(undefined);
   const { _resetSdkStateForTesting } = await import("../../src/deeplake-api.js");
   _resetSdkStateForTesting();
+  // Plant credentials in a sandbox HOME so billingUrl() can read orgName +
+  // workspaceId. Tests that want to verify the no-creds fallback delete
+  // the file inside the test body.
+  TEMP_HOME = mkdtempSync(join(tmpdir(), "hivemind-bal-exh-test-"));
+  ORIGINAL_HOME = process.env.HOME;
+  process.env.HOME = TEMP_HOME;
+  mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+  writeFileSync(
+    join(TEMP_HOME, ".deeplake", "credentials.json"),
+    JSON.stringify({
+      token: "tok",
+      orgId: "org-uuid",
+      orgName: "acme",
+      userName: "ada",
+      workspaceId: "default",
+      apiUrl: "https://api.example",
+      savedAt: "2026-05-19T00:00:00Z",
+    }),
+    { mode: 0o600 },
+  );
 });
 
 afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) process.env.HOME = ORIGINAL_HOME;
+  else delete process.env.HOME;
+  rmSync(TEMP_HOME, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
 
@@ -62,6 +91,8 @@ describe("DeeplakeApi — 402 balance-exhausted handling", () => {
     expect(arg.severity).toBe("warn");
     expect(arg.title).toMatch(/credits exhausted/i);
     expect(arg.body).toMatch(/top up/i);
+    // Org-scoped billing URL: deeplake.ai/{orgName}/workspace/{workspaceId}/billing
+    expect(arg.body).toContain("https://deeplake.ai/acme/workspace/default/billing");
     expect(arg.dedupKey.reason).toBe("balance-zero");
     // Date is included so the banner re-fires daily until the user tops up
     // rather than firing once-ever and going quiet.
@@ -100,6 +131,22 @@ describe("DeeplakeApi — 402 balance-exhausted handling", () => {
     const api = await makeApi();
     await expect(api.query("SELECT 1")).rejects.toThrow(/Query failed: 500/);
     expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to https://deeplake.ai when credentials are missing or malformed", async () => {
+    // Wipe the planted creds — billingUrl() should return the bare host
+    // rather than producing a URL with literal `undefined` segments.
+    rmSync(join(TEMP_HOME, ".deeplake", "credentials.json"));
+    fetchMock.mockResolvedValueOnce(
+      bodyResp(402, JSON.stringify({ balance_cents: 0, error: "insufficient balance, please top up" })),
+    );
+    const api = await makeApi();
+    await expect(api.query("SELECT 1")).rejects.toThrow(/402/);
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+    const arg = enqueueNotificationMock.mock.calls[0][0];
+    expect(arg.body).toContain("https://deeplake.ai");
+    expect(arg.body).not.toContain("undefined");
+    expect(arg.body).not.toContain("/workspace/");
   });
 
   it("still throws the original Query failed error (caller's catch path unchanged)", async () => {

--- a/tests/claude-code/deeplake-api-balance-exhausted.test.ts
+++ b/tests/claude-code/deeplake-api-balance-exhausted.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for the balance-exhausted notification path in DeeplakeApi.
+ *
+ * Server returns 402 with body `{"balance_cents":0,"error":"insufficient
+ * balance, please top up"}` when the org runs out of credits. Without
+ * surfacing this, captures and memory recalls fail silently — the agent
+ * reads empty memory and confidently reasons from no data, never telling
+ * the user why. This pins the contract that:
+ *
+ *   - A 402 with `balance_cents` in the body enqueues a session-start banner
+ *   - Process-local dedup: subsequent 402s in the same process don't double-enqueue
+ *   - Non-402 errors do NOT enqueue
+ *   - 402 WITHOUT `balance_cents` (some other 402 cause) does NOT enqueue
+ *   - The original error still throws so callers' existing handling is unchanged
+ */
+
+const enqueueNotificationMock = vi.fn();
+vi.mock("../../src/notifications/queue.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/notifications/queue.js")>(
+    "../../src/notifications/queue.js",
+  );
+  return { ...actual, enqueueNotification: (...a: unknown[]) => enqueueNotificationMock(...a) };
+});
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function bodyResp(status: number, body: string): Response {
+  return new Response(body, { status, headers: { "Content-Type": "application/json" } });
+}
+
+beforeEach(async () => {
+  fetchMock.mockReset();
+  enqueueNotificationMock.mockReset();
+  enqueueNotificationMock.mockResolvedValue(undefined);
+  const { _resetSdkStateForTesting } = await import("../../src/deeplake-api.js");
+  _resetSdkStateForTesting();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function makeApi() {
+  const { DeeplakeApi } = await import("../../src/deeplake-api.js");
+  return new DeeplakeApi("tok", "https://api.example", "org", "ws", "memory");
+}
+
+describe("DeeplakeApi — 402 balance-exhausted handling", () => {
+  it("enqueues a session-start banner when the daemon returns 402 with balance_cents:0", async () => {
+    fetchMock.mockResolvedValueOnce(
+      bodyResp(402, JSON.stringify({ balance_cents: 0, error: "insufficient balance, please top up" })),
+    );
+    const api = await makeApi();
+    await expect(api.query("SELECT 1")).rejects.toThrow(/Query failed: 402/);
+
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+    const arg = enqueueNotificationMock.mock.calls[0][0];
+    expect(arg.id).toBe("balance-exhausted");
+    expect(arg.severity).toBe("warn");
+    expect(arg.title).toMatch(/credits exhausted/i);
+    expect(arg.body).toMatch(/top up/i);
+    expect(arg.dedupKey.reason).toBe("balance-zero");
+    // Date is included so the banner re-fires daily until the user tops up
+    // rather than firing once-ever and going quiet.
+    expect(arg.dedupKey.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("process-local dedup: a second 402 in the same process does not re-enqueue", async () => {
+    fetchMock.mockResolvedValue(
+      bodyResp(402, JSON.stringify({ balance_cents: 0, error: "insufficient balance, please top up" })),
+    );
+    const api = await makeApi();
+    await expect(api.query("SELECT 1")).rejects.toThrow(/402/);
+    await expect(api.query("INSERT INTO sessions VALUES (1)")).rejects.toThrow(/402/);
+    await expect(api.query("SELECT 2")).rejects.toThrow(/402/);
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT enqueue when status is 402 but body lacks balance_cents (a different 402 reason)", async () => {
+    fetchMock.mockResolvedValueOnce(bodyResp(402, JSON.stringify({ error: "some-other-402-cause" })));
+    const api = await makeApi();
+    await expect(api.query("SELECT 1")).rejects.toThrow(/402/);
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT enqueue for non-402 errors", async () => {
+    // 500 with balance_cents in body — only the STATUS+BODY combination should match.
+    fetchMock.mockResolvedValueOnce(
+      bodyResp(500, JSON.stringify({ balance_cents: 0, error: "internal" })),
+    );
+    // Re-fire 4 times (3 retries + final) to exhaust retry budget.
+    fetchMock.mockResolvedValue(bodyResp(500, JSON.stringify({ balance_cents: 0, error: "internal" })));
+    vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+    const api = await makeApi();
+    await expect(api.query("SELECT 1")).rejects.toThrow(/Query failed: 500/);
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("still throws the original Query failed error (caller's catch path unchanged)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      bodyResp(402, JSON.stringify({ balance_cents: 0, error: "insufficient balance, please top up" })),
+    );
+    const api = await makeApi();
+    let caught: unknown = null;
+    try {
+      await api.query("SELECT 1");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/Query failed: 402/);
+    expect((caught as Error).message).toMatch(/insufficient balance/);
+  });
+});

--- a/tests/claude-code/embeddings-bundle-scan.test.ts
+++ b/tests/claude-code/embeddings-bundle-scan.test.ts
@@ -83,16 +83,12 @@ describe("shipped capture.js — self-heal + visible-failure notification", () =
         expect(src).toContain("ensurePluginNodeModulesLink");
       });
 
-      it(`capture.js carries the embed-deps-missing notification dedupKey`, () => {
+      it(`capture.js does NOT carry the removed embed-deps-missing notification`, () => {
         const src = readFileSync(a.captureHook, "utf-8");
-        // The notification ID is what the SessionStart drain renders.
-        expect(src).toContain("embed-deps-missing");
-      });
-
-      it(`capture.js still suppresses notifications when user-disabled (no nag for explicit opt-out)`, () => {
-        const src = readFileSync(a.captureHook, "utf-8");
-        // The guard must survive in the shipped artifact.
-        expect(src).toMatch(/user-disabled/);
+        // The notification was removed; if a future refactor reintroduces
+        // the string, this test fails and forces a deliberate decision.
+        expect(src).not.toContain("embed-deps-missing");
+        expect(src).not.toContain("Hivemind embeddings disabled");
       });
     });
   }

--- a/tests/claude-code/embeddings-client.test.ts
+++ b/tests/claude-code/embeddings-client.test.ts
@@ -408,7 +408,13 @@ describe("isTransformersMissingError", () => {
   });
 });
 
-describe("EmbedClient — transformers-missing handling", () => {
+describe("EmbedClient — transformers-missing handling (silent — no user banner)", () => {
+  // Previously this path enqueued a "Hivemind embeddings disabled — deps
+  // missing" notification telling the user to run `hivemind embeddings
+  // install`. The notification was removed; the recycle-stuck-daemon
+  // self-heal stays. These tests pin the contract that no user-visible
+  // notification fires from this code path under any conditions.
+
   beforeEach(() => {
     enqueueNotificationMock.mockReset();
     _resetClientStateForTesting();
@@ -420,7 +426,7 @@ describe("EmbedClient — transformers-missing handling", () => {
     _resetDisableForTesting();
   });
 
-  it("enqueues an embed-deps-missing notification when daemon reports the transformers wrapper error", async () => {
+  it("does NOT enqueue when the daemon reports the transformers wrapper error", async () => {
     _setEnabledReaderForTesting(() => true);
     const dir = makeTmpDir();
     await startFakeDaemon(dir, (req) => {
@@ -430,15 +436,10 @@ describe("EmbedClient — transformers-missing handling", () => {
     const client = new EmbedClient({ socketDir: dir, timeoutMs: 500, autoSpawn: false, daemonEntry: "" });
     const vec = await client.embed("hello");
     expect(vec).toBeNull();
-    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
-    const arg = enqueueNotificationMock.mock.calls[0][0];
-    expect(arg.id).toBe("embed-deps-missing");
-    expect(arg.severity).toBe("warn");
-    expect(arg.body).toMatch(/hivemind embeddings install/);
-    expect(arg.dedupKey.reason).toBe("transformers-missing");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
   });
 
-  it("does NOT enqueue when the user has disabled embeddings (no nag for explicit opt-out)", async () => {
+  it("does NOT enqueue when the user has disabled embeddings (no banner even pre-removal — guard still holds)", async () => {
     _setEnabledReaderForTesting(() => false);
     const dir = makeTmpDir();
     await startFakeDaemon(dir, (req) => {
@@ -450,7 +451,7 @@ describe("EmbedClient — transformers-missing handling", () => {
     expect(enqueueNotificationMock).not.toHaveBeenCalled();
   });
 
-  it("deduplicates within a single process: second failing call does not double-enqueue", async () => {
+  it("does NOT enqueue across two clients hitting the same broken daemon", async () => {
     _setEnabledReaderForTesting(() => true);
     const dir = makeTmpDir();
     await startFakeDaemon(dir, (req) => {
@@ -461,10 +462,10 @@ describe("EmbedClient — transformers-missing handling", () => {
     const c2 = new EmbedClient({ socketDir: dir, timeoutMs: 500, autoSpawn: false, daemonEntry: "" });
     await c1.embed("a");
     await c2.embed("b");
-    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
   });
 
-  it("does not enqueue on a generic daemon error unrelated to transformers", async () => {
+  it("does NOT enqueue on a generic daemon error unrelated to transformers", async () => {
     _setEnabledReaderForTesting(() => true);
     const dir = makeTmpDir();
     await startFakeDaemon(dir, (req) => {

--- a/tests/claude-code/notifications-queue-lock.test.ts
+++ b/tests/claude-code/notifications-queue-lock.test.ts
@@ -115,10 +115,10 @@ describe("readQueue — malformed JSON branch", () => {
 describe("enqueueNotification — sameDedupKey branches", () => {
   it("skips append when an equivalent (id, dedupKey) is already queued (same-process dedup)", async () => {
     const n = {
-      id: "embed-deps-missing",
+      id: "dedup-fixture",
       title: "T",
       body: "B",
-      dedupKey: { reason: "transformers-missing", detail: "exact" },
+      dedupKey: { reason: "same-key", detail: "exact" },
     };
     await enqueueNotification(n);
     await enqueueNotification(n);

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -294,17 +294,16 @@ describe("enqueueNotification cross-process safety", () => {
   const modPath = new URL("../../src/notifications/queue.ts", import.meta.url).pathname;
 
   it("cross-process producers with identical (id, dedupKey) collapse to one queue entry", async () => {
-    // Regression for CodeRabbit #8/#12: previously the dedup gate
-    // (`_signalledMissingDeps`) lived in-process, so every fresh hook
-    // process would re-enqueue the same `embed-deps-missing` warning
-    // until the next drain. Two subprocesses with identical
-    // (id, dedupKey) must now produce exactly one entry in the queue.
+    // Regression for CodeRabbit #8/#12: previously fresh hook processes
+    // would re-enqueue the same notification until the next drain. Two
+    // subprocesses with identical (id, dedupKey) must now produce exactly
+    // one entry in the queue.
     const code =
       `import("${modPath}").then(async m => { ` +
       `  await m.enqueueNotification({ ` +
-      `    id: "embed-deps-missing", ` +
+      `    id: "dedup-fixture", ` +
       `    title: "T", body: "B", ` +
-      `    dedupKey: { reason: "transformers-missing", detail: "same" } ` +
+      `    dedupKey: { reason: "same-key", detail: "same" } ` +
       `  }); ` +
       `  process.stdout.write("ok"); ` +
       `});`;
@@ -318,7 +317,7 @@ describe("enqueueNotification cross-process safety", () => {
     }
     const q = readQueue().queue;
     expect(q.length).toBe(1);
-    expect(q[0].id).toBe("embed-deps-missing");
+    expect(q[0].id).toBe("dedup-fixture");
   }, 60_000);
 
   it("N parallel producers each append exactly once (no lost writes)", async () => {

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -416,6 +416,54 @@ describe("enqueueNotification + drainSessionStart", () => {
     expect(writes.length).toBe(1);
     expect(JSON.parse(writes[0]).hookSpecificOutput.additionalContext).toContain("B2");
   });
+
+  it("transient: true — drain fires it but does NOT record in state.shown, so a re-enqueue refires", async () => {
+    // Regression for the balance-exhausted "show every session until topped
+    // up" semantics. Without transient, state.shown would block the second
+    // drain even though the queue has a fresh entry with the same key.
+    const n = {
+      id: "balance-exhausted",
+      title: "Credits exhausted",
+      body: "Top up.",
+      dedupKey: { reason: "balance-zero" },
+      transient: true as const,
+    };
+    await enqueueNotification(n);
+    await drainSessionStart({ agent: "claude-code", creds: null });
+    expect(writes.length).toBe(1);
+
+    // state.shown must NOT have recorded the transient notification.
+    const state = readState();
+    expect(state.shown["balance-exhausted"]).toBeUndefined();
+
+    // A second cycle: re-enqueue + drain → should fire again (same dedupKey).
+    writes.length = 0;
+    await enqueueNotification(n);
+    await drainSessionStart({ agent: "claude-code", creds: null });
+    expect(writes.length).toBe(1);
+  });
+
+  it("transient: false (default) — drain records in state.shown, blocking refire on same dedupKey", async () => {
+    // Control test: confirms the dedup-via-state contract holds for normal
+    // (non-transient) notifications. Without this, the transient flag's
+    // contract is meaningless.
+    const n = {
+      id: "non-transient",
+      title: "X",
+      body: "Y",
+      dedupKey: { v: 1 },
+    };
+    await enqueueNotification(n);
+    await drainSessionStart({ agent: "claude-code", creds: null });
+    expect(writes.length).toBe(1);
+    const state = readState();
+    expect(state.shown["non-transient"]).toBeDefined();
+
+    writes.length = 0;
+    await enqueueNotification(n);
+    await drainSessionStart({ agent: "claude-code", creds: null });
+    expect(writes.length).toBe(0); // blocked by state.shown
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -893,6 +893,59 @@ describe("state.tryClaim (per-notification atomic claim)", () => {
   });
 });
 
+describe("state.readState malformed-payload branches", () => {
+  it("treats a `false` JSON payload as empty (the !parsed branch)", async () => {
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(statePath(), "false", "utf-8");
+    expect(readState()).toEqual({ shown: {} });
+  });
+
+  it("treats a number JSON payload as empty (typeof !== object branch)", async () => {
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(statePath(), "42", "utf-8");
+    expect(readState()).toEqual({ shown: {} });
+  });
+
+  it("treats a missing shown key as empty (typeof shown !== object branch)", async () => {
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(statePath(), JSON.stringify({ otherKey: "val" }), "utf-8");
+    expect(readState()).toEqual({ shown: {} });
+  });
+});
+
+describe("state.releaseClaim (transient notification cleanup)", () => {
+  it("unlinks the claim file so the next tryClaim with the same key succeeds", async () => {
+    const { tryClaim, releaseClaim } = await import("../../src/notifications/state.js");
+    const n: Notification = { id: "release-test", dedupKey: { v: 1 }, title: "t", body: "b" };
+    expect(tryClaim(n)).toBe(true);
+    // Without releaseClaim, the second claim would EEXIST → false.
+    releaseClaim(n);
+    expect(tryClaim(n)).toBe(true);
+  });
+
+  it("silent no-op when the claim file doesn't exist (ENOENT swallowed)", async () => {
+    const { releaseClaim } = await import("../../src/notifications/state.js");
+    const n: Notification = { id: "never-claimed", dedupKey: { v: 1 }, title: "t", body: "b" };
+    // Never tryClaim'd — no file on disk. Must not throw.
+    expect(() => releaseClaim(n)).not.toThrow();
+  });
+
+  it("logs and continues on non-ENOENT errors (e.g. claim path is a directory)", async () => {
+    const { mkdirSync } = await import("node:fs");
+    const { releaseClaim } = await import("../../src/notifications/state.js");
+    const claimsDir = join(TEMP_HOME, ".deeplake", "notifications-claims");
+    mkdirSync(claimsDir, { recursive: true, mode: 0o700 });
+    // Make the claim path point at a DIRECTORY instead of a file —
+    // unlinkSync on a dir throws EISDIR (POSIX) or EPERM (Linux). Either
+    // way it's not ENOENT, so the fail-soft logging branch fires.
+    const n: Notification = { id: "release-test-2", dedupKey: { v: 2 }, title: "t", body: "b" };
+    const { createHash } = await import("node:crypto");
+    const keyHash = createHash("sha256").update(JSON.stringify(n.dedupKey)).digest("hex").slice(0, 12);
+    mkdirSync(join(claimsDir, `release-test-2-${keyHash}`), { recursive: true });
+    expect(() => releaseClaim(n)).not.toThrow();
+  });
+});
+
 describe("drainSessionStart with per-notification claim", () => {
   it("two parallel drains emit the welcome banner exactly once total (not duplicated)", async () => {
     let stdoutWrites = 0;


### PR DESCRIPTION
## Summary
- Strip the \`enqueueNotification({id: \"embed-deps-missing\", title: \"Hivemind embeddings disabled — deps missing\", ...})\` call from \`handleTransformersMissing()\` in \`src/embeddings/client.ts\`.
- Keep the stuck-daemon recycle (SIGTERM + sock/pid cleanup) — that's the actual self-heal, fixes the issue silently on the next call.
- Remove the now-orphaned \`_signalledMissingDeps\` flag, \`embeddingsStatus()\` user-disabled check, and \`enqueueNotification\` / \`embeddingsStatus\` imports.

## Why
The banner kept stacking on top of the primary session-start message even for users whose embeddings work correctly (the daemon recycles silently and embeddings are fine on next call). The CLI's \`embeddings status\` already documents the install command for users with persistent failures, so the banner doesn't carry unique value. Removing it reduces session-start noise without losing self-heal capability.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run build\`
- [x] \`npx vitest run tests/claude-code/embeddings-client.test.ts tests/claude-code/embeddings-bundle-scan.test.ts tests/claude-code/notifications.test.ts tests/claude-code/notifications-queue-lock.test.ts\` — 130/130 passing
- [x] Full suite: 2704/2705 (one unrelated flake in deeplake-fs.test.ts — confirmed pre-existing on origin/main at 40% failure rate over 5 runs)
- [ ] After merge: confirm session-start no longer shows the embeddings-disabled warning even with a known-broken daemon

## Tests pinned to the new contract
- \`embeddings-client.test.ts\`: four cases in \"transformers-missing handling\" flipped to assert \`enqueueNotificationMock\` NEVER fires
- \`embeddings-bundle-scan.test.ts\`: scan flipped from \"capture.js carries embed-deps-missing\" to \"capture.js does NOT carry embed-deps-missing\" — guards against accidental reintroduction
- Queue tests using \`embed-deps-missing\` as a fixture id switched to neutral \`dedup-fixture\` (those tests validate queue dedup, not embeddings-specific behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary user notifications about missing embeddings dependencies; the system now silently manages daemon recovery without disrupting workflows.

* **Chores**
  * Updated internal daemon lifecycle management and logging infrastructure across multiple bundles for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->