### PR TITLE
analytics: machine-stable install_id sent on device-flow requests

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -5,6 +5,7 @@
 
 import { execSync } from "node:child_process";
 import { deeplakeClientHeader } from "../utils/client-header.js";
+import { hivemindInstallIDHeader } from "./install-id.js";
 import {
   type Credentials,
   loadCredentials,
@@ -93,7 +94,11 @@ async function apiDelete(path: string, token: string, apiUrl: string, orgId?: st
 export async function requestDeviceCode(apiUrl = DEFAULT_API_URL): Promise<DeviceCodeResponse> {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
+    headers: {
+      "Content-Type": "application/json",
+      ...deeplakeClientHeader(),
+      ...hivemindInstallIDHeader(),
+    },
   });
   if (!resp.ok) throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
   return resp.json() as Promise<DeviceCodeResponse>;
@@ -102,7 +107,11 @@ export async function requestDeviceCode(apiUrl = DEFAULT_API_URL): Promise<Devic
 export async function pollForToken(deviceCode: string, apiUrl = DEFAULT_API_URL): Promise<DeviceTokenResponse | null> {
   const resp = await fetch(`${apiUrl}/auth/device/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", ...deeplakeClientHeader() },
+    headers: {
+      "Content-Type": "application/json",
+      ...deeplakeClientHeader(),
+      ...hivemindInstallIDHeader(),
+    },
     body: JSON.stringify({ device_code: deviceCode }),
   });
   if (resp.ok) return resp.json() as Promise<DeviceTokenResponse>;

--- a/src/commands/install-id.ts
+++ b/src/commands/install-id.ts
@@ -1,0 +1,82 @@
+/**
+ * Machine-stable install ID for hivemind CLI device flow.
+ *
+ * Persisted to ~/.deeplake/install-id on first use. Sent as the
+ * X-Hivemind-Install-Id header on /auth/device/code and /auth/device/token
+ * so the deeplake-api backend uses it as the anonymous PostHog distinct_id
+ * (instead of hashing the per-attempt OAuth device_code).
+ *
+ * Why this exists: without a stable ID, every `hivemind install` retry from
+ * the same machine creates a new anonymous Person in PostHog. One real user
+ * × N retries = N orphan Persons, only one of which gets aliased to their
+ * Auth0 identity at completion. The other N-1 inflate funnel denominators
+ * forever.
+ *
+ * Best-effort by design: if reading or writing the file fails, the helper
+ * returns an empty string and the network code omits the header — the
+ * backend then falls back to its pre-install-id behavior (hashing the
+ * device_code). No CLI flow ever breaks because of install-id issues.
+ *
+ * No imports from any module that touches `fetch` belong here — same
+ * static-analysis split as auth-creds.ts.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+// Lazy paths so HOME overrides in tests take effect per-call. Same pattern
+// as auth-creds.ts; see that file for the rationale (CI branch-coverage
+// flake from vi.resetModules + dynamic re-import).
+function configDir(): string {
+  return join(homedir(), ".deeplake");
+}
+function installIDPath(): string {
+  return join(configDir(), "install-id");
+}
+
+// Loose validity check: only accept content that looks like a UUID
+// (8-4-4-4-12 hex). Anything else is treated as corrupt and rotated. This
+// catches truncated/garbled files without trying to be cryptographic.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Read the install ID from disk, or generate and persist a new one.
+ *
+ * Returns an empty string if both read AND write fail (e.g. read-only
+ * filesystem). Never throws — callers omit the header on empty result.
+ */
+export function getOrCreateInstallID(): string {
+  // Read first — happy path is one fs call.
+  try {
+    const value = readFileSync(installIDPath(), "utf-8").trim();
+    if (UUID_RE.test(value)) return value;
+    // Fall through to regenerate on invalid contents.
+  } catch {
+    // Missing file (ENOENT) or unreadable — fall through to generate.
+  }
+
+  const id = randomUUID();
+  try {
+    mkdirSync(configDir(), { recursive: true, mode: 0o700 });
+    writeFileSync(installIDPath(), id, { mode: 0o600 });
+    return id;
+  } catch {
+    // Can't persist — return empty so the caller skips the header. The
+    // alternative (returning the in-memory id) would create a new orphan
+    // anon Person per process, defeating the whole point.
+    return "";
+  }
+}
+
+/**
+ * Returns `{ "X-Hivemind-Install-Id": "<uuid>" }` for spreading into a
+ * headers object, or `{}` when the install ID can't be obtained. Callers
+ * use it the same way as `deeplakeClientHeader()`.
+ */
+export function hivemindInstallIDHeader(): Record<string, string> {
+  const id = getOrCreateInstallID();
+  if (!id) return {};
+  return { "X-Hivemind-Install-Id": id };
+}

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const fetchMock = vi.fn();
 const saveCredentialsMock = vi.fn();
 const loadCredentialsMock = vi.fn();
+const installIDHeaderMock = vi.fn();
 
 vi.stubGlobal("fetch", fetchMock);
 vi.mock("../../src/commands/auth-creds.js", () => ({
@@ -23,6 +24,13 @@ vi.mock("../../src/commands/auth-creds.js", () => ({
 }));
 vi.mock("../../src/utils/client-header.js", () => ({
   deeplakeClientHeader: () => ({ "X-Deeplake-Client": "hivemind/test" }),
+}));
+// Mock install-id so device-flow tests neither touch the test runner's
+// real $HOME (which would create ~/.deeplake/install-id) nor depend on
+// the actual UUID generation. installIDHeaderMock controls what
+// hivemindInstallIDHeader() returns per test case.
+vi.mock("../../src/commands/install-id.js", () => ({
+  hivemindInstallIDHeader: () => installIDHeaderMock(),
 }));
 
 async function importAuth() {
@@ -38,6 +46,11 @@ beforeEach(() => {
   fetchMock.mockReset();
   saveCredentialsMock.mockReset();
   loadCredentialsMock.mockReset();
+  installIDHeaderMock.mockReset();
+  // Default: install-id helper returns the empty object, so the header
+  // is omitted (matches the graceful-degradation path). Individual tests
+  // override this to assert the happy path.
+  installIDHeaderMock.mockReturnValue({});
 });
 
 afterEach(() => {
@@ -85,6 +98,33 @@ describe("requestDeviceCode", () => {
     expect(init.headers["X-Deeplake-Client"]).toBe("hivemind/test");
   });
 
+  it("includes X-Hivemind-Install-Id header when install-id helper returns one", async () => {
+    installIDHeaderMock.mockReturnValueOnce({ "X-Hivemind-Install-Id": "uuid-from-helper" });
+    fetchMock.mockResolvedValueOnce(ok({
+      device_code: "dc1", user_code: "ABCD", verification_uri: "u", verification_uri_complete: "uc",
+      expires_in: 600, interval: 5,
+    }));
+    const { requestDeviceCode } = await importAuth();
+    await requestDeviceCode("https://api.example");
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["X-Hivemind-Install-Id"]).toBe("uuid-from-helper");
+  });
+
+  it("omits X-Hivemind-Install-Id header when install-id helper returns empty (graceful-degrade path)", async () => {
+    // beforeEach default already sets installIDHeaderMock to return {} — make it explicit here for clarity.
+    installIDHeaderMock.mockReturnValueOnce({});
+    fetchMock.mockResolvedValueOnce(ok({
+      device_code: "dc1", user_code: "ABCD", verification_uri: "u", verification_uri_complete: "uc",
+      expires_in: 600, interval: 5,
+    }));
+    const { requestDeviceCode } = await importAuth();
+    await requestDeviceCode("https://api.example");
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["X-Hivemind-Install-Id"]).toBeUndefined();
+    // Other headers must still be present — the missing install-id must not nuke them.
+    expect(init.headers["X-Deeplake-Client"]).toBe("hivemind/test");
+  });
+
   it("throws on non-200 response", async () => {
     fetchMock.mockResolvedValueOnce(new Response("nope", { status: 503 }));
     const { requestDeviceCode } = await importAuth();
@@ -98,6 +138,32 @@ describe("pollForToken", () => {
     const { pollForToken } = await importAuth();
     const r = await pollForToken("dc1", "https://api.example");
     expect(r?.access_token).toBe("tok");
+  });
+
+  it("includes X-Hivemind-Install-Id header when install-id helper returns one", async () => {
+    installIDHeaderMock.mockReturnValueOnce({ "X-Hivemind-Install-Id": "uuid-poll" });
+    fetchMock.mockResolvedValueOnce(ok({ access_token: "tok", token_type: "Bearer", expires_in: 3600 }));
+    const { pollForToken } = await importAuth();
+    await pollForToken("dc1", "https://api.example");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example/auth/device/token");
+    expect(init.method).toBe("POST");
+    expect(init.headers["X-Hivemind-Install-Id"]).toBe("uuid-poll");
+    expect(init.headers["X-Deeplake-Client"]).toBe("hivemind/test");
+    // device_code must be in the body, not the headers — sanity that we
+    // didn't break the request shape while adding the header.
+    expect(JSON.parse(init.body)).toEqual({ device_code: "dc1" });
+  });
+
+  it("omits X-Hivemind-Install-Id header when install-id helper returns empty", async () => {
+    installIDHeaderMock.mockReturnValueOnce({});
+    fetchMock.mockResolvedValueOnce(ok({ access_token: "tok", token_type: "Bearer", expires_in: 3600 }));
+    const { pollForToken } = await importAuth();
+    await pollForToken("dc1", "https://api.example");
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["X-Hivemind-Install-Id"]).toBeUndefined();
+    expect(init.headers["X-Deeplake-Client"]).toBe("hivemind/test");
   });
 
   it("returns null on authorization_pending (still waiting)", async () => {

--- a/tests/claude-code/install-id.test.ts
+++ b/tests/claude-code/install-id.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, mkdirSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getOrCreateInstallID,
+  hivemindInstallIDHeader,
+} from "../../src/commands/install-id.js";
+
+/**
+ * Source-level tests for src/commands/install-id.ts.
+ *
+ * Same static-import + process.env.HOME override pattern as auth-creds.test.ts
+ * — see that file for the rationale (vi.resetModules + reimport caused a
+ * V8 coverage-merge flake on CI). The lazy homedir() inside install-id.ts
+ * lets us flip HOME between tests against a single module instance.
+ */
+
+let TEMP_HOME = "";
+let ORIGINAL_HOME: string | undefined;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function installIDFile(): string {
+  return join(TEMP_HOME, ".deeplake", "install-id");
+}
+
+beforeEach(() => {
+  TEMP_HOME = mkdtempSync(join(tmpdir(), "hivemind-install-id-test-"));
+  ORIGINAL_HOME = process.env.HOME;
+  process.env.HOME = TEMP_HOME;
+});
+
+afterEach(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  rmSync(TEMP_HOME, { recursive: true, force: true });
+});
+
+describe("install-id — generate + persist", () => {
+  it("creates a UUID on first call and persists it to ~/.deeplake/install-id", () => {
+    expect(existsSync(installIDFile())).toBe(false);
+
+    const id = getOrCreateInstallID();
+
+    expect(id).toMatch(UUID_RE);
+    expect(existsSync(installIDFile())).toBe(true);
+    expect(readFileSync(installIDFile(), "utf-8")).toBe(id);
+  });
+
+  it("returns the same ID across calls (stable across the same process)", () => {
+    const first = getOrCreateInstallID();
+    const second = getOrCreateInstallID();
+    const third = getOrCreateInstallID();
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it("reuses an existing valid ID on disk without regenerating", () => {
+    const preexisting = "11111111-2222-3333-4444-555555555555";
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(installIDFile(), preexisting);
+
+    expect(getOrCreateInstallID()).toBe(preexisting);
+  });
+
+  it("rotates a corrupt on-disk value (not a UUID) to a fresh one", () => {
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(installIDFile(), "not-a-uuid-just-garbage");
+
+    const id = getOrCreateInstallID();
+
+    expect(id).toMatch(UUID_RE);
+    expect(id).not.toBe("not-a-uuid-just-garbage");
+    expect(readFileSync(installIDFile(), "utf-8")).toBe(id);
+  });
+
+  it("trims surrounding whitespace from existing valid IDs", () => {
+    const preexisting = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+    writeFileSync(installIDFile(), `  ${preexisting}\n`);
+
+    expect(getOrCreateInstallID()).toBe(preexisting);
+  });
+
+  it("writes the file with mode 0600 (owner-only read/write)", () => {
+    // Skip on Windows where POSIX modes don't apply meaningfully.
+    if (process.platform === "win32") return;
+
+    getOrCreateInstallID();
+    const mode = statSync(installIDFile()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("install-id — hivemindInstallIDHeader", () => {
+  it("returns { X-Hivemind-Install-Id: <uuid> } when an ID is available", () => {
+    const header = hivemindInstallIDHeader();
+    expect(Object.keys(header)).toEqual(["X-Hivemind-Install-Id"]);
+    expect(header["X-Hivemind-Install-Id"]).toMatch(UUID_RE);
+  });
+
+  it("returns the SAME header value as getOrCreateInstallID() — they share state", () => {
+    const id = getOrCreateInstallID();
+    expect(hivemindInstallIDHeader()).toEqual({ "X-Hivemind-Install-Id": id });
+  });
+});
+
+describe("install-id — graceful degradation", () => {
+  it("returns empty string + empty header when ~/.deeplake is unwritable", () => {
+    // Pre-create the config dir as read-only so writeFileSync(install-id) fails.
+    if (process.platform === "win32") return; // POSIX-only test
+    if (process.getuid && process.getuid() === 0) return; // root bypasses mode checks
+    mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true, mode: 0o500 });
+
+    const id = getOrCreateInstallID();
+    expect(id).toBe("");
+    expect(hivemindInstallIDHeader()).toEqual({});
+
+    // Restore so afterEach cleanup can rm the dir.
+    chmodSync(join(TEMP_HOME, ".deeplake"), 0o700);
+  });
+});


### PR DESCRIPTION
## Summary

Generates a machine-stable `install_id` (UUID v4) on first `hivemind install`, persists to `~/.deeplake/install-id` (mode 0600), and sends it as the `X-Hivemind-Install-Id` header on `/auth/device/code` and `/auth/device/token`. Pairs with the companion deeplake-api PR (activeloopai/deeplake-api#239) that uses this header as the anonymous PostHog distinct_id, collapsing all install attempts from the same machine onto one anon Person.

## Why

Today every `hivemind install` retry mints a fresh OAuth `device_code` → backend hashes that into a fresh `hivemind_intent_<hash>` anon distinct_id → fresh anonymous PostHog Person. One user × 5 retries = 5 orphan anon Persons, only one of which (the attempt whose device flow completes) gets aliased to the user's identified Auth0 ID. The other 4 sit forever inflating the funnel denominator.

With a stable `install_id`, all attempts from one machine share one anon Person; on completion that one Person merges with the identified user. Clean Person identity, accurate funnel.

## Design notes

- `install-id.ts` is a fs-only module (no `fetch` imports), following the same static-analysis split as `auth-creds.ts`. The reason for the split is documented in `auth-creds.ts` — per-file rules flag fs+fetch co-occurrence.
- Lazy `homedir()` accessor (not bound at module load) so tests can flip `process.env.HOME` between cases against a single module instance. Same pattern as `auth-creds.ts`; the rationale (V8 coverage-merge flake from `vi.resetModules + dynamic re-import`) is documented there.
- Graceful degradation: if the file can't be read OR written (e.g. read-only `$HOME`, unusual permissions), `getOrCreateInstallID()` returns `""` and `hivemindInstallIDHeader()` returns `{}` — the network code spreads it into the headers object as a no-op, so the request still goes out and the backend falls back to its pre-install-id behavior. No CLI flow ever breaks because of install-id issues.
- Corrupt on-disk values are rotated: a strict UUID regex validates the file content; anything else triggers regenerate-and-persist.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 9 new unit tests pass (`tests/claude-code/install-id.test.ts`):
  - Generate + persist on first call
  - Stability across repeated calls
  - Reuse of existing valid on-disk ID
  - Rotation of corrupt value
  - Whitespace trimming
  - File mode 0600 (POSIX-only)
  - Header shape correct
  - Header + `getOrCreateInstallID` share state
  - Empty header when `~/.deeplake` is unwritable
- [x] Existing `auth-creds.test.ts` still passes (no regression on the sibling module)
- [ ] Manual after merge: clean install on a fresh `$HOME`, verify `~/.deeplake/install-id` is created, verify PostHog `signup_intent` event carries `install_id` property AND `distinct_id = "hivemind_install_<uuid>"`

## Notes for reviewer

- The header name `X-Hivemind-Install-Id` and the file path `~/.deeplake/install-id` are coordinated with deeplake-api PR #239. Renaming either requires synchronized change there.
- This PR is the consumer side. The backend has a graceful fallback for older CLIs that don't send the header, so the order of release doesn't matter for safety. It DOES matter for analytics: ideally the backend ships first so that when this CLI release goes out, signup_intents start landing under stable IDs immediately. If this ships first while the backend hasn't yet read the header, we just send a no-op header and the backend behaves identically to today.
- The bundle/build-time tests in this repo (which check for `embed-daemon.js`, `capture.js` etc. in the built artifact) were failing pre-PR on a fresh worktree without `npm run build`. Source-level tests cover the change here; bundle/runtime verification happens in the standard CI build step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-stable install ID that persists locally on first use and is sent with device authorization requests
  * System gracefully handles unavailable storage by omitting the header when necessary

* **Tests**
  * Added comprehensive test suite validating install ID generation, persistence, and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Live E2E test plan (run against locally-built CLI + locally-built deeplake-api)

Companion to activeloopai/deeplake-api#239. Each repo's PR linked from the other.

### Setup

```bash
# 1. Build this CLI bundle from the worktree
cd ~/al-projects/hivemind-worktrees/install-id
ln -sf ~/al-projects/hivemind/node_modules ./node_modules
npm run build
grep -c 'X-Hivemind-Install-Id' bundle/cli.js   # should print 1

# 2. Boot the companion deeplake-api locally with the install-id-reading code
#    (see deeplake-api PR #239 for that setup)

# 3. Fresh sandbox HOME so install-id file is generated by THIS PR's code
SANDBOX=/tmp/hivemind-install-id-test-$(date +%s)
mkdir -p "$SANDBOX/.claude"
```

### Test A — fresh install on a clean machine

```bash
HOME=$SANDBOX HIVEMIND_API_URL=http://localhost:8080 \
  node ~/al-projects/hivemind-worktrees/install-id/bundle/cli.js install --only claude
```

Sign in with an existing account at the verification URL.

| Assertion | Result |
|-----------|--------|
| `~/.deeplake/install-id` created in sandbox, mode `0600`, contents valid UUID v4 | ✓ `3b46129e-8ec5-4c40-b3db-bcd739005cab` |
| `signup_intent.distinct_id` = `hivemind_install_<that-uuid>` (NOT the legacy `hivemind_intent_<sha>`) | ✓ |
| Backend received `X-Hivemind-Install-Id` header on `/auth/device/code` AND `/auth/device/token` | ✓ (alias and login_completed both used install-id-derived anon) |

### Test B — second install from same machine, install-id reused

```bash
# Keep install-id file, drop creds so device flow re-triggers
rm $SANDBOX/.deeplake/credentials.json
HOME=$SANDBOX HIVEMIND_API_URL=http://localhost:8080 \
  node ~/al-projects/hivemind-worktrees/install-id/bundle/cli.js install --only claude
```

Sign in again.

**Critical assertion (the entire point of this PR):**

| Assertion | Result |
|-----------|--------|
| Install-id file unchanged between attempts | ✓ `3b46129e-...` same UUID |
| Second `signup_intent.distinct_id` equals first | ✓ both = `hivemind_install_3b46129e-8ec5-4c40-b3db-bcd739005cab` |
| **Total anonymous PostHog Persons created for the user: 1, not 2** | ✓ — proven by both events sharing the same distinct_id |

Without this PR, the two attempts would produce two distinct `hivemind_intent_<sha256>` IDs (different device_codes → different hashes), creating two orphan anon Persons. This PR collapses them.

### Backward compatibility

The deeplake-api side falls back to its pre-install-id behavior (`hivemind_intent_<sha256(device_code)>`) when the `X-Hivemind-Install-Id` header is absent. So:

- **Old hivemind + new deeplake-api**: works (backend uses device_code hash, as today)
- **New hivemind + old deeplake-api**: works (backend ignores the unknown header)
- **New hivemind + new deeplake-api**: install-id collapsing kicks in

Either repo can ship first without breaking anything.
