### PR TITLE
feat(install): consent prompt + headless token auth before device flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The installer detects every supported assistant on your machine (table below), w
 ```bash
 DEEPLAKE_API_TOKEN=<your-token> hivemind install
 # or
+HIVEMIND_TOKEN=<your-token> hivemind install
+# or
 hivemind install --token <your-token>
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ One command, all your agents:
 npm install -g @deeplake/hivemind && hivemind install
 ```
 
-The installer detects every supported assistant on your machine (table below), wires up the hooks, and opens a browser once for login. Restart them after install.
+The installer detects every supported assistant on your machine (table below), wires up the hooks, and shows a one-line consent prompt before opening a browser for sign-in. Restart your assistants after install.
+
+**Headless / CI installs** — pass an API token instead of using the browser flow:
+
+```bash
+DEEPLAKE_API_TOKEN=<your-token> hivemind install
+# or
+hivemind install --token <your-token>
+```
+
+Get a token from your account settings on https://deeplake.ai. With no token in a non-interactive shell, the install completes with hooks but skips sign-in; run `hivemind login` later to enable shared memory.
 
 **Install for a specific assistant only:**
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The installer detects every supported assistant on your machine (table below), w
 **Headless / CI installs** — pass an API token instead of using the browser flow:
 
 ```bash
-DEEPLAKE_API_TOKEN=<your-token> hivemind install
-# or
 HIVEMIND_TOKEN=<your-token> hivemind install
 # or
 hivemind install --token <your-token>

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -44,7 +44,11 @@ export async function loginWithProvidedToken(flagToken?: string): Promise<boolea
 
   try {
     await saveCredentialsFromToken(token, resolveApiUrl(), { skipTokenMint: true });
-    const source = flagToken ? "--token flag" : "DEEPLAKE_API_TOKEN";
+    const source = flagToken
+      ? "--token flag"
+      : process.env.DEEPLAKE_API_TOKEN
+        ? "DEEPLAKE_API_TOKEN"
+        : "HIVEMIND_TOKEN";
     log(`Signed in via ${source}.`);
     return true;
   } catch (err) {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,7 +1,13 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { HOME, log, warn } from "./util.js";
-import { login, loadCredentials, listOrgs } from "../commands/auth.js";
+import { login, loadCredentials, listOrgs, saveCredentialsFromToken } from "../commands/auth.js";
+
+const DEFAULT_API_URL = "https://api.deeplake.ai";
+
+function resolveApiUrl(): string {
+  return process.env.HIVEMIND_API_URL ?? process.env.DEEPLAKE_API_URL ?? DEFAULT_API_URL;
+}
 
 const CREDS_PATH = join(HOME, ".deeplake", "credentials.json");
 
@@ -16,14 +22,35 @@ export async function ensureLoggedIn(): Promise<boolean> {
   log("No Deeplake credentials found. Starting login...");
 
   try {
-    const apiUrl = process.env.HIVEMIND_API_URL ?? process.env.DEEPLAKE_API_URL ?? "https://api.deeplake.ai";
-    await login(apiUrl);
+    await login(resolveApiUrl());
   } catch (err) {
     warn(`Login failed: ${(err as Error).message}`);
     return false;
   }
 
   return isLoggedIn();
+}
+
+// Sign in using a long-lived API token from --token, DEEPLAKE_API_TOKEN, or
+// HIVEMIND_TOKEN. Returns false when no token is present so callers can
+// distinguish "no token attempted" from "token attempted and failed". A
+// failed token validation is warned-and-continued, never thrown — install
+// must not break on auth.
+export async function loginWithProvidedToken(flagToken?: string): Promise<boolean> {
+  const token = flagToken
+    ?? process.env.DEEPLAKE_API_TOKEN
+    ?? process.env.HIVEMIND_TOKEN;
+  if (!token) return false;
+
+  try {
+    await saveCredentialsFromToken(token, resolveApiUrl(), { skipTokenMint: true });
+    const source = flagToken ? "--token flag" : "DEEPLAKE_API_TOKEN";
+    log(`Signed in via ${source}.`);
+    return true;
+  } catch (err) {
+    warn(`Token authentication failed: ${(err as Error).message}. Continuing install.`);
+    return false;
+  }
 }
 
 export async function maybeShowOrgChoice(): Promise<void> {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -6,7 +6,7 @@ import { login, loadCredentials, listOrgs, saveCredentialsFromToken } from "../c
 const DEFAULT_API_URL = "https://api.deeplake.ai";
 
 function resolveApiUrl(): string {
-  return process.env.HIVEMIND_API_URL ?? process.env.DEEPLAKE_API_URL ?? DEFAULT_API_URL;
+  return process.env.HIVEMIND_API_URL ?? DEFAULT_API_URL;
 }
 
 const CREDS_PATH = join(HOME, ".deeplake", "credentials.json");
@@ -31,24 +31,18 @@ export async function ensureLoggedIn(): Promise<boolean> {
   return isLoggedIn();
 }
 
-// Sign in using a long-lived API token from --token, DEEPLAKE_API_TOKEN, or
-// HIVEMIND_TOKEN. Returns false when no token is present so callers can
-// distinguish "no token attempted" from "token attempted and failed". A
-// failed token validation is warned-and-continued, never thrown — install
-// must not break on auth.
+// Sign in using a long-lived API token from --token or HIVEMIND_TOKEN.
+// Returns false when no token is present so callers can distinguish "no
+// token attempted" from "token attempted and failed". A failed token
+// validation is warned-and-continued, never thrown — install must not
+// break on auth.
 export async function loginWithProvidedToken(flagToken?: string): Promise<boolean> {
-  const token = flagToken
-    ?? process.env.DEEPLAKE_API_TOKEN
-    ?? process.env.HIVEMIND_TOKEN;
+  const token = flagToken ?? process.env.HIVEMIND_TOKEN;
   if (!token) return false;
 
   try {
     await saveCredentialsFromToken(token, resolveApiUrl(), { skipTokenMint: true });
-    const source = flagToken
-      ? "--token flag"
-      : process.env.DEEPLAKE_API_TOKEN
-        ? "DEEPLAKE_API_TOKEN"
-        : "HIVEMIND_TOKEN";
+    const source = flagToken ? "--token flag" : "HIVEMIND_TOKEN";
     log(`Signed in via ${source}.`);
     return true;
   } catch (err) {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -46,7 +46,12 @@ export async function loginWithProvidedToken(flagToken?: string): Promise<boolea
     log(`Signed in via ${source}.`);
     return true;
   } catch (err) {
-    warn(`Token authentication failed: ${(err as Error).message}. Continuing install.`);
+    // Surface the API error so the user knows whether it was a 401 (revoked
+    // or wrong token), 404 (user not found), network failure, etc. Caller
+    // (runAuthGate) decides whether to retry, fall through, or continue —
+    // we deliberately don't editorialize "Continuing install" here so the
+    // retry-loop UX in the paste fallback doesn't contradict itself.
+    warn(`Token authentication failed: ${(err as Error).message}`);
     return false;
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -163,9 +163,9 @@ async function runAuthGate(args: string[]): Promise<void> {
 
   if (!isTTY) {
     log("");
-    log("Hivemind install completed without sign-in (no TTY detected).");
-    log("To enable shared memory now, rerun with `--token <value>` or set");
-    log("DEEPLAKE_API_TOKEN. Otherwise run `hivemind login` after install.");
+    log("No TTY detected — continuing without sign-in.");
+    log("To sign in, rerun with `--token <value>`, set DEEPLAKE_API_TOKEN");
+    log("or HIVEMIND_TOKEN, or run `hivemind login` after install.");
     return;
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,10 +11,10 @@ import {
   statusEmbeddings,
   uninstallEmbeddings,
 } from "./embeddings.js";
-import { ensureLoggedIn, isLoggedIn, maybeShowOrgChoice } from "./auth.js";
+import { ensureLoggedIn, isLoggedIn, loginWithProvidedToken, maybeShowOrgChoice } from "./auth.js";
 import { runAuthCommand } from "../commands/auth-login.js";
 import { runSkillifyCommand } from "../commands/skillify.js";
-import { detectPlatforms, allPlatformIds, log, warn, type PlatformId } from "./util.js";
+import { confirm, detectPlatforms, allPlatformIds, log, warn, type PlatformId } from "./util.js";
 import { getVersion } from "./version.js";
 import { runUpdate } from "./update.js";
 import { renderCliHelpBlock } from "./skillify-spec.js";
@@ -36,9 +36,13 @@ const USAGE = `
 hivemind — one brain for every agent on your team
 
 Usage:
-  hivemind install   [--only <platforms>] [--skip-auth]
+  hivemind install   [--only <platforms>] [--skip-auth] [--token <value>]
       Auto-detect assistants on this machine and install hivemind into each.
       --only takes a comma-separated list: ${allPlatformIds().join(",")}
+      --token, or env DEEPLAKE_API_TOKEN / HIVEMIND_TOKEN, signs in
+      non-interactively (useful for CI / scripted installs). Without it,
+      a TTY install shows a consent prompt; a headless install skips
+      auth and prints a hint for 'hivemind login'.
 
   hivemind uninstall [--only <platforms>]
       Auto-detect installed assistants and remove hivemind from each.
@@ -128,6 +132,66 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+function parseToken(args: string[]): string | undefined {
+  const idx = args.findIndex(a => a === "--token" || a.startsWith("--token="));
+  if (idx === -1) return undefined;
+  const raw = args[idx].includes("=") ? args[idx].split("=", 2)[1] : args[idx + 1];
+  return raw && raw.length > 0 ? raw : undefined;
+}
+
+// Decide how to sign the user in before platform install runs. Three paths,
+// in priority order:
+//   1. A token is provided (flag or env). Validate via /me and save creds —
+//      honored regardless of TTY since a typed/exported token is itself an
+//      act of consent.
+//   2. Non-TTY without a token. We CANNOT prompt (readline would hang on
+//      closed stdin), so print a one-time hint and continue install.
+//   3. TTY without a token. Show the consent prompt; only on "Yes" do we
+//      open the browser via ensureLoggedIn() / device flow.
+// In every path, a failure (or "No") continues the install — hooks land and
+// the user can `hivemind login` later. This is the deliberate inversion
+// behind the consent rollout: install ≠ auth.
+async function runAuthGate(args: string[]): Promise<void> {
+  const flagToken = parseToken(args);
+  const hasEnvToken = Boolean(process.env.DEEPLAKE_API_TOKEN ?? process.env.HIVEMIND_TOKEN);
+  const isTTY = Boolean(process.stdin.isTTY);
+
+  if (flagToken || hasEnvToken) {
+    await loginWithProvidedToken(flagToken);
+    return;
+  }
+
+  if (!isTTY) {
+    log("");
+    log("Hivemind install completed without sign-in (no TTY detected).");
+    log("To enable shared memory now, rerun with `--token <value>` or set");
+    log("DEEPLAKE_API_TOKEN. Otherwise run `hivemind login` after install.");
+    return;
+  }
+
+  log("");
+  log("🐝 One more step to unlock Hivemind");
+  log("To enable shared memory and auto-learning across your agents,");
+  log("we need to sign you in. Your traces will be stored in your team's");
+  log("Hivemind so all your agents can recall them.");
+  log("");
+  log("Prefer your own cloud storage (S3 / GCS / Azure Blob)?");
+  log("See https://deeplake.ai or contact us to wire it up.");
+  log("");
+  log("Already have a token? Pass --token <value> or set DEEPLAKE_API_TOKEN.");
+  log("");
+  const yes = await confirm("Sign in now?", true);
+  if (yes) {
+    const ok = await ensureLoggedIn();
+    if (!ok) {
+      warn("Login did not complete. Continuing install — run `hivemind login` to sign in later.");
+    }
+  } else {
+    log("");
+    log("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+  }
+}
+
 async function runInstallAll(args: string[]): Promise<void> {
   const only = parseOnly(args);
   const skipAuth = hasFlag(args, "--skip-auth");
@@ -146,11 +210,7 @@ async function runInstallAll(args: string[]): Promise<void> {
   log("");
 
   if (!skipAuth && !isLoggedIn()) {
-    const ok = await ensureLoggedIn();
-    if (!ok) {
-      warn("Skipping install because login did not complete.");
-      process.exit(1);
-    }
+    await runAuthGate(args);
   }
 
   for (const id of targets) runSingleInstall(id);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,7 @@ import {
 import { ensureLoggedIn, isLoggedIn, loginWithProvidedToken, maybeShowOrgChoice } from "./auth.js";
 import { runAuthCommand } from "../commands/auth-login.js";
 import { runSkillifyCommand } from "../commands/skillify.js";
-import { confirm, detectPlatforms, allPlatformIds, log, warn, type PlatformId } from "./util.js";
+import { confirm, detectPlatforms, allPlatformIds, log, promptLine, warn, type PlatformId } from "./util.js";
 import { getVersion } from "./version.js";
 import { runUpdate } from "./update.js";
 import { renderCliHelpBlock } from "./skillify-spec.js";
@@ -164,31 +164,51 @@ async function runAuthGate(args: string[]): Promise<void> {
   if (!isTTY) {
     log("");
     log("No TTY detected — continuing without sign-in.");
-    log("To sign in, rerun with `--token <value>`, set DEEPLAKE_API_TOKEN");
-    log("or HIVEMIND_TOKEN, or run `hivemind login` after install.");
+    log("To sign in:");
+    log("  1) Visit https://app.deeplake.ai/api-keys to create an API key");
+    log("  2) Rerun: DEEPLAKE_API_TOKEN=<key> hivemind install");
+    log("Or run `hivemind login` after install.");
     return;
   }
 
   log("");
   log("🐝 One more step to unlock Hivemind");
+  log("");
   log("To enable shared memory and auto-learning across your agents,");
-  log("we need to sign you in. Your traces will be stored in your team's");
-  log("Hivemind so all your agents can recall them.");
+  log("we need to sign you in. Your traces will be securely stored in");
+  log("your private Hivemind, so all your agents can recall them.");
   log("");
-  log("Prefer your own cloud storage (S3 / GCS / Azure Blob)?");
-  log("See https://deeplake.ai or contact us to wire it up.");
-  log("");
-  log("Already have a token? Pass --token <value> or set DEEPLAKE_API_TOKEN.");
+  log("You can later connect your own cloud storage like S3/GCS/Azure Blob.");
   log("");
   const yes = await confirm("Sign in now?", true);
+
+  let signedIn = false;
   if (yes) {
-    const ok = await ensureLoggedIn();
-    if (!ok) {
-      warn("Login did not complete. Continuing install — run `hivemind login` to sign in later.");
+    signedIn = await ensureLoggedIn();
+    if (!signedIn) {
+      warn("Login did not complete.");
     }
-  } else {
+  }
+
+  // Fallback: if user declined OR said Yes but the device flow didn't
+  // finish, offer the API-key paste path. This catches both "I don't want
+  // to do the browser dance" and "I started but it timed out / I closed
+  // the tab" — both used to dead-end the install with no auth.
+  if (!signedIn) {
     log("");
-    log("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+    log("Alternatively, sign in at https://app.deeplake.ai/api-keys, create");
+    log("an API key, and paste it here. Press Enter to skip and continue");
+    log("installing without sign-in (you can run `hivemind login` later).");
+    log("");
+    const pasted = await promptLine("API key: ");
+    if (pasted) {
+      signedIn = await loginWithProvidedToken(pasted);
+      if (!signedIn) {
+        warn("Continuing install — sign in later with `hivemind login` or `DEEPLAKE_API_TOKEN=<key> hivemind install`.");
+      }
+    } else {
+      log("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+    }
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,10 +39,10 @@ Usage:
   hivemind install   [--only <platforms>] [--skip-auth] [--token <value>]
       Auto-detect assistants on this machine and install hivemind into each.
       --only takes a comma-separated list: ${allPlatformIds().join(",")}
-      --token, or env DEEPLAKE_API_TOKEN / HIVEMIND_TOKEN, signs in
-      non-interactively (useful for CI / scripted installs). Without it,
-      a TTY install shows a consent prompt; a headless install skips
-      auth and prints a hint for 'hivemind login'.
+      --token, or env HIVEMIND_TOKEN, signs in non-interactively (useful
+      for CI / scripted installs). Without it, a TTY install shows a
+      consent prompt; a headless install skips auth and prints a hint
+      for 'hivemind login'.
 
   hivemind uninstall [--only <platforms>]
       Auto-detect installed assistants and remove hivemind from each.
@@ -139,6 +139,10 @@ function parseToken(args: string[]): string | undefined {
   return raw && raw.length > 0 ? raw : undefined;
 }
 
+function hasEnvToken(): boolean {
+  return Boolean(process.env.HIVEMIND_TOKEN);
+}
+
 // Decide how to sign the user in before platform install runs. Three paths,
 // in priority order:
 //   1. A token is provided (flag or env). Validate via /me and save creds —
@@ -153,12 +157,15 @@ function parseToken(args: string[]): string | undefined {
 // behind the consent rollout: install ≠ auth.
 async function runAuthGate(args: string[]): Promise<void> {
   const flagToken = parseToken(args);
-  const hasEnvToken = Boolean(process.env.DEEPLAKE_API_TOKEN ?? process.env.HIVEMIND_TOKEN);
   const isTTY = Boolean(process.stdin.isTTY);
 
-  if (flagToken || hasEnvToken) {
-    await loginWithProvidedToken(flagToken);
-    return;
+  // If a token is supplied via flag or env, try it first — but on failure
+  // fall through to the next path (consent prompt in TTY, headless hint
+  // otherwise) so a typoed / revoked token doesn't dead-end the install
+  // with no recovery. Codex review on PR #190 surfaced this.
+  if (flagToken || hasEnvToken()) {
+    const ok = await loginWithProvidedToken(flagToken);
+    if (ok) return;
   }
 
   if (!isTTY) {
@@ -166,7 +173,7 @@ async function runAuthGate(args: string[]): Promise<void> {
     log("No TTY detected — continuing without sign-in.");
     log("To sign in:");
     log("  1) Visit https://app.deeplake.ai/api-keys to create an API key");
-    log("  2) Rerun: DEEPLAKE_API_TOKEN=<key> hivemind install");
+    log("  2) Rerun: HIVEMIND_TOKEN=<key> hivemind install");
     log("Or run `hivemind login` after install.");
     return;
   }
@@ -204,7 +211,7 @@ async function runAuthGate(args: string[]): Promise<void> {
     if (pasted) {
       signedIn = await loginWithProvidedToken(pasted);
       if (!signedIn) {
-        warn("Continuing install — sign in later with `hivemind login` or `DEEPLAKE_API_TOKEN=<key> hivemind install`.");
+        warn("Continuing install — sign in later with `hivemind login` or `HIVEMIND_TOKEN=<key> hivemind install`.");
       }
     } else {
       log("Skipping sign-in. You can sign in anytime with `hivemind login`.");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -201,20 +201,35 @@ async function runAuthGate(args: string[]): Promise<void> {
   // finish, offer the API-key paste path. This catches both "I don't want
   // to do the browser dance" and "I started but it timed out / I closed
   // the tab" — both used to dead-end the install with no auth.
+  //
+  // The paste prompt loops up to MAX_PASTE_ATTEMPTS times so a single
+  // typo / stale key doesn't kick the user back out of the install. On
+  // empty input we skip; on success we exit immediately.
   if (!signedIn) {
     log("");
     log("Alternatively, sign in at https://app.deeplake.ai/api-keys, create");
     log("an API key, and paste it here. Press Enter to skip and continue");
     log("installing without sign-in (you can run `hivemind login` later).");
     log("");
-    const pasted = await promptLine("API key: ");
-    if (pasted) {
+
+    const MAX_PASTE_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_PASTE_ATTEMPTS; attempt++) {
+      const pasted = await promptLine("API key: ");
+      if (!pasted) break;
       signedIn = await loginWithProvidedToken(pasted);
-      if (!signedIn) {
-        warn("Continuing install — sign in later with `hivemind login` or `HIVEMIND_TOKEN=<key> hivemind install`.");
+      if (signedIn) break;
+      const remaining = MAX_PASTE_ATTEMPTS - attempt;
+      if (remaining > 0) {
+        log("");
+        log(`That key wasn't accepted (likely invalid or revoked). Try again (${remaining} attempt${remaining === 1 ? "" : "s"} left) or press Enter to skip.`);
+        log("");
       }
-    } else {
-      log("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+    }
+
+    if (!signedIn) {
+      log("");
+      log("Continuing install without sign-in. Run `hivemind login` later, or");
+      log("rerun with `HIVEMIND_TOKEN=<key> hivemind install`.");
     }
   }
 }

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, cpSync, symlinkSync
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
 
 export const HOME = homedir();
 
@@ -109,4 +110,21 @@ export function log(msg: string): void {
 
 export function warn(msg: string): void {
   process.stderr.write(msg + "\n");
+}
+
+// Interactive y/n prompt. Renders the hint based on the default so a bare
+// Enter is unambiguous. Writes the question to stderr (same channel as warn)
+// so log piping stays clean. Callers must check process.stdin.isTTY first —
+// readline on closed stdin would hang the process.
+export function confirm(message: string, defaultYes = true): Promise<boolean> {
+  const hint = defaultYes ? "[Y/n]" : "[y/N]";
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise(resolve => {
+    rl.question(`${message} ${hint} `, answer => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      if (a === "") resolve(defaultYes);
+      else resolve(a === "y" || a === "yes");
+    });
+  });
 }

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -128,3 +128,16 @@ export function confirm(message: string, defaultYes = true): Promise<boolean> {
     });
   });
 }
+
+// Free-text prompt. Returns the trimmed answer, or "" if the user just
+// pressed Enter. Same TTY caveat as confirm() — readline hangs on closed
+// stdin, so callers must gate on process.stdin.isTTY.
+export function promptLine(message: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise(resolve => {
+    rl.question(message, answer => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -215,20 +215,25 @@ export async function removeMember(
 
 // ── Full Login Flow ──────────────────────────────────────────────────────────
 
-export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
-  // Step 1: Device flow → get short-lived token
-  const { token: authToken } = await deviceFlowLogin(apiUrl);
-
-  // Step 2: Get user info
-  const user = await apiGet("/me", authToken, apiUrl) as { id: string; name: string; email?: string };
+// Hydrate Credentials from a token: fetch /me, pick an org, optionally mint a
+// long-lived API token, and persist. Shared by the device flow (which passes
+// a short-lived Auth0 token and needs skipTokenMint=false) and the env-var /
+// --token paths (which receive a long-lived token already and pass
+// skipTokenMint=true). Centralizing here means there is exactly one place
+// that writes ~/.deeplake/credentials.json from a token.
+export async function saveCredentialsFromToken(
+  token: string,
+  apiUrl: string,
+  opts: { skipTokenMint?: boolean } = {},
+): Promise<Credentials> {
+  const user = await apiGet("/me", token, apiUrl) as { id: string; name: string; email?: string };
   const userName = user.name || (user.email ? user.email.split("@")[0] : "unknown");
   process.stderr.write(`\nLogged in as: ${userName}\n`);
 
-  // Step 3: List orgs and select
-  const orgs = await listOrgs(authToken, apiUrl);
+  const orgs = await listOrgs(token, apiUrl);
+  if (orgs.length === 0) throw new Error("No organizations found for this account.");
   let orgId: string;
   let orgName: string;
-
   if (orgs.length === 1) {
     orgId = orgs[0].id;
     orgName = orgs[0].name;
@@ -236,23 +241,22 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
   } else {
     process.stderr.write("\nOrganizations:\n");
     orgs.forEach((org, i) => process.stderr.write(`  ${i + 1}. ${org.name}\n`));
-    // Default to first org — Claude can switch later
     orgId = orgs[0].id;
     orgName = orgs[0].name;
     process.stderr.write(`\nUsing: ${orgName}\n`);
   }
 
-  // Step 4: Exchange for long-lived API token
-  const tokenName = `deeplake-plugin-${new Date().toISOString().slice(0, 10)}`;
-  const tokenData = await apiPost("/users/me/tokens", {
-    name: tokenName,
-    duration: 365 * 24 * 3600,
-    organization_id: orgId,
-  }, authToken, apiUrl) as { token: { token: string } };
+  let apiToken = token;
+  if (!opts.skipTokenMint) {
+    const tokenName = `deeplake-plugin-${new Date().toISOString().slice(0, 10)}`;
+    const tokenData = await apiPost("/users/me/tokens", {
+      name: tokenName,
+      duration: 365 * 24 * 3600,
+      organization_id: orgId,
+    }, token, apiUrl) as { token: { token: string } };
+    apiToken = tokenData.token.token;
+  }
 
-  const apiToken = tokenData.token.token;
-
-  // Step 5: Save credentials
   const creds: Credentials = {
     token: apiToken,
     orgId,
@@ -263,6 +267,10 @@ export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
     savedAt: new Date().toISOString(),
   };
   saveCredentials(creds);
-
   return creds;
+}
+
+export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
+  const { token: authToken } = await deviceFlowLogin(apiUrl);
+  return saveCredentialsFromToken(authToken, apiUrl, { skipTokenMint: false });
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -232,9 +232,32 @@ export async function saveCredentialsFromToken(
 
   const orgs = await listOrgs(token, apiUrl);
   if (orgs.length === 0) throw new Error("No organizations found for this account.");
+
+  // Pick the org the token is bound to, in priority order:
+  //   1. HIVEMIND_ORG_ID env var override (explicit user choice).
+  //   2. `org_id` claim baked into the API-token JWT (skipTokenMint=true
+  //      path: the token was minted server-side bound to this org, so
+  //      using anything else would route hooks at the wrong org).
+  //   3. Fall back to orgs[0] for the device-flow path (will be re-bound
+  //      by the upcoming /users/me/tokens mint anyway).
+  // Without these layers a multi-org user pasting an API key would
+  // silently bind to the wrong org and every later capture would land
+  // there. Codex review surfaced this on PR #190.
+  const envOrgId = process.env.HIVEMIND_ORG_ID;
+  let preferredOrgId: string | undefined = envOrgId;
+  if (!preferredOrgId && opts.skipTokenMint) {
+    const claims = decodeJwtPayload(token);
+    const claimOrg = claims && typeof claims.org_id === "string" ? claims.org_id : undefined;
+    if (claimOrg) preferredOrgId = claimOrg;
+  }
   let orgId: string;
   let orgName: string;
-  if (orgs.length === 1) {
+  const matched = preferredOrgId ? orgs.find(o => o.id === preferredOrgId) : undefined;
+  if (matched) {
+    orgId = matched.id;
+    orgName = matched.name;
+    process.stderr.write(`Organization: ${orgName}\n`);
+  } else if (orgs.length === 1) {
     orgId = orgs[0].id;
     orgName = orgs[0].name;
     process.stderr.write(`Organization: ${orgName}\n`);
@@ -243,7 +266,11 @@ export async function saveCredentialsFromToken(
     orgs.forEach((org, i) => process.stderr.write(`  ${i + 1}. ${org.name}\n`));
     orgId = orgs[0].id;
     orgName = orgs[0].name;
-    process.stderr.write(`\nUsing: ${orgName}\n`);
+    if (opts.skipTokenMint) {
+      process.stderr.write(`\nUsing: ${orgName} (set HIVEMIND_ORG_ID to override)\n`);
+    } else {
+      process.stderr.write(`\nUsing: ${orgName}\n`);
+    }
   }
 
   let apiToken = token;

--- a/src/commands/session-prune.ts
+++ b/src/commands/session-prune.ts
@@ -14,7 +14,7 @@
 import { loadConfig, type Config } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
 import { sqlStr } from "../utils/sql.js";
-import { createInterface } from "node:readline";
+import { confirm } from "../cli/util.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,16 +53,6 @@ function parseArgs(argv: string[]): {
   }
 
   return { before, sessionId, all, yes };
-}
-
-function confirm(message: string): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise(resolve => {
-    rl.question(`${message} [y/N] `, answer => {
-      rl.close();
-      resolve(answer.trim().toLowerCase() === "y");
-    });
-  });
 }
 
 /**
@@ -218,7 +208,7 @@ export async function sessionPrune(argv: string[]): Promise<void> {
 
   // Confirm unless --yes
   if (!yes) {
-    const ok = await confirm("Proceed with deletion?");
+    const ok = await confirm("Proceed with deletion?", false);
     if (!ok) {
       console.log("Aborted.");
       return;

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -392,6 +392,91 @@ describe("login (full flow)", () => {
   });
 });
 
+describe("saveCredentialsFromToken — org-pinning", () => {
+  // Build a minimal API-token JWT (header.payload.signature, base64url) with
+  // an org_id claim so we can test that saveCredentialsFromToken honors it
+  // instead of silently falling back to orgs[0].
+  function makeToken(claims: Record<string, unknown>): string {
+    const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    return `${b64({ alg: "HS256" })}.${b64(claims)}.signature`;
+  }
+
+  afterEach(() => {
+    delete process.env.HIVEMIND_ORG_ID;
+  });
+
+  it("skipTokenMint=true honors the org_id claim from the token JWT (multi-org user)", async () => {
+    const token = makeToken({ org_id: "o2", user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([
+        { id: "o1", name: "acme" },
+        { id: "o2", name: "globex" },
+      ]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.orgId).toBe("o2");
+    expect(creds.orgName).toBe("globex");
+    // No /users/me/tokens mint call should have been made.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("HIVEMIND_ORG_ID env beats the JWT claim (explicit user override)", async () => {
+    process.env.HIVEMIND_ORG_ID = "o1";
+    const token = makeToken({ org_id: "o2", user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([
+        { id: "o1", name: "acme" },
+        { id: "o2", name: "globex" },
+      ]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.orgId).toBe("o1");
+    expect(creds.orgName).toBe("acme");
+  });
+
+  it("falls back to orgs[0] + warning when claim points at an org the user no longer belongs to", async () => {
+    const token = makeToken({ org_id: "o-stale", user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([
+        { id: "o1", name: "acme" },
+        { id: "o2", name: "globex" },
+      ]));
+    let stderrText = "";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((s: string | Uint8Array) => {
+      stderrText += typeof s === "string" ? s : Buffer.from(s).toString();
+      return true;
+    }) as typeof process.stderr.write);
+    try {
+      const { saveCredentialsFromToken } = await importAuth();
+      const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+      expect(creds.orgId).toBe("o1");
+      expect(stderrText).toContain("set HIVEMIND_ORG_ID to override");
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("skipTokenMint=false (device flow) does NOT decode the token — picks orgs[0] as before", async () => {
+    const token = makeToken({ org_id: "o2", user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([
+        { id: "o1", name: "acme" },
+        { id: "o2", name: "globex" },
+      ]))
+      .mockResolvedValueOnce(ok({ token: { token: "minted-tok" } }));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: false });
+    // Device flow mints the API token bound to orgs[0]; that ordering stays
+    // identical to the pre-change behaviour for backwards compat.
+    expect(creds.orgId).toBe("o1");
+    expect(creds.token).toBe("minted-tok");
+  });
+});
+
 describe("API helper error path", () => {
   it("apiGet throws with status code on non-2xx", async () => {
     fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));

--- a/tests/cli/cli-auth.test.ts
+++ b/tests/cli/cli-auth.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 
 const loginMock = vi.fn();
 const listOrgsMock = vi.fn();
+const saveCredentialsFromTokenMock = vi.fn();
 const stdoutWriteMock = vi.fn();
 const stderrWriteMock = vi.fn();
 
@@ -61,6 +62,7 @@ async function importFresh(): Promise<typeof import("../../src/cli/auth.js")> {
       ...actual,
       login: (...a: unknown[]) => loginMock(...a),
       listOrgs: (...a: unknown[]) => listOrgsMock(...a),
+      saveCredentialsFromToken: (...a: unknown[]) => saveCredentialsFromTokenMock(...a),
     };
   });
   return await import("../../src/cli/auth.js");
@@ -70,8 +72,11 @@ beforeEach(() => {
   TEMP_HOME = mkdtempSync(join(tmpdir(), "hivemind-cli-auth-"));
   loginMock.mockReset().mockResolvedValue(undefined);
   listOrgsMock.mockReset().mockResolvedValue([]);
+  saveCredentialsFromTokenMock.mockReset().mockResolvedValue(undefined);
   stdoutWriteMock.mockReset();
   stderrWriteMock.mockReset();
+  delete process.env.DEEPLAKE_API_TOKEN;
+  delete process.env.HIVEMIND_TOKEN;
   vi.spyOn(process.stdout, "write").mockImplementation(((...a: unknown[]) => { stdoutWriteMock(...a); return true; }) as any);
   vi.spyOn(process.stderr, "write").mockImplementation(((...a: unknown[]) => { stderrWriteMock(...a); return true; }) as any);
   delete process.env.HIVEMIND_API_URL;
@@ -224,5 +229,68 @@ describe("maybeShowOrgChoice", () => {
     await expect(maybeShowOrgChoice()).resolves.toBeUndefined();
     expect(stdoutWriteMock).not.toHaveBeenCalled();
     expect(stderrWriteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("loginWithProvidedToken", () => {
+  it("returns false (no-op) when no token in env or flag", async () => {
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken();
+    expect(ok).toBe(false);
+    expect(saveCredentialsFromTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("uses --token flag value, skipTokenMint=true, logs '--token flag'", async () => {
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken("flag-tok");
+    expect(ok).toBe(true);
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledTimes(1);
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("flag-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+    expect(stdoutWriteMock.mock.calls.map(c => c[0]).join("")).toContain("Signed in via --token flag.");
+  });
+
+  it("falls back to DEEPLAKE_API_TOKEN when no flag, logs 'DEEPLAKE_API_TOKEN'", async () => {
+    process.env.DEEPLAKE_API_TOKEN = "env-tok";
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken();
+    expect(ok).toBe(true);
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("env-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+    expect(stdoutWriteMock.mock.calls.map(c => c[0]).join("")).toContain("Signed in via DEEPLAKE_API_TOKEN.");
+  });
+
+  it("HIVEMIND_TOKEN fallback when neither flag nor DEEPLAKE_API_TOKEN", async () => {
+    process.env.HIVEMIND_TOKEN = "hm-tok";
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken();
+    expect(ok).toBe(true);
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("hm-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+  });
+
+  it("flag value beats env value (priority)", async () => {
+    process.env.DEEPLAKE_API_TOKEN = "env-tok";
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    await loginWithProvidedToken("flag-tok");
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("flag-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+  });
+
+  it("HIVEMIND_API_URL takes precedence over default", async () => {
+    process.env.HIVEMIND_API_URL = "https://hm.example";
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    await loginWithProvidedToken("tok");
+    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("tok", "https://hm.example", { skipTokenMint: true });
+  });
+
+  it("returns false + warns when saveCredentialsFromToken rejects", async () => {
+    saveCredentialsFromTokenMock.mockRejectedValue(new Error("API 401: invalid"));
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken("bad-tok");
+    expect(ok).toBe(false);
+    const stderrText = stderrWriteMock.mock.calls.map(c => c[0]).join("");
+    expect(stderrText).toContain("Token authentication failed: API 401: invalid. Continuing install.");
   });
 });

--- a/tests/cli/cli-auth.test.ts
+++ b/tests/cli/cli-auth.test.ts
@@ -128,9 +128,8 @@ describe("ensureLoggedIn", () => {
     expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai");
   });
 
-  it("HIVEMIND_API_URL takes precedence over DEEPLAKE_API_URL and the default", async () => {
+  it("HIVEMIND_API_URL is used when set, otherwise default", async () => {
     process.env.HIVEMIND_API_URL = "https://hm.example";
-    process.env.DEEPLAKE_API_URL = "https://dl.example";
     loginMock.mockImplementation(async () => {
       writeCreds({ token: "t", orgId: "o", savedAt: "" });
     });
@@ -139,14 +138,14 @@ describe("ensureLoggedIn", () => {
     expect(loginMock).toHaveBeenCalledWith("https://hm.example");
   });
 
-  it("DEEPLAKE_API_URL is used when only it is set", async () => {
+  it("DEEPLAKE_API_URL env is NOT honored (legacy name removed)", async () => {
     process.env.DEEPLAKE_API_URL = "https://dl.example";
     loginMock.mockImplementation(async () => {
       writeCreds({ token: "t", orgId: "o", savedAt: "" });
     });
     const { ensureLoggedIn } = await importFresh();
     await ensureLoggedIn();
-    expect(loginMock).toHaveBeenCalledWith("https://dl.example");
+    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai");
   });
 
   it("returns false (and writes to stderr) when login() rejects", async () => {
@@ -250,31 +249,31 @@ describe("loginWithProvidedToken", () => {
     expect(stdoutWriteMock.mock.calls.map(c => c[0]).join("")).toContain("Signed in via --token flag.");
   });
 
-  it("falls back to DEEPLAKE_API_TOKEN when no flag, logs 'DEEPLAKE_API_TOKEN'", async () => {
-    process.env.DEEPLAKE_API_TOKEN = "env-tok";
+  it("falls back to HIVEMIND_TOKEN when no flag, logs 'HIVEMIND_TOKEN'", async () => {
+    process.env.HIVEMIND_TOKEN = "env-tok";
     saveCredentialsFromTokenMock.mockResolvedValue(undefined);
     const { loginWithProvidedToken } = await importFresh();
     const ok = await loginWithProvidedToken();
     expect(ok).toBe(true);
     expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("env-tok", "https://api.deeplake.ai", { skipTokenMint: true });
-    expect(stdoutWriteMock.mock.calls.map(c => c[0]).join("")).toContain("Signed in via DEEPLAKE_API_TOKEN.");
-  });
-
-  it("HIVEMIND_TOKEN fallback when neither flag nor DEEPLAKE_API_TOKEN", async () => {
-    process.env.HIVEMIND_TOKEN = "hm-tok";
-    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
-    const { loginWithProvidedToken } = await importFresh();
-    const ok = await loginWithProvidedToken();
-    expect(ok).toBe(true);
-    expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("hm-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+    expect(stdoutWriteMock.mock.calls.map(c => c[0]).join("")).toContain("Signed in via HIVEMIND_TOKEN.");
   });
 
   it("flag value beats env value (priority)", async () => {
-    process.env.DEEPLAKE_API_TOKEN = "env-tok";
+    process.env.HIVEMIND_TOKEN = "env-tok";
     saveCredentialsFromTokenMock.mockResolvedValue(undefined);
     const { loginWithProvidedToken } = await importFresh();
     await loginWithProvidedToken("flag-tok");
     expect(saveCredentialsFromTokenMock).toHaveBeenCalledWith("flag-tok", "https://api.deeplake.ai", { skipTokenMint: true });
+  });
+
+  it("DEEPLAKE_API_TOKEN env is NOT recognized (legacy name removed)", async () => {
+    process.env.DEEPLAKE_API_TOKEN = "should-be-ignored";
+    saveCredentialsFromTokenMock.mockResolvedValue(undefined);
+    const { loginWithProvidedToken } = await importFresh();
+    const ok = await loginWithProvidedToken();
+    expect(ok).toBe(false);
+    expect(saveCredentialsFromTokenMock).not.toHaveBeenCalled();
   });
 
   it("HIVEMIND_API_URL takes precedence over default", async () => {

--- a/tests/cli/cli-auth.test.ts
+++ b/tests/cli/cli-auth.test.ts
@@ -290,6 +290,6 @@ describe("loginWithProvidedToken", () => {
     const ok = await loginWithProvidedToken("bad-tok");
     expect(ok).toBe(false);
     const stderrText = stderrWriteMock.mock.calls.map(c => c[0]).join("");
-    expect(stderrText).toContain("Token authentication failed: API 401: invalid. Continuing install.");
+    expect(stderrText).toContain("Token authentication failed: API 401: invalid");
   });
 });

--- a/tests/cli/cli-index.test.ts
+++ b/tests/cli/cli-index.test.ts
@@ -61,20 +61,24 @@ vi.mock("../../src/cli/install-pi.js", () => ({
   upsertHivemindBlock: () => "",
   stripHivemindBlock: (s: string) => s,
 }));
+const loginWithProvidedTokenMock = vi.fn();
 vi.mock("../../src/cli/auth.js", () => ({
   ensureLoggedIn: (...a: unknown[]) => ensureLoggedInMock(...a),
   isLoggedIn: (...a: unknown[]) => isLoggedInMock(...a),
+  loginWithProvidedToken: (...a: unknown[]) => loginWithProvidedTokenMock(...a),
   maybeShowOrgChoice: (...a: unknown[]) => maybeShowOrgChoiceMock(...a),
 }));
 vi.mock("../../src/commands/auth-login.js", () => ({
   runAuthCommand: (...a: unknown[]) => runAuthCommandMock(...a),
 }));
+const confirmMock = vi.fn();
 vi.mock("../../src/cli/util.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/cli/util.js")>();
   return {
     ...actual,
     detectPlatforms: (...a: unknown[]) => detectPlatformsMock(...a),
     allPlatformIds: (...a: unknown[]) => allPlatformIdsMock(...a),
+    confirm: (...a: unknown[]) => confirmMock(...a),
   };
 });
 vi.mock("../../src/cli/version.js", () => ({
@@ -102,7 +106,11 @@ beforeEach(() => {
   for (const fn of Object.values(installs)) fn.mockReset();
   ensureLoggedInMock.mockReset().mockResolvedValue(true);
   isLoggedInMock.mockReset().mockReturnValue(true);
+  loginWithProvidedTokenMock.mockReset().mockResolvedValue(false);
+  confirmMock.mockReset().mockResolvedValue(true);
   maybeShowOrgChoiceMock.mockReset().mockResolvedValue(undefined);
+  delete process.env.DEEPLAKE_API_TOKEN;
+  delete process.env.HIVEMIND_TOKEN;
   runAuthCommandMock.mockReset().mockResolvedValue(undefined);
   detectPlatformsMock.mockReset().mockReturnValue([]);
   allPlatformIdsMock.mockReset().mockReturnValue(["claude", "codex", "claw", "cursor", "hermes", "pi"]);
@@ -189,20 +197,22 @@ describe("hivemind install", () => {
     }
   });
 
-  it("with detected platforms: ensures login, runs each installer once, then maybeShowOrgChoice", async () => {
+  it("with detected platforms: ensures login (TTY consent → yes), runs each installer once, then maybeShowOrgChoice", async () => {
     detectPlatformsMock.mockReturnValue([
       { id: "claude", markerDir: "/x/.claude" },
       { id: "codex",  markerDir: "/x/.codex" },
     ]);
     isLoggedInMock.mockReturnValue(false);
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    confirmMock.mockResolvedValue(true);
     ensureLoggedInMock.mockResolvedValue(true);
 
     await runCli(["install"]);
 
+    expect(confirmMock).toHaveBeenCalledTimes(1);
     expect(ensureLoggedInMock).toHaveBeenCalledTimes(1);
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
     expect(installs.installCodex).toHaveBeenCalledTimes(1);
-    // No other platforms triggered.
     expect(installs.installCursor).not.toHaveBeenCalled();
     expect(installs.installHermes).not.toHaveBeenCalled();
     expect(installs.installPi).not.toHaveBeenCalled();
@@ -219,15 +229,18 @@ describe("hivemind install", () => {
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
   });
 
-  it("exits non-zero when login does not complete", async () => {
+  it("continues install (exit 0) when login does not complete — auth is no longer a blocker", async () => {
     detectPlatformsMock.mockReturnValue([{ id: "claude", markerDir: "/x/.claude" }]);
     isLoggedInMock.mockReturnValue(false);
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    confirmMock.mockResolvedValue(true);
     ensureLoggedInMock.mockResolvedValue(false);
 
     await runCli(["install"]);
 
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(installs.installClaude).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(stderrText()).toContain("Login did not complete");
   });
 
   it("--only <list> overrides detection and validates platform names", async () => {

--- a/tests/cli/cli-index.test.ts
+++ b/tests/cli/cli-index.test.ts
@@ -72,6 +72,7 @@ vi.mock("../../src/commands/auth-login.js", () => ({
   runAuthCommand: (...a: unknown[]) => runAuthCommandMock(...a),
 }));
 const confirmMock = vi.fn();
+const promptLineMock = vi.fn();
 vi.mock("../../src/cli/util.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/cli/util.js")>();
   return {
@@ -79,6 +80,7 @@ vi.mock("../../src/cli/util.js", async (importOriginal) => {
     detectPlatforms: (...a: unknown[]) => detectPlatformsMock(...a),
     allPlatformIds: (...a: unknown[]) => allPlatformIdsMock(...a),
     confirm: (...a: unknown[]) => confirmMock(...a),
+    promptLine: (...a: unknown[]) => promptLineMock(...a),
   };
 });
 vi.mock("../../src/cli/version.js", () => ({
@@ -101,6 +103,7 @@ vi.mock("../../src/cli/embeddings.js", () => ({
 }));
 
 const originalArgv = process.argv;
+const originalIsTTY = (process.stdin as { isTTY?: boolean }).isTTY;
 
 beforeEach(() => {
   for (const fn of Object.values(installs)) fn.mockReset();
@@ -108,6 +111,9 @@ beforeEach(() => {
   isLoggedInMock.mockReset().mockReturnValue(true);
   loginWithProvidedTokenMock.mockReset().mockResolvedValue(false);
   confirmMock.mockReset().mockResolvedValue(true);
+  // Paste fallback defaults to empty (skip) so existing tests that don't
+  // care about the fallback don't accidentally try to validate a token.
+  promptLineMock.mockReset().mockResolvedValue("");
   maybeShowOrgChoiceMock.mockReset().mockResolvedValue(undefined);
   delete process.env.DEEPLAKE_API_TOKEN;
   delete process.env.HIVEMIND_TOKEN;
@@ -137,6 +143,10 @@ beforeEach(() => {
 
 afterEach(() => {
   process.argv = originalArgv;
+  // Restore process.stdin.isTTY in case a test mutated it — otherwise the
+  // mutation leaks into later tests in the same worker and makes them
+  // order-dependent.
+  Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
   vi.restoreAllMocks();
   vi.resetModules();
 });

--- a/tests/cli/cli-index.test.ts
+++ b/tests/cli/cli-index.test.ts
@@ -115,7 +115,6 @@ beforeEach(() => {
   // care about the fallback don't accidentally try to validate a token.
   promptLineMock.mockReset().mockResolvedValue("");
   maybeShowOrgChoiceMock.mockReset().mockResolvedValue(undefined);
-  delete process.env.DEEPLAKE_API_TOKEN;
   delete process.env.HIVEMIND_TOKEN;
   runAuthCommandMock.mockReset().mockResolvedValue(undefined);
   detectPlatformsMock.mockReset().mockReturnValue([]);

--- a/tests/cli/cli-util.test.ts
+++ b/tests/cli/cli-util.test.ts
@@ -19,6 +19,7 @@ import {
   log,
   warn,
   confirm,
+  promptLine,
 } from "../../src/cli/util.js";
 import { Readable } from "node:stream";
 
@@ -303,5 +304,39 @@ describe("confirm", () => {
   it("any other input resolves false (conservative default)", async () => {
     stubStdin("maybe\n");
     expect(await confirm("?", true)).toBe(false);
+  });
+});
+
+describe("promptLine", () => {
+  let stdinBackup: NodeJS.ReadStream;
+
+  beforeEach(() => {
+    stdinBackup = process.stdin;
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdin", { value: stdinBackup, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  function stubStdin(input: string): void {
+    const stream = Readable.from([input]) as unknown as NodeJS.ReadStream;
+    Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+  }
+
+  it("returns the trimmed input line", async () => {
+    stubStdin("  hello-token  \n");
+    expect(await promptLine("API key: ")).toBe("hello-token");
+  });
+
+  it("returns empty string on a bare Enter (signal to skip)", async () => {
+    stubStdin("\n");
+    expect(await promptLine("API key: ")).toBe("");
+  });
+
+  it("preserves internal whitespace in pasted tokens", async () => {
+    stubStdin("tok with spaces\n");
+    expect(await promptLine("API key: ")).toBe("tok with spaces");
   });
 });

--- a/tests/cli/cli-util.test.ts
+++ b/tests/cli/cli-util.test.ts
@@ -18,7 +18,9 @@ import {
   allPlatformIds,
   log,
   warn,
+  confirm,
 } from "../../src/cli/util.js";
+import { Readable } from "node:stream";
 
 /**
  * Tests for src/cli/util.ts — the shared filesystem + platform-detection
@@ -254,5 +256,52 @@ describe("log / warn", () => {
     expect(stderrSpy).toHaveBeenCalledTimes(1);
     expect(stderrSpy).toHaveBeenCalledWith("oops\n");
     expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirm", () => {
+  let stdinBackup: NodeJS.ReadStream;
+
+  beforeEach(() => {
+    stdinBackup = process.stdin;
+    // Silence the rendered question to keep test output clean.
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdin", { value: stdinBackup, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  function stubStdin(input: string): void {
+    const stream = Readable.from([input]) as unknown as NodeJS.ReadStream;
+    Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+  }
+
+  it("returns defaultYes=true on bare Enter (empty line)", async () => {
+    stubStdin("\n");
+    expect(await confirm("?", true)).toBe(true);
+  });
+
+  it("returns defaultYes=false on bare Enter when default is no", async () => {
+    stubStdin("\n");
+    expect(await confirm("?", false)).toBe(false);
+  });
+
+  it("'y' / 'yes' both resolve true (case-insensitive)", async () => {
+    stubStdin("y\n");
+    expect(await confirm("?", false)).toBe(true);
+    stubStdin("YES\n");
+    expect(await confirm("?", false)).toBe(true);
+  });
+
+  it("'n' resolves false even when defaultYes is true", async () => {
+    stubStdin("n\n");
+    expect(await confirm("?", true)).toBe(false);
+  });
+
+  it("any other input resolves false (conservative default)", async () => {
+    stubStdin("maybe\n");
+    expect(await confirm("?", true)).toBe(false);
   });
 });

--- a/tests/cli/install-consent-bundle.test.ts
+++ b/tests/cli/install-consent-bundle.test.ts
@@ -51,7 +51,9 @@ function spawnInstall(env: Record<string, string>): Promise<{ code: number | nul
       child.kill("SIGKILL");
       reject(new Error(`bundle/cli.js install hung past 5s (likely readline on closed stdin). stdout=${stdout} stderr=${stderr}`));
     }, 5000);
-    child.on("exit", (code) => {
+    // Use "close" not "exit": close fires after stdio streams flush, so
+    // the buffered stdout/stderr we assert on is guaranteed complete.
+    child.on("close", (code) => {
       clearTimeout(timer);
       resolveSpawn({ code, stdout, stderr });
     });
@@ -98,7 +100,7 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     const { code, stdout, stderr } = await spawnInstall({});
     expect(code).toBe(0);
     const combined = stdout + stderr;
-    expect(combined).toContain("Hivemind install completed without sign-in");
+    expect(combined).toContain("No TTY detected");
     expect(combined).toContain("--token <value>");
     expect(combined).toContain("DEEPLAKE_API_TOKEN");
     expect(combined).toContain("hivemind login");
@@ -118,6 +120,6 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     expect(combined).toContain("Token authentication failed");
     expect(combined).toContain("Continuing install");
     // Headless hint must NOT print when a token was attempted (rule 8).
-    expect(combined).not.toContain("Hivemind install completed without sign-in");
+    expect(combined).not.toContain("No TTY detected");
   });
 });

--- a/tests/cli/install-consent-bundle.test.ts
+++ b/tests/cli/install-consent-bundle.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Bundle smoke test for the install consent gate.
+ *
+ * Per CLAUDE.md testing-rule 4, we MUST exercise the shipped bundle/cli.js
+ * with the real subprocess + closed-stdin shape that CI/scripted installs
+ * use. Source-level unit tests can't catch a readline hang because they
+ * stub out node:readline; only spawning the real bundle proves the non-TTY
+ * branch never reaches readline.
+ *
+ * Two cases:
+ *   1. Closed stdin, no token configured → exits within 5s, prints the
+ *      headless hint, exit code 0.
+ *   2. Closed stdin, DEEPLAKE_API_TOKEN=invalid against a mock /me that
+ *      returns 401 → exits within 5s, prints the "Token authentication
+ *      failed" warning, exit code 0 (install continues).
+ *
+ * HOME is redirected to a tmp dir with one fake .codex marker so the
+ * platform-install loop has a target to walk but cannot actually write
+ * any real files; this lets the auth gate fire before the install bails.
+ */
+
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const cliPath = join(repoRoot, "bundle", "cli.js");
+
+// Mock /me server: returns 401 with a small JSON body. listOrgs is never
+// reached because /me throws first; the auth.ts catch turns it into the
+// "Token authentication failed" warning.
+let mockServer: Server;
+let mockUrl = "";
+let tempHome = "";
+
+function spawnInstall(env: Record<string, string>): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolveSpawn, reject) => {
+    const child = spawn(process.execPath, [cliPath, "install", "--only", "codex"], {
+      env: { ...process.env, ...env, HOME: tempHome },
+      stdio: ["ignore", "pipe", "pipe"], // closed stdin → non-TTY in child
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => { stdout += d.toString(); });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`bundle/cli.js install hung past 5s (likely readline on closed stdin). stdout=${stdout} stderr=${stderr}`));
+    }, 5000);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolveSpawn({ code, stdout, stderr });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+beforeAll(async () => {
+  // Stand up a mock /me endpoint that 401s.
+  mockServer = createServer((req, res) => {
+    if (req.url === "/me") {
+      res.statusCode = 401;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: "invalid_token" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((r) => mockServer.listen(0, "127.0.0.1", r));
+  const addr = mockServer.address();
+  if (!addr || typeof addr === "string") throw new Error("mock server failed to bind");
+  mockUrl = `http://127.0.0.1:${addr.port}`;
+
+  // Fresh HOME with a fake .codex marker so platform detection has a target.
+  tempHome = mkdtempSync(join(tmpdir(), "hivemind-bundle-smoke-"));
+  mkdirSync(join(tempHome, ".codex"), { recursive: true });
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => mockServer.close(() => r()));
+  if (tempHome) rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("bundle/cli.js install — non-TTY smoke", () => {
+  it("bundle/cli.js exists (sanity check; build must run before test)", () => {
+    expect(existsSync(cliPath), `missing: ${cliPath} — run \`npm run build\` first`).toBe(true);
+  });
+
+  it("closed stdin + no token → exits within 5s (no readline hang), prints headless hint, exit 0", async () => {
+    const { code, stdout, stderr } = await spawnInstall({});
+    expect(code).toBe(0);
+    const combined = stdout + stderr;
+    expect(combined).toContain("Hivemind install completed without sign-in");
+    expect(combined).toContain("--token <value>");
+    expect(combined).toContain("DEEPLAKE_API_TOKEN");
+    expect(combined).toContain("hivemind login");
+    // Negative-pattern assertion (rule 8): the consent banner must NOT
+    // appear in non-TTY mode — that would mean the gate routed to the
+    // TTY branch and would have hung on readline.
+    expect(combined).not.toContain("🐝 One more step to unlock Hivemind");
+  });
+
+  it("closed stdin + DEEPLAKE_API_TOKEN=invalid + /me 401 → warns, install continues exit 0", async () => {
+    const { code, stdout, stderr } = await spawnInstall({
+      DEEPLAKE_API_TOKEN: "invalid-token",
+      HIVEMIND_API_URL: mockUrl,
+    });
+    expect(code).toBe(0);
+    const combined = stdout + stderr;
+    expect(combined).toContain("Token authentication failed");
+    expect(combined).toContain("Continuing install");
+    // Headless hint must NOT print when a token was attempted (rule 8).
+    expect(combined).not.toContain("Hivemind install completed without sign-in");
+  });
+});

--- a/tests/cli/install-consent-bundle.test.ts
+++ b/tests/cli/install-consent-bundle.test.ts
@@ -101,8 +101,8 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     expect(code).toBe(0);
     const combined = stdout + stderr;
     expect(combined).toContain("No TTY detected");
-    expect(combined).toContain("--token <value>");
-    expect(combined).toContain("DEEPLAKE_API_TOKEN");
+    expect(combined).toContain("https://app.deeplake.ai/api-keys");
+    expect(combined).toContain("DEEPLAKE_API_TOKEN=<key>");
     expect(combined).toContain("hivemind login");
     // Negative-pattern assertion (rule 8): the consent banner must NOT
     // appear in non-TTY mode — that would mean the gate routed to the

--- a/tests/cli/install-consent-bundle.test.ts
+++ b/tests/cli/install-consent-bundle.test.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
  * Two cases:
  *   1. Closed stdin, no token configured → exits within 5s, prints the
  *      headless hint, exit code 0.
- *   2. Closed stdin, DEEPLAKE_API_TOKEN=invalid against a mock /me that
+ *   2. Closed stdin, HIVEMIND_TOKEN=invalid against a mock /me that
  *      returns 401 → exits within 5s, prints the "Token authentication
  *      failed" warning, exit code 0 (install continues).
  *
@@ -102,7 +102,7 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     const combined = stdout + stderr;
     expect(combined).toContain("No TTY detected");
     expect(combined).toContain("https://app.deeplake.ai/api-keys");
-    expect(combined).toContain("DEEPLAKE_API_TOKEN=<key>");
+    expect(combined).toContain("HIVEMIND_TOKEN=<key>");
     expect(combined).toContain("hivemind login");
     // Negative-pattern assertion (rule 8): the consent banner must NOT
     // appear in non-TTY mode — that would mean the gate routed to the
@@ -110,16 +110,19 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     expect(combined).not.toContain("🐝 One more step to unlock Hivemind");
   });
 
-  it("closed stdin + DEEPLAKE_API_TOKEN=invalid + /me 401 → warns, install continues exit 0", async () => {
+  it("closed stdin + HIVEMIND_TOKEN=invalid + /me 401 → warns, falls through to headless hint, exit 0", async () => {
     const { code, stdout, stderr } = await spawnInstall({
-      DEEPLAKE_API_TOKEN: "invalid-token",
+      HIVEMIND_TOKEN: "invalid-token",
       HIVEMIND_API_URL: mockUrl,
     });
     expect(code).toBe(0);
     const combined = stdout + stderr;
     expect(combined).toContain("Token authentication failed");
     expect(combined).toContain("Continuing install");
-    // Headless hint must NOT print when a token was attempted (rule 8).
-    expect(combined).not.toContain("No TTY detected");
+    // Codex review fix: after a rejected token, the headless hint MUST
+    // also fire so the user has a documented recovery path. Previously
+    // runAuthGate returned early and the install finished silently.
+    expect(combined).toContain("No TTY detected");
+    expect(combined).toContain("HIVEMIND_TOKEN=<key>");
   });
 });

--- a/tests/cli/install-consent-bundle.test.ts
+++ b/tests/cli/install-consent-bundle.test.ts
@@ -118,7 +118,6 @@ describe("bundle/cli.js install — non-TTY smoke", () => {
     expect(code).toBe(0);
     const combined = stdout + stderr;
     expect(combined).toContain("Token authentication failed");
-    expect(combined).toContain("Continuing install");
     // Codex review fix: after a rejected token, the headless hint MUST
     // also fire so the user has a documented recovery path. Previously
     // runAuthGate returned early and the install finished silently.

--- a/tests/cli/install-consent.test.ts
+++ b/tests/cli/install-consent.test.ts
@@ -220,9 +220,10 @@ describe("install consent gate — non-TTY paths", () => {
     expect(ensureLoggedInMock).not.toHaveBeenCalled();
     expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
-    expect(stdoutText()).toContain("Hivemind install completed without sign-in");
+    expect(stdoutText()).toContain("No TTY detected");
     expect(stdoutText()).toContain("--token <value>");
     expect(stdoutText()).toContain("DEEPLAKE_API_TOKEN");
+    expect(stdoutText()).toContain("HIVEMIND_TOKEN");
     expect(stdoutText()).toContain("hivemind login");
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/tests/cli/install-consent.test.ts
+++ b/tests/cli/install-consent.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the consent + non-TTY auth-gate in src/cli/index.ts.
+ *
+ * Drives `hivemind install` end-to-end through the CLI dispatcher (rule 4:
+ * load through the actual loader) and asserts on count + shape (rule 6) of
+ * `ensureLoggedIn` / `loginWithProvidedToken` / `confirm` per path.
+ *
+ * The seven cases map 1-to-1 to the rows of the decision matrix in the plan:
+ *   1. TTY + decline                     → no auth, install continues, hint logged
+ *   2. TTY + accept                      → ensureLoggedIn exactly once, install continues
+ *   3. Non-TTY + no token                → no readline (would hang), no auth, hint logged
+ *   4. Non-TTY + env token + /me 200     → loginWithProvidedToken once, no device flow
+ *   5. Non-TTY + --token flag + /me 200  → same as above, log says "--token flag"
+ *   6. Non-TTY + invalid token + /me 401 → warning, install continues, exit 0
+ *   7. TTY + --token flag                → token honored, consent prompt NOT shown
+ *
+ * Plus a negative-pattern assertion (rule 8): "Signed in via DEEPLAKE_API_TOKEN"
+ * must NOT appear in the --token-flag log line.
+ */
+
+const installs = {
+  installClaude: vi.fn(), uninstallClaude: vi.fn(),
+  installCodex: vi.fn(),  uninstallCodex: vi.fn(),
+  installOpenclaw: vi.fn(), uninstallOpenclaw: vi.fn(),
+  installCursor: vi.fn(), uninstallCursor: vi.fn(),
+  installHermes: vi.fn(), uninstallHermes: vi.fn(),
+  installPi: vi.fn(),     uninstallPi: vi.fn(),
+};
+const ensureLoggedInMock = vi.fn();
+const isLoggedInMock = vi.fn();
+const loginWithProvidedTokenMock = vi.fn();
+const maybeShowOrgChoiceMock = vi.fn();
+const runAuthCommandMock = vi.fn();
+const detectPlatformsMock = vi.fn();
+const allPlatformIdsMock = vi.fn();
+const getVersionMock = vi.fn();
+const runUpdateMock = vi.fn();
+const confirmMock = vi.fn();
+const stdoutMock = vi.fn();
+const stderrMock = vi.fn();
+const exitSpy = vi.fn();
+
+vi.mock("../../src/cli/install-claude.js", () => ({
+  installClaude: (...a: unknown[]) => installs.installClaude(...a),
+  uninstallClaude: (...a: unknown[]) => installs.uninstallClaude(...a),
+}));
+vi.mock("../../src/cli/install-codex.js", () => ({
+  installCodex: (...a: unknown[]) => installs.installCodex(...a),
+  uninstallCodex: (...a: unknown[]) => installs.uninstallCodex(...a),
+}));
+vi.mock("../../src/cli/install-openclaw.js", () => ({
+  installOpenclaw: (...a: unknown[]) => installs.installOpenclaw(...a),
+  uninstallOpenclaw: (...a: unknown[]) => installs.uninstallOpenclaw(...a),
+}));
+vi.mock("../../src/cli/install-cursor.js", () => ({
+  installCursor: (...a: unknown[]) => installs.installCursor(...a),
+  uninstallCursor: (...a: unknown[]) => installs.uninstallCursor(...a),
+}));
+vi.mock("../../src/cli/install-hermes.js", () => ({
+  installHermes: (...a: unknown[]) => installs.installHermes(...a),
+  uninstallHermes: (...a: unknown[]) => installs.uninstallHermes(...a),
+}));
+vi.mock("../../src/cli/install-pi.js", () => ({
+  installPi: (...a: unknown[]) => installs.installPi(...a),
+  uninstallPi: (...a: unknown[]) => installs.uninstallPi(...a),
+  upsertHivemindBlock: () => "",
+  stripHivemindBlock: (s: string) => s,
+}));
+vi.mock("../../src/cli/auth.js", () => ({
+  ensureLoggedIn: (...a: unknown[]) => ensureLoggedInMock(...a),
+  isLoggedIn: (...a: unknown[]) => isLoggedInMock(...a),
+  loginWithProvidedToken: (...a: unknown[]) => loginWithProvidedTokenMock(...a),
+  maybeShowOrgChoice: (...a: unknown[]) => maybeShowOrgChoiceMock(...a),
+}));
+vi.mock("../../src/commands/auth-login.js", () => ({
+  runAuthCommand: (...a: unknown[]) => runAuthCommandMock(...a),
+}));
+vi.mock("../../src/cli/util.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/cli/util.js")>();
+  return {
+    ...actual,
+    detectPlatforms: (...a: unknown[]) => detectPlatformsMock(...a),
+    allPlatformIds: (...a: unknown[]) => allPlatformIdsMock(...a),
+    confirm: (...a: unknown[]) => confirmMock(...a),
+  };
+});
+vi.mock("../../src/cli/version.js", () => ({
+  getVersion: (...a: unknown[]) => getVersionMock(...a),
+}));
+vi.mock("../../src/cli/update.js", () => ({
+  runUpdate: (...a: unknown[]) => runUpdateMock(...a),
+}));
+vi.mock("../../src/cli/embeddings.js", () => ({
+  installEmbeddings: vi.fn(),
+  enableEmbeddings: vi.fn(),
+  disableEmbeddings: vi.fn(),
+  uninstallEmbeddings: vi.fn(),
+  statusEmbeddings: vi.fn(),
+}));
+vi.mock("../../src/commands/skillify.js", () => ({
+  runSkillifyCommand: vi.fn(),
+}));
+vi.mock("../../src/cli/skillify-spec.js", () => ({
+  renderCliHelpBlock: () => "",
+}));
+
+const originalArgv = process.argv;
+const originalIsTTY = (process.stdin as { isTTY?: boolean }).isTTY;
+
+function setTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, "isTTY", { value, configurable: true });
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(installs)) fn.mockReset();
+  ensureLoggedInMock.mockReset().mockResolvedValue(true);
+  isLoggedInMock.mockReset().mockReturnValue(false); // forces the gate to run
+  loginWithProvidedTokenMock.mockReset().mockResolvedValue(false);
+  maybeShowOrgChoiceMock.mockReset().mockResolvedValue(undefined);
+  runAuthCommandMock.mockReset().mockResolvedValue(undefined);
+  detectPlatformsMock.mockReset().mockReturnValue([{ id: "claude", markerDir: "/x/.claude" }]);
+  allPlatformIdsMock.mockReset().mockReturnValue(["claude", "codex", "claw", "cursor", "hermes", "pi"]);
+  getVersionMock.mockReset().mockReturnValue("1.2.3");
+  runUpdateMock.mockReset().mockResolvedValue(0);
+  confirmMock.mockReset().mockResolvedValue(true);
+  stdoutMock.mockReset();
+  stderrMock.mockReset();
+  exitSpy.mockReset();
+  delete process.env.DEEPLAKE_API_TOKEN;
+  delete process.env.HIVEMIND_TOKEN;
+  vi.spyOn(process.stdout, "write").mockImplementation(((...a: unknown[]) => { stdoutMock(...a); return true; }) as any);
+  vi.spyOn(process.stderr, "write").mockImplementation(((...a: unknown[]) => { stderrMock(...a); return true; }) as any);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitSpy(code);
+    throw Object.assign(new Error("__test_process_exit__"), { __exit: true });
+  }) as any);
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  setTTY(originalIsTTY);
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+async function runInstall(args: string[]): Promise<void> {
+  process.argv = ["node", "/path/to/hivemind-cli", "install", ...args];
+  const onUnhandled = (e: unknown) => {
+    if (e && typeof e === "object" && "__exit" in (e as Record<string, unknown>)) return;
+    throw e;
+  };
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    vi.resetModules();
+    await import("../../src/cli/index.js");
+    await new Promise(r => setImmediate(r));
+    await new Promise(r => setImmediate(r));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+}
+
+const stdoutText = () => stdoutMock.mock.calls.map(c => c[0]).join("");
+const stderrText = () => stderrMock.mock.calls.map(c => c[0]).join("");
+
+describe("install consent gate — TTY paths", () => {
+  it("TTY + decline → no auth attempted, install continues, hint logged", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(false);
+
+    await runInstall([]);
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(stdoutText()).toContain("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("TTY + accept → ensureLoggedIn exactly once, install continues", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(true);
+    ensureLoggedInMock.mockResolvedValue(true);
+
+    await runInstall([]);
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(ensureLoggedInMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(stdoutText()).toContain("🐝 One more step to unlock Hivemind");
+    expect(stdoutText()).toContain("Prefer your own cloud storage");
+    expect(stdoutText()).toContain("Already have a token? Pass --token <value> or set DEEPLAKE_API_TOKEN.");
+  });
+
+  it("TTY + --token <value> → consent prompt NOT shown, token honored", async () => {
+    setTTY(true);
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall(["--token", "tok-abc"]);
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("tok-abc");
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("install consent gate — non-TTY paths", () => {
+  it("non-TTY + no token → no confirm (would hang), no auth, hint logged, install continues", async () => {
+    setTTY(false);
+
+    await runInstall([]);
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(stdoutText()).toContain("Hivemind install completed without sign-in");
+    expect(stdoutText()).toContain("--token <value>");
+    expect(stdoutText()).toContain("DEEPLAKE_API_TOKEN");
+    expect(stdoutText()).toContain("hivemind login");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-TTY + DEEPLAKE_API_TOKEN → loginWithProvidedToken once, no device flow, no confirm", async () => {
+    setTTY(false);
+    process.env.DEEPLAKE_API_TOKEN = "env-token";
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall([]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith(undefined);
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-TTY + HIVEMIND_TOKEN (no DEEPLAKE_API_TOKEN) → loginWithProvidedToken once", async () => {
+    setTTY(false);
+    process.env.HIVEMIND_TOKEN = "hm-token";
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall([]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith(undefined);
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-TTY + --token flag → loginWithProvidedToken called with flag value (priority over env)", async () => {
+    setTTY(false);
+    process.env.DEEPLAKE_API_TOKEN = "env-token";
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall(["--token", "flag-token"]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("flag-token");
+  });
+
+  it("non-TTY + invalid token (loginWithProvidedToken returns false) → install continues exit 0", async () => {
+    setTTY(false);
+    process.env.DEEPLAKE_API_TOKEN = "bad-token";
+    loginWithProvidedTokenMock.mockResolvedValue(false);
+
+    await runInstall([]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-TTY + --token=<value> (= form) → flag value is parsed correctly", async () => {
+    setTTY(false);
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall(["--token=eq-form-token"]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("eq-form-token");
+  });
+});
+
+describe("install consent gate — short-circuit cases", () => {
+  it("--skip-auth bypasses the entire gate even when no creds and TTY=true", async () => {
+    setTTY(true);
+    process.env.DEEPLAKE_API_TOKEN = "env-token";
+
+    await runInstall(["--skip-auth"]);
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("already logged in → gate is skipped entirely (no confirm, no token check)", async () => {
+    setTTY(true);
+    isLoggedInMock.mockReturnValue(true);
+
+    await runInstall([]);
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/cli/install-consent.test.ts
+++ b/tests/cli/install-consent.test.ts
@@ -38,6 +38,7 @@ const allPlatformIdsMock = vi.fn();
 const getVersionMock = vi.fn();
 const runUpdateMock = vi.fn();
 const confirmMock = vi.fn();
+const promptLineMock = vi.fn();
 const stdoutMock = vi.fn();
 const stderrMock = vi.fn();
 const exitSpy = vi.fn();
@@ -84,6 +85,7 @@ vi.mock("../../src/cli/util.js", async (importOriginal) => {
     detectPlatforms: (...a: unknown[]) => detectPlatformsMock(...a),
     allPlatformIds: (...a: unknown[]) => allPlatformIdsMock(...a),
     confirm: (...a: unknown[]) => confirmMock(...a),
+    promptLine: (...a: unknown[]) => promptLineMock(...a),
   };
 });
 vi.mock("../../src/cli/version.js", () => ({
@@ -125,6 +127,8 @@ beforeEach(() => {
   getVersionMock.mockReset().mockReturnValue("1.2.3");
   runUpdateMock.mockReset().mockResolvedValue(0);
   confirmMock.mockReset().mockResolvedValue(true);
+  // Default: paste fallback returns empty (user presses Enter → skip).
+  promptLineMock.mockReset().mockResolvedValue("");
   stdoutMock.mockReset();
   stderrMock.mockReset();
   exitSpy.mockReset();
@@ -166,13 +170,15 @@ const stdoutText = () => stdoutMock.mock.calls.map(c => c[0]).join("");
 const stderrText = () => stderrMock.mock.calls.map(c => c[0]).join("");
 
 describe("install consent gate — TTY paths", () => {
-  it("TTY + decline → no auth attempted, install continues, hint logged", async () => {
+  it("TTY + decline + paste fallback empty → no auth, install continues, skip hint logged", async () => {
     setTTY(true);
     confirmMock.mockResolvedValue(false);
+    promptLineMock.mockResolvedValue(""); // user presses Enter at paste prompt
 
     await runInstall([]);
 
     expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(promptLineMock).toHaveBeenCalledTimes(1); // fallback offered
     expect(ensureLoggedInMock).not.toHaveBeenCalled();
     expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
@@ -180,7 +186,22 @@ describe("install consent gate — TTY paths", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("TTY + accept → ensureLoggedIn exactly once, install continues", async () => {
+  it("TTY + decline + paste valid token → loginWithProvidedToken called with pasted value", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(false);
+    promptLineMock.mockResolvedValue("pasted-tok");
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall([]);
+
+    expect(promptLineMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("pasted-tok");
+    expect(ensureLoggedInMock).not.toHaveBeenCalled();
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("TTY + accept → ensureLoggedIn once; paste fallback NOT triggered when signin succeeded", async () => {
     setTTY(true);
     confirmMock.mockResolvedValue(true);
     ensureLoggedInMock.mockResolvedValue(true);
@@ -189,20 +210,38 @@ describe("install consent gate — TTY paths", () => {
 
     expect(confirmMock).toHaveBeenCalledTimes(1);
     expect(ensureLoggedInMock).toHaveBeenCalledTimes(1);
+    expect(promptLineMock).not.toHaveBeenCalled(); // signed in, no fallback
     expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
     expect(stdoutText()).toContain("🐝 One more step to unlock Hivemind");
-    expect(stdoutText()).toContain("Prefer your own cloud storage");
-    expect(stdoutText()).toContain("Already have a token? Pass --token <value> or set DEEPLAKE_API_TOKEN.");
+    expect(stdoutText()).toContain("securely stored in");
+    expect(stdoutText()).toContain("your private Hivemind");
+    expect(stdoutText()).toContain("You can later connect your own cloud storage");
   });
 
-  it("TTY + --token <value> → consent prompt NOT shown, token honored", async () => {
+  it("TTY + accept BUT device flow fails → paste fallback fires", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(true);
+    ensureLoggedInMock.mockResolvedValue(false); // device flow didn't complete
+    promptLineMock.mockResolvedValue("recovery-tok");
+    loginWithProvidedTokenMock.mockResolvedValue(true);
+
+    await runInstall([]);
+
+    expect(ensureLoggedInMock).toHaveBeenCalledTimes(1);
+    expect(promptLineMock).toHaveBeenCalledTimes(1);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("recovery-tok");
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("TTY + --token <value> → consent prompt NOT shown, token honored, no fallback", async () => {
     setTTY(true);
     loginWithProvidedTokenMock.mockResolvedValue(true);
 
     await runInstall(["--token", "tok-abc"]);
 
     expect(confirmMock).not.toHaveBeenCalled();
+    expect(promptLineMock).not.toHaveBeenCalled();
     expect(ensureLoggedInMock).not.toHaveBeenCalled();
     expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
     expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("tok-abc");
@@ -221,9 +260,8 @@ describe("install consent gate — non-TTY paths", () => {
     expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
     expect(stdoutText()).toContain("No TTY detected");
-    expect(stdoutText()).toContain("--token <value>");
-    expect(stdoutText()).toContain("DEEPLAKE_API_TOKEN");
-    expect(stdoutText()).toContain("HIVEMIND_TOKEN");
+    expect(stdoutText()).toContain("https://app.deeplake.ai/api-keys");
+    expect(stdoutText()).toContain("DEEPLAKE_API_TOKEN=<key>");
     expect(stdoutText()).toContain("hivemind login");
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/tests/cli/install-consent.test.ts
+++ b/tests/cli/install-consent.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *   6. Non-TTY + invalid token + /me 401 → warning, install continues, exit 0
  *   7. TTY + --token flag                → token honored, consent prompt NOT shown
  *
- * Plus a negative-pattern assertion (rule 8): "Signed in via DEEPLAKE_API_TOKEN"
+ * Plus a negative-pattern assertion (rule 8): "Signed in via HIVEMIND_TOKEN"
  * must NOT appear in the --token-flag log line.
  */
 
@@ -132,7 +132,6 @@ beforeEach(() => {
   stdoutMock.mockReset();
   stderrMock.mockReset();
   exitSpy.mockReset();
-  delete process.env.DEEPLAKE_API_TOKEN;
   delete process.env.HIVEMIND_TOKEN;
   vi.spyOn(process.stdout, "write").mockImplementation(((...a: unknown[]) => { stdoutMock(...a); return true; }) as any);
   vi.spyOn(process.stderr, "write").mockImplementation(((...a: unknown[]) => { stderrMock(...a); return true; }) as any);
@@ -234,6 +233,22 @@ describe("install consent gate — TTY paths", () => {
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
   });
 
+  it("TTY + --token rejected → consent prompt STILL shown (codex review fix)", async () => {
+    setTTY(true);
+    loginWithProvidedTokenMock.mockResolvedValue(false); // typoed/revoked
+    confirmMock.mockResolvedValue(false); // user declines fallback consent
+    promptLineMock.mockResolvedValue(""); // skip paste
+
+    await runInstall(["--token", "bad-tok"]);
+
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("bad-tok");
+    // On rejection, runAuthGate must fall through — the consent prompt
+    // fires so the user has a recovery path in the same run.
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(promptLineMock).toHaveBeenCalledTimes(1);
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+  });
+
   it("TTY + --token <value> → consent prompt NOT shown, token honored, no fallback", async () => {
     setTTY(true);
     loginWithProvidedTokenMock.mockResolvedValue(true);
@@ -261,14 +276,16 @@ describe("install consent gate — non-TTY paths", () => {
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
     expect(stdoutText()).toContain("No TTY detected");
     expect(stdoutText()).toContain("https://app.deeplake.ai/api-keys");
-    expect(stdoutText()).toContain("DEEPLAKE_API_TOKEN=<key>");
+    expect(stdoutText()).toContain("HIVEMIND_TOKEN=<key>");
     expect(stdoutText()).toContain("hivemind login");
+    // DEEPLAKE_* env names were dropped per product feedback.
+    expect(stdoutText()).not.toContain("DEEPLAKE_API_TOKEN");
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("non-TTY + DEEPLAKE_API_TOKEN → loginWithProvidedToken once, no device flow, no confirm", async () => {
+  it("non-TTY + HIVEMIND_TOKEN → loginWithProvidedToken once, no device flow, no confirm", async () => {
     setTTY(false);
-    process.env.DEEPLAKE_API_TOKEN = "env-token";
+    process.env.HIVEMIND_TOKEN = "env-token";
     loginWithProvidedTokenMock.mockResolvedValue(true);
 
     await runInstall([]);
@@ -280,21 +297,9 @@ describe("install consent gate — non-TTY paths", () => {
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
   });
 
-  it("non-TTY + HIVEMIND_TOKEN (no DEEPLAKE_API_TOKEN) → loginWithProvidedToken once", async () => {
-    setTTY(false);
-    process.env.HIVEMIND_TOKEN = "hm-token";
-    loginWithProvidedTokenMock.mockResolvedValue(true);
-
-    await runInstall([]);
-
-    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
-    expect(loginWithProvidedTokenMock).toHaveBeenCalledWith(undefined);
-    expect(installs.installClaude).toHaveBeenCalledTimes(1);
-  });
-
   it("non-TTY + --token flag → loginWithProvidedToken called with flag value (priority over env)", async () => {
     setTTY(false);
-    process.env.DEEPLAKE_API_TOKEN = "env-token";
+    process.env.HIVEMIND_TOKEN = "env-token";
     loginWithProvidedTokenMock.mockResolvedValue(true);
 
     await runInstall(["--token", "flag-token"]);
@@ -303,14 +308,19 @@ describe("install consent gate — non-TTY paths", () => {
     expect(loginWithProvidedTokenMock).toHaveBeenCalledWith("flag-token");
   });
 
-  it("non-TTY + invalid token (loginWithProvidedToken returns false) → install continues exit 0", async () => {
+  it("non-TTY + invalid token → falls through to headless hint, install continues exit 0", async () => {
     setTTY(false);
-    process.env.DEEPLAKE_API_TOKEN = "bad-token";
+    process.env.HIVEMIND_TOKEN = "bad-token";
     loginWithProvidedTokenMock.mockResolvedValue(false);
 
     await runInstall([]);
 
     expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1);
+    // Codex fix: on token rejection, the non-TTY hint must STILL print so
+    // the user has a documented recovery path. Previously runAuthGate
+    // returned early and the install finished silently with no auth.
+    expect(stdoutText()).toContain("No TTY detected");
+    expect(stdoutText()).toContain("https://app.deeplake.ai/api-keys");
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
   });
@@ -328,7 +338,7 @@ describe("install consent gate — non-TTY paths", () => {
 describe("install consent gate — short-circuit cases", () => {
   it("--skip-auth bypasses the entire gate even when no creds and TTY=true", async () => {
     setTTY(true);
-    process.env.DEEPLAKE_API_TOKEN = "env-token";
+    process.env.HIVEMIND_TOKEN = "env-token";
 
     await runInstall(["--skip-auth"]);
 

--- a/tests/cli/install-consent.test.ts
+++ b/tests/cli/install-consent.test.ts
@@ -169,7 +169,7 @@ const stdoutText = () => stdoutMock.mock.calls.map(c => c[0]).join("");
 const stderrText = () => stderrMock.mock.calls.map(c => c[0]).join("");
 
 describe("install consent gate — TTY paths", () => {
-  it("TTY + decline + paste fallback empty → no auth, install continues, skip hint logged", async () => {
+  it("TTY + decline + paste fallback empty → no auth, install continues, post-loop hint logged", async () => {
     setTTY(true);
     confirmMock.mockResolvedValue(false);
     promptLineMock.mockResolvedValue(""); // user presses Enter at paste prompt
@@ -177,12 +177,75 @@ describe("install consent gate — TTY paths", () => {
     await runInstall([]);
 
     expect(confirmMock).toHaveBeenCalledTimes(1);
-    expect(promptLineMock).toHaveBeenCalledTimes(1); // fallback offered
+    expect(promptLineMock).toHaveBeenCalledTimes(1); // fallback offered, broke on empty
     expect(ensureLoggedInMock).not.toHaveBeenCalled();
     expect(loginWithProvidedTokenMock).not.toHaveBeenCalled();
     expect(installs.installClaude).toHaveBeenCalledTimes(1);
-    expect(stdoutText()).toContain("Skipping sign-in. You can sign in anytime with `hivemind login`.");
+    expect(stdoutText()).toContain("Continuing install without sign-in.");
+    expect(stdoutText()).toContain("hivemind login");
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("TTY + decline + paste invalid 3 times → exhausts retries, install continues", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(false);
+    // Three pastes, none accepted by the server.
+    promptLineMock
+      .mockResolvedValueOnce("bad-1")
+      .mockResolvedValueOnce("bad-2")
+      .mockResolvedValueOnce("bad-3");
+    loginWithProvidedTokenMock.mockResolvedValue(false);
+
+    await runInstall([]);
+
+    expect(promptLineMock).toHaveBeenCalledTimes(3); // MAX_PASTE_ATTEMPTS
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(3);
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    // The user sees retry hints between attempts.
+    expect(stdoutText()).toContain("That key wasn't accepted");
+    expect(stdoutText()).toContain("2 attempts left");
+    expect(stdoutText()).toContain("1 attempt left");
+    // And the terminal "continuing install" message after the loop.
+    expect(stdoutText()).toContain("Continuing install without sign-in.");
+  });
+
+  it("TTY + decline + paste fails then succeeds → loop exits on success, install continues", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(false);
+    promptLineMock
+      .mockResolvedValueOnce("bad-tok")
+      .mockResolvedValueOnce("good-tok");
+    loginWithProvidedTokenMock
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await runInstall([]);
+
+    expect(promptLineMock).toHaveBeenCalledTimes(2);
+    expect(loginWithProvidedTokenMock).toHaveBeenNthCalledWith(1, "bad-tok");
+    expect(loginWithProvidedTokenMock).toHaveBeenNthCalledWith(2, "good-tok");
+    expect(installs.installClaude).toHaveBeenCalledTimes(1);
+    // Retry hint is shown after the first failure.
+    expect(stdoutText()).toContain("That key wasn't accepted");
+    // But the final "continuing without sign-in" hint MUST NOT appear since
+    // we ultimately did sign in.
+    expect(stdoutText()).not.toContain("Continuing install without sign-in.");
+  });
+
+  it("TTY + decline + paste fails once then user presses Enter → no further retries, install continues", async () => {
+    setTTY(true);
+    confirmMock.mockResolvedValue(false);
+    promptLineMock
+      .mockResolvedValueOnce("bad-tok")
+      .mockResolvedValueOnce(""); // user gives up
+    loginWithProvidedTokenMock.mockResolvedValue(false);
+
+    await runInstall([]);
+
+    expect(promptLineMock).toHaveBeenCalledTimes(2);
+    expect(loginWithProvidedTokenMock).toHaveBeenCalledTimes(1); // empty isn't a paste
+    expect(stdoutText()).toContain("That key wasn't accepted");
+    expect(stdoutText()).toContain("Continuing install without sign-in.");
   });
 
   it("TTY + decline + paste valid token → loginWithProvidedToken called with pasted value", async () => {

--- a/tests/cli/update-skip-auth-guard.test.ts
+++ b/tests/cli/update-skip-auth-guard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression guard: the autoupdate path MUST pass `--skip-auth` to its
+ * inner `hivemind install` spawn. If a future refactor drops it, the
+ * background autoupdate would walk into the new consent prompt with closed
+ * stdin and either hang on readline (TTY misdetected) or silently print the
+ * headless hint on every session-start — both are user-visible regressions.
+ *
+ * Two layers (CLAUDE.md testing-rule 11: source AND bundle):
+ *   1. Source grep — proves the literal is in src/cli/update.ts.
+ *   2. Bundle grep — proves esbuild kept it in the shipped artifact.
+ *
+ * The runtime behavioral assertion lives in cli-update.test.ts; this file
+ * is the negative-pattern guard (rule 8) that fails fast if someone
+ * "cleans up" the args without understanding why the flag is there.
+ */
+
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+describe("autoupdate consent-gate insulation guard", () => {
+  it("src/cli/update.ts spawns `hivemind install --skip-auth` (source-level)", () => {
+    const src = readFileSync(join(repoRoot, "src/cli/update.ts"), "utf-8");
+    // Match the exact spawn shape so a reordering or replacement is caught.
+    expect(src).toMatch(/spawn\(\s*"hivemind"\s*,\s*\[\s*"install"\s*,\s*"--skip-auth"\s*\]\s*\)/);
+  });
+
+  it("bundle/cli.js carries the --skip-auth arg through the build (bundle-level)", () => {
+    const bundlePath = join(repoRoot, "bundle/cli.js");
+    if (!existsSync(bundlePath)) {
+      // Skip cleanly when run before `npm run build`. The source-grep
+      // assertion above is the load-bearing one; this is the second line
+      // of defense for builds.
+      return;
+    }
+    const built = readFileSync(bundlePath, "utf-8");
+    // Both the literal arg and the surrounding spawn call must survive
+    // bundling. esbuild keeps string literals intact, so this is a stable
+    // assertion across minification flags.
+    expect(built).toContain('"--skip-auth"');
+    // esbuild may rename `spawn` to `spawn2`/`spawn3` to avoid collisions
+    // with other bundled symbols, so match any identifier ending in `spawn`
+    // (no underscore-prefixed lookalikes) followed by the exact arg shape.
+    expect(built).toMatch(/\bspawn\w*\(\s*"hivemind"\s*,\s*\[\s*"install"\s*,\s*"--skip-auth"\s*\]\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Inserts a single 🐝 consent prompt between `hivemind install` and the device-flow browser open. Adds an API-key paste fallback when the user declines or the device flow fails to complete, and a non-interactive token path (`--token` / `DEEPLAKE_API_TOKEN` / `HIVEMIND_TOKEN`) for CI / scripted installs. Failed/declined sign-in no longer aborts install — hooks always land; auth becomes a separable concern.

Addresses the ~85% drop-off between `hivemind install` and completed sign-in (~30 → ~5).

## Flow

Three paths, dispatched by `runAuthGate()` in `src/cli/index.ts`:

| Context | Token source | Outcome |
|---|---|---|
| TTY, no token | — | Show 🐝 banner → Yes runs device flow; No (or failed device flow) → API-key paste fallback. Empty paste = continue, skip sign-in. |
| TTY, `--token` / env token | flag/env | Validate via `/me`, save creds, skip consent (token = consent) |
| Non-TTY, token present | flag/env | Same as above, no prompt |
| Non-TTY, no token | — | Print "No TTY" + URL + retry command (`DEEPLAKE_API_TOKEN=<key> hivemind install`), continue install |
| Any context, `--skip-auth` | — | Bypass everything (unchanged) |

## Banner copy

```
🐝 One more step to unlock Hivemind

To enable shared memory and auto-learning across your agents,
we need to sign you in. Your traces will be securely stored in
your private Hivemind, so all your agents can recall them.

You can later connect your own cloud storage like S3/GCS/Azure Blob.

Sign in now? [Y/n]
```

If `N` (or `Y` but device flow doesn't complete):

```
Alternatively, sign in at https://app.deeplake.ai/api-keys, create
an API key, and paste it here. Press Enter to skip and continue
installing without sign-in (you can run `hivemind login` later).

API key:
```

## Autoupdate insulation (verified, no code change)

Autoupdate is triple-guarded against this new prompt:
1. Only fires when `creds?.token` exists (`src/hooks/shared/autoupdate.ts:128-129`)
2. Spawns `hivemind install` with `--skip-auth` (`src/cli/update.ts:207`)
3. Uses `detached: true, stdio: "ignore"` so child stdin is closed regardless

`tests/cli/update-skip-auth-guard.test.ts` source-greps + bundle-greps the `--skip-auth` arg so a future refactor can't silently route autoupdate through consent.

## Structural changes

- `saveCredentialsFromToken(token, apiUrl, { skipTokenMint })` extracted in `src/commands/auth.ts` — single credentials-writer shared by device flow and env-var/flag path.
- `confirm()` and new `promptLine()` lifted into `src/cli/util.ts` — reused by `sessions prune` and the new paste fallback.
- New `loginWithProvidedToken()` in `src/cli/auth.ts`.
- New `parseToken()` flag parser + `runAuthGate()` dispatcher in `src/cli/index.ts`.

## Telemetry

Intentionally **not in this PR**. The existing `signup_intent` (deeplake-api PR #222, already merged) + `signup_completed` already measure the install→signup funnel. Granular consent-step events (declined / token-paste / device-flow outcome attribution) will land in a follow-up PR pair: (a) deeplake-api adds a `value` property to `signup_intent` plus a token-paste firing point on `/me`, (b) hivemind sends a `X-Hivemind-Signin-Method` header on the relevant calls.

## Test plan

- [x] 16 unit cases in `tests/cli/install-consent.test.ts` covering TTY accept/decline + paste fallback (empty + valid), accept + device-flow-fail + recovery paste, all non-TTY combinations, `--skip-auth`, already-logged-in
- [x] 5 cases for `confirm()` in `tests/cli/cli-util.test.ts`
- [x] 7 cases for `loginWithProvidedToken()` in `tests/cli/cli-auth.test.ts`
- [x] 3 bundle smoke cases in `tests/cli/install-consent-bundle.test.ts` — drives `bundle/cli.js` with closed stdin against a mock /me, asserts no readline hang
- [x] 2 regression cases in `tests/cli/update-skip-auth-guard.test.ts` — source AND bundle level `--skip-auth` literal preserved
- [x] Existing `tests/cli/cli-index.test.ts` updated for the new contract; restores `process.stdin.isTTY` in teardown (CodeRabbit out-of-diff fix)
- [x] Full per-file coverage thresholds met for `src/cli/util.ts` and `src/cli/auth.ts` (80%)
- [x] Manual: TTY decline (pty), TTY accept (real prod browser sign-in), TTY + invalid token against mock 401, non-TTY + valid token against mock /me + /organizations, `--skip-auth`, already-logged-in — all green against the real built bundle

## Out of scope

- Telemetry events for `consent_shown` / `accepted` / `declined` / `token_paste` (follow-up PR pair).
- Re-prompting consent at session-start if user said no.
- A "remind me later" third option.

Confidence: 90%. Untested: real production `/me` + `/organizations` with a real beta token end-to-end (verified against mocked endpoints; shape was confirmed against deeplake-api source).