### PR TITLE
fix(plugin-cache-gc): refcount in-use versions via `.in_use/<pid>`

### DIFF
--- a/src/utils/plugin-cache.ts
+++ b/src/utils/plugin-cache.ts
@@ -1,9 +1,10 @@
 import { cpSync, existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 const KEEP_RE = /\.keep-(\d+)$/;
+const IN_USE_DIR = ".in_use";
 
 export function isSemver(name: string): boolean {
   return SEMVER_RE.test(name);
@@ -51,6 +52,85 @@ function isPidAlive(pid: number): boolean {
   } catch (e: any) {
     return e?.code === "EPERM";
   }
+}
+
+/**
+ * Read `/proc/<pid>/stat` field 22 (start time in jiffies since boot) on
+ * Linux. Returns null when the file can't be read (process gone, macOS,
+ * weird perms) — callers fall back to PID-only liveness in that case.
+ *
+ * field 22 = "starttime" per `man 5 proc`. Stable across the process's
+ * lifetime, monotonic across reboots (it's relative to boot time but the
+ * counter only increments while a given boot is running). Combined with
+ * the PID, it uniquely identifies a process on this host across PID
+ * reuse — exactly the property Claude Code relies on when writing
+ * `.in_use/<pid>` files with shape `{"pid":N,"procStart":"<starttime>"}`.
+ */
+function readProcStart(pid: number): string | null {
+  if (platform() !== "linux") return null;
+  try {
+    const raw = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    // Field 2 ("comm") is bracketed by () and may contain spaces; skip it
+    // by splitting on the LAST closing paren, then take field 20 of the
+    // remainder (field 22 of the whole line, 1-indexed).
+    const tail = raw.slice(raw.lastIndexOf(")") + 1).trim();
+    const fields = tail.split(/\s+/);
+    return fields[19] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A `.in_use/<pid>` file claims that PID is actively using this plugin
+ * version. We treat the claim as live iff:
+ *
+ *   1. The PID is alive on this host (`kill(pid, 0)` succeeds), AND
+ *   2. If the file includes `procStart`, it matches `/proc/<pid>/stat`
+ *      field 22 — same process, not a PID-reused-by-the-kernel reincarnation.
+ *
+ * Returns false on malformed JSON or unreadable files. Returns true on
+ * matching live process. Returns false on dead/reused PID.
+ *
+ * macOS (or anywhere `/proc` doesn't exist) skips the procStart check
+ * and accepts kill(pid, 0) as sufficient evidence. False-keep is much
+ * cheaper than false-delete: a kept old version costs disk; a deleted
+ * in-use version breaks every hook in the session that depends on it.
+ */
+function isInUseClaimLive(claimPath: string): boolean {
+  let raw: string;
+  try { raw = readFileSync(claimPath, "utf-8"); } catch { return false; }
+  let parsed: { pid?: unknown; procStart?: unknown };
+  try { parsed = JSON.parse(raw); } catch { return false; }
+  const pid = typeof parsed.pid === "number" ? parsed.pid : Number(parsed.pid);
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+
+  if (!isPidAlive(pid)) return false;
+
+  if (typeof parsed.procStart === "string" && parsed.procStart.length > 0) {
+    const actual = readProcStart(pid);
+    // Only enforce match when we can read procfs. On macOS or when
+    // /proc isn't available, actual is null and we keep the claim live.
+    if (actual !== null && actual !== parsed.procStart) return false;
+  }
+  return true;
+}
+
+/**
+ * Return true if any `.in_use/<pid>` claim file in `versionDir` references
+ * a live process. Used by `planGc` to refuse-to-delete a plugin version
+ * that some still-running session has pinned.
+ *
+ * Empty / missing `.in_use/` directory → false (no live claims).
+ */
+export function isVersionInUse(versionDir: string): boolean {
+  const inUseDir = join(versionDir, IN_USE_DIR);
+  let entries: string[];
+  try { entries = readdirSync(inUseDir); } catch { return false; }
+  for (const name of entries) {
+    if (isInUseClaimLive(join(inUseDir, name))) return true;
+  }
+  return false;
 }
 
 export interface SnapshotHandle {
@@ -140,6 +220,11 @@ export interface GcPlan {
  *
  * - Keeps the current version (from the manifest) plus the next-newest
  *   versions up to `keepCount` total.
+ * - **Also keeps any older version that a live session still claims**
+ *   via a `.in_use/<pid>` file (checked through `isInUse`). Without this,
+ *   GC happily evicts the bundle dir a long-running session is pinned
+ *   to, and every subsequent hook in that session ENOENTs on
+ *   `${CLAUDE_PLUGIN_ROOT}/bundle/...`. See issue #188.
  * - Marks stale `.keep-<pid>` snapshots (dead PID) for deletion.
  * - Leaves unknown entries (non-semver, non-`.keep-*`) alone so we
  *   never touch files the installer or user put there for other reasons.
@@ -149,6 +234,7 @@ export function planGc(
   currentVersion: string | null,
   keepCount: number,
   isAlive: (pid: number) => boolean = isPidAlive,
+  isInUse: (versionDir: string) => boolean = isVersionInUse,
 ): GcPlan {
   const entries = safeReaddir(versionsRoot);
   const versions = entries.filter(isSemver);
@@ -165,7 +251,17 @@ export function planGc(
   const deleteVersions: string[] = [];
   if (currentVersion && versions.includes(currentVersion)) {
     for (const v of versions) {
-      if (!keep.has(v)) deleteVersions.push(v);
+      if (keep.has(v)) continue;
+      // Refcount gate: refuse to delete a version that any live session
+      // still claims via `.in_use/<pid>`. The cost of false-keep is one
+      // unused bundle dir on disk; the cost of false-delete is "Plugin
+      // directory does not exist" hook errors for the whole remaining
+      // life of every pinned session.
+      if (isInUse(join(versionsRoot, v))) {
+        keep.add(v);
+        continue;
+      }
+      deleteVersions.push(v);
     }
   }
 

--- a/tests/claude-code/plugin-cache.test.ts
+++ b/tests/claude-code/plugin-cache.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { chmodSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir, homedir } from "node:os";
+import { tmpdir, homedir, platform } from "node:os";
 import {
   compareSemverDesc,
   executeGc,
   isSemver,
+  isVersionInUse,
   planGc,
   readCurrentVersionFromManifest,
   resolveVersionedPluginDir,
@@ -267,6 +268,153 @@ describe("planGc", () => {
   it("handles missing versionsRoot gracefully", () => {
     const plan = planGc(join(root, "does-not-exist"), "0.6.39", 2, () => false);
     expect(plan).toEqual({ keep: [], deleteVersions: [], deleteSnapshots: [] });
+  });
+
+  // -- In-use refcounting (issue #188) -----------------------------------
+  // Without this, GC happily evicts an old version that a long-running
+  // session is still pinned to → every hook in that session ENOENTs on
+  // ${CLAUDE_PLUGIN_ROOT}/bundle/... afterwards.
+
+  it("keeps an old version when isInUse claims it's still in use", () => {
+    mk("0.6.37", "0.6.38", "0.6.39", "0.6.40");
+    // 0.6.37 is well below the keep-2 cutoff but a live session claims it.
+    const isInUse = (versionDir: string) => versionDir.endsWith("/0.6.37");
+    const plan = planGc(root, "0.6.40", 2, () => false, isInUse);
+    expect(plan.keep).toContain("0.6.37");
+    expect(plan.deleteVersions).not.toContain("0.6.37");
+    // 0.6.38 has no in-use claim, so it's still deleted.
+    expect(plan.deleteVersions).toContain("0.6.38");
+  });
+
+  it("still deletes old versions with no in-use claim", () => {
+    mk("0.6.37", "0.6.38", "0.6.39", "0.6.40");
+    const plan = planGc(root, "0.6.40", 2, () => false, () => false);
+    expect(new Set(plan.deleteVersions)).toEqual(new Set(["0.6.37", "0.6.38"]));
+  });
+
+  it("does NOT consult isInUse for versions already inside the keep window", () => {
+    // CLAUDE.md rule 6: assert count, not just presence. A correct impl
+    // short-circuits the refcount check for kept versions — calling
+    // isInUse on them would waste time and tempt buggy impls into
+    // double-keep paths.
+    mk("0.6.37", "0.6.38", "0.6.39", "0.6.40");
+    const calls: string[] = [];
+    const isInUse = (versionDir: string) => { calls.push(versionDir); return false; };
+    planGc(root, "0.6.40", 2, () => false, isInUse);
+    // Only 0.6.37 and 0.6.38 are deletion candidates; 0.6.39 and 0.6.40
+    // are auto-kept and must not be queried.
+    expect(calls.map(c => c.split("/").pop())).toEqual(["0.6.37", "0.6.38"]);
+  });
+
+  it("default isInUse (real disk) returns false when no .in_use dirs exist", () => {
+    // Old planGc tests don't pass an isInUse arg → they use the real one
+    // backed by readdirSync(.in_use). On these tmpdirs without .in_use/
+    // subdirs, the real impl must return false so behavior is unchanged.
+    mk("0.6.37", "0.6.39", "0.6.40");
+    const plan = planGc(root, "0.6.40", 2, () => false);
+    expect(plan.deleteVersions).toContain("0.6.37");
+  });
+});
+
+describe("isVersionInUse", () => {
+  let root: string;
+  beforeEach(() => { root = mkRoot(); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it("returns false when the version dir has no .in_use subdirectory", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(v, { recursive: true });
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("returns false when .in_use is empty", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("returns true when .in_use holds a live process's claim with matching procStart", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    // Use *this* process as the live PID. On Linux we read its real
+    // procStart so the match succeeds. On macOS readProcStart returns
+    // null and the procStart check is skipped — also a match.
+    const pid = process.pid;
+    let procStart = "0";
+    if (platform() === "linux") {
+      const raw = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const tail = raw.slice(raw.lastIndexOf(")") + 1).trim();
+      procStart = tail.split(/\s+/)[19] ?? "0";
+    }
+    writeFileSync(join(v, ".in_use", String(pid)), JSON.stringify({ pid, procStart }));
+    expect(isVersionInUse(v)).toBe(true);
+  });
+
+  it("returns false when the only claim's PID is dead", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    // 0x7FFFFFFF is above /proc/sys/kernel/pid_max on Linux and reserved
+    // on macOS → guaranteed not-alive.
+    writeFileSync(join(v, ".in_use", "2147483647"), JSON.stringify({ pid: 2147483647, procStart: "1" }));
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("returns false on Linux when procStart doesn't match the live PID (PID reuse case)", () => {
+    if (platform() !== "linux") return;
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    // Live PID (this test process), but with a procStart that can't
+    // match the kernel's actual start time. CLAUDE.md rule 1: cross-
+    // process state (PID-reuse) is one of the bugs that ship past
+    // single-instance tests; pin it explicitly.
+    writeFileSync(
+      join(v, ".in_use", String(process.pid)),
+      JSON.stringify({ pid: process.pid, procStart: "0" }),
+    );
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("ignores claim files with malformed JSON", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    writeFileSync(join(v, ".in_use", "garbage"), "not json {");
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("ignores claim files missing or with non-numeric pid", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    writeFileSync(join(v, ".in_use", "no-pid"), JSON.stringify({ procStart: "1" }));
+    writeFileSync(join(v, ".in_use", "bad-pid"), JSON.stringify({ pid: "not-a-number" }));
+    expect(isVersionInUse(v)).toBe(false);
+  });
+
+  it("returns true if ANY of multiple claim files is live (one alive among dead ones)", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    writeFileSync(join(v, ".in_use", "2147483647"), JSON.stringify({ pid: 2147483647, procStart: "1" }));
+    writeFileSync(join(v, ".in_use", "garbage"), "definitely not json");
+    // Our own PID — guaranteed live. Same Linux/macOS handling as the
+    // matching-procStart test above.
+    const pid = process.pid;
+    let procStart = "0";
+    if (platform() === "linux") {
+      const raw = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const tail = raw.slice(raw.lastIndexOf(")") + 1).trim();
+      procStart = tail.split(/\s+/)[19] ?? "0";
+    }
+    writeFileSync(join(v, ".in_use", String(pid)), JSON.stringify({ pid, procStart }));
+    expect(isVersionInUse(v)).toBe(true);
+  });
+
+  it("treats a claim without procStart as live when the PID is alive (legacy claim format)", () => {
+    const v = join(root, "0.6.39");
+    mkdirSync(join(v, ".in_use"), { recursive: true });
+    // Forwards-compat: older Claude Code versions may have written
+    // claim files with just {pid}. Without procStart, we trust kill(pid, 0)
+    // alone — preferable to false-deleting a still-live session's bundle.
+    writeFileSync(join(v, ".in_use", String(process.pid)), JSON.stringify({ pid: process.pid }));
+    expect(isVersionInUse(v)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #188.

## Summary

`planGc` kept current + N-1 newest by position alone, never reading the `.in_use/<pid>` claim files Claude Code writes for each session that has resolved `${CLAUDE_PLUGIN_ROOT}` to a given plugin version. A long-running session pinned to a version that falls out of the keep window had its bundle dir evicted under it on the next SessionEnd GC, breaking every remaining hook with `Plugin directory does not exist: …/hivemind/<pinned>`.

This PR makes `planGc` a refuse-to-delete gate for versions outside the keep window: if **any** live PID still claims the version via `.in_use/<pid>`, the version is kept. Versions inside the keep window are auto-kept and not queried, so the new gate can never widen the deletion set.

## Behavior

`isVersionInUse(versionDir)` treats a claim as live iff:
1. `kill(pid, 0)` succeeds, AND
2. On Linux, `/proc/<pid>/stat` field 22 (starttime) matches the recorded `procStart` (PID-reuse safe). macOS / no-procfs accepts `kill(pid, 0)` alone — false-keep is cheap, false-delete breaks sessions.

Falls back gracefully on: missing `.in_use/`, empty `.in_use/`, malformed JSON, missing/non-numeric `pid`, dead PID, mismatched `procStart`, legacy claims without `procStart`.

## Test plan

`tests/claude-code/plugin-cache.test.ts` adds:

- [x] `isVersionInUse`: missing `.in_use` dir → false; empty `.in_use` → false; live PID + matching `procStart` → true; dead PID → false; live PID + mismatched `procStart` (Linux only) → false (covers the PID-reuse case CLAUDE.md rule 1 calls out); malformed JSON ignored; missing/non-numeric pid ignored; any-live-wins among mixed claims; legacy claim without `procStart` trusts `kill(pid, 0)` alone.
- [x] `planGc`: keeps an out-of-window version when in-use; still deletes when not in-use; does NOT call `isInUse` for versions already inside the keep window (count-based assertion per CLAUDE.md rule 6 — a buggy impl can't widen the deletion set); default real-disk `isInUse` returns false on tmpdirs without `.in_use/` (proves existing tests' behavior is preserved unchanged).
- [x] `npm run typecheck` clean
- [x] focused suite: 43/43 pass
- [x] full suite: 2814/2815 pass (the one fail is a pre-existing flake in `deeplake-fs.test.ts > batches and flushes`, unrelated and not introduced here)

## Related

- #187 — concurrent `hivemind update` lock. That PR prevents partial installs that break the `hivemind` binary itself. This PR prevents the GC from evicting bundle dirs out from under live sessions. Both are independent failure modes of "hooks fail after autoupdate" — #187 fixes the install-corruption variant, this PR fixes the GC-eviction variant.

## Known limitation

If `~/.claude/plugins/cache/` is on a shared filesystem (NFS), `.in_use/<pid>` files written by sessions on other hosts will be checked against the local kernel's PID table — false-deletes are possible. Mitigation would require including a host identifier in claim files; that's a Claude-Code-side change, not a hivemind-side one. Filing a separate issue if anyone hits this in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin versions in use are now automatically detected and protected from deletion during garbage collection operations.
  * Cache system enhanced with process lifecycle awareness to track version usage across different platforms.

* **Tests**
  * Added extensive test coverage for version-in-use tracking, process validation, and garbage collection decision-making.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->