### PR TITLE
feat(dashboard): hivemind dashboard — codebase graph + KPI viewer

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,12 +64,16 @@ Usage:
       every detected agent bundle. Single command for all agents.
 
   hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
-      Build a self-contained HTML dashboard for this repo and open it
-      in the default browser. Combines KPI cards (tokens saved, skills
-      created, memory recalls, sessions) with the codebase-graph
-      visualization. Writes to ~/.hivemind/dashboards/<repo-key>/
-      index.html by default; --no-open skips the browser launch
-      (useful in headless / CI scenarios).
+                     [--serve] [--port <n>]
+      Build a self-contained HTML dashboard for this repo. Combines
+      KPI cards (tokens saved, skills created, memory recalls,
+      sessions) with the codebase-graph visualization. Writes to
+      ~/.hivemind/dashboards/<repo-key>/index.html by default.
+      --no-open skips the browser launch (headless / CI scenarios).
+      --serve starts a loopback HTTP server at http://127.0.0.1:<port>
+      (default 8123) so the dashboard is reachable via a URL — useful
+      over SSH; VS Code / Cursor Remote-SSH auto-forwards the port
+      and opens it in the integrated Simple Browser tab on click.
 
 Semantic search (embeddings):
   hivemind embeddings install                Download @huggingface/transformers

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./embeddings.js";
 import { ensureLoggedIn, isLoggedIn, loginWithProvidedToken, maybeShowOrgChoice } from "./auth.js";
 import { runAuthCommand } from "../commands/auth-login.js";
+import { runDashboardCommand } from "../commands/dashboard.js";
 import { runSkillifyCommand } from "../commands/skillify.js";
 import { confirm, detectPlatforms, allPlatformIds, log, promptLine, warn, type PlatformId } from "./util.js";
 import { getVersion } from "./version.js";
@@ -61,6 +62,14 @@ Usage:
   hivemind update [--dry-run]
       Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
       every detected agent bundle. Single command for all agents.
+
+  hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
+      Build a self-contained HTML dashboard for this repo and open it
+      in the default browser. Combines KPI cards (tokens saved, skills
+      created, memory recalls, sessions) with the codebase-graph
+      visualization. Writes to ~/.hivemind/dashboards/<repo-key>/
+      index.html by default; --no-open skips the browser launch
+      (useful in headless / CI scenarios).
 
 Semantic search (embeddings):
   hivemind embeddings install                Download @huggingface/transformers
@@ -335,6 +344,11 @@ async function main(): Promise<void> {
   if (cmd === "skillify") {
     runSkillifyCommand(args.slice(1));
     return;
+  }
+
+  if (cmd === "dashboard") {
+    const code = await runDashboardCommand(args.slice(1));
+    process.exit(code);
   }
 
   if (cmd === "embeddings") {

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -31,18 +31,29 @@ import { dirname, join, resolve } from "node:path";
 import { loadDashboardData } from "../dashboard/data.js";
 import { openInBrowser } from "../dashboard/open.js";
 import { renderDashboardHtml } from "../dashboard/render.js";
+import { serveDashboardHtml, type ServeHandle } from "../dashboard/serve.js";
 
 const USAGE = `hivemind dashboard — codebase graph + KPI dashboard (HTML)
 
 Usage:
   hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
-      Build a self-contained HTML dashboard for this repo and open
-      it in the default browser.
+                     [--serve] [--port <n>]
+      Build a self-contained HTML dashboard for this repo, write it
+      to disk, and either open it in the default browser or serve
+      it over loopback HTTP for headless / SSH workflows.
 
       --cwd <path>   Use a different project root (defaults to cwd).
       --out <path>   Write to a custom path (defaults to
                      ~/.hivemind/dashboards/<repo-key>/index.html).
-      --no-open      Don't open the browser; only write the file.
+      --no-open      Don't open the browser. Combine with --serve
+                     to start the server without auto-launching.
+      --serve        Start a loopback HTTP server (127.0.0.1) so the
+                     dashboard is reachable at a URL. Stays alive
+                     until Ctrl+C. Ideal for VS Code / Cursor
+                     Remote-SSH (auto-forwards the port → click to
+                     open in the integrated browser tab).
+      --port <n>     Port for --serve (default 8123). Falls back to
+                     a kernel-assigned port if <n> is in use.
 
   hivemind dashboard --help
       Show this message.
@@ -61,6 +72,9 @@ export interface DashboardArgs {
   /** Empty string means "use the default path under ~/.hivemind/dashboards/". */
   outPath: string;
   open: boolean;
+  serve: boolean;
+  /** undefined means "use the server's default port (8123)". */
+  port: number | undefined;
 }
 
 export interface ParseResult {
@@ -69,17 +83,29 @@ export interface ParseResult {
   error?: string;
 }
 
+function parsePort(raw: string | undefined): number | { error: string } {
+  if (raw === undefined || raw === "") return { error: "--port requires a value" };
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    return { error: `--port must be an integer in [0, 65535], got '${raw}'` };
+  }
+  return n;
+}
+
 /** Pure arg parser — extracted so tests can verify flag handling
  *  without touching disk. */
 export function parseDashboardArgs(args: string[]): ParseResult {
   let cwd: string | undefined;
   let outPath = "";
   let open = true;
+  let serve = false;
+  let port: number | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--help" || a === "-h") return { help: true };
     if (a === "--no-open") { open = false; continue; }
+    if (a === "--serve") { serve = true; continue; }
     if (a === "--cwd") {
       const v = args[++i];
       // Reject flag tokens used as a value — `--cwd --no-open` should
@@ -103,6 +129,22 @@ export function parseDashboardArgs(args: string[]): ParseResult {
       continue;
     }
     if (a.startsWith("--out=")) { outPath = a.slice("--out=".length); continue; }
+    if (a === "--port") {
+      const v = args[++i];
+      if (v === undefined || v.startsWith("-")) {
+        return { error: "--port requires a value" };
+      }
+      const parsed = parsePort(v);
+      if (typeof parsed === "object") return { error: parsed.error };
+      port = parsed;
+      continue;
+    }
+    if (a.startsWith("--port=")) {
+      const parsed = parsePort(a.slice("--port=".length));
+      if (typeof parsed === "object") return { error: parsed.error };
+      port = parsed;
+      continue;
+    }
     return { error: `unknown arg '${a}'` };
   }
 
@@ -111,6 +153,8 @@ export function parseDashboardArgs(args: string[]): ParseResult {
       cwd: cwd ?? process.cwd(),
       outPath,
       open,
+      serve,
+      port,
     },
   };
 }
@@ -125,6 +169,11 @@ export function defaultDashboardOutPath(repoKey: string): string {
 export interface RunDashboardOptions {
   /** Test injection — defaults to the real openInBrowser. */
   opener?: typeof openInBrowser;
+  /** Test injection — defaults to the real serveDashboardHtml. */
+  server?: typeof serveDashboardHtml;
+  /** Test injection — defaults to a real process.on('SIGINT', ...).
+   *  Returns a cleanup fn the runner calls after the server stops. */
+  onSignal?: (signal: NodeJS.Signals, handler: () => void) => () => void;
   /** Where stdout messages land. Defaults to process.stdout.write. */
   out?: (msg: string) => void;
   /** Where errors land. Defaults to process.stderr.write. */
@@ -179,6 +228,10 @@ export async function runDashboardCommand(
     out(`(no codebase graph yet — run 'hivemind graph build' to populate)\n`);
   }
 
+  if (parsed.args.serve) {
+    return await runServeLoop(html, parsed.args, runOpts, out, err);
+  }
+
   if (open) {
     const result = opener(absOut);
     if (result.attempted) {
@@ -188,4 +241,66 @@ export async function runDashboardCommand(
     }
   }
   return 0;
+}
+
+async function runServeLoop(
+  html: string,
+  args: DashboardArgs,
+  runOpts: RunDashboardOptions,
+  out: (s: string) => void,
+  err: (s: string) => void,
+): Promise<number> {
+  const server = runOpts.server ?? serveDashboardHtml;
+  const opener = runOpts.opener ?? openInBrowser;
+  const onSignal = runOpts.onSignal ?? defaultOnSignal;
+
+  let handle: ServeHandle;
+  try {
+    handle = await server({ html, port: args.port });
+  } catch (e: any) {
+    err(`hivemind dashboard: failed to start server: ${e?.message ?? String(e)}\n`);
+    return 1;
+  }
+
+  const url = `http://${handle.host}:${handle.port}/`;
+  out(`Serving dashboard at ${url}  (Ctrl+C to stop)\n`);
+
+  // Open the URL (not the file path) so the browser hits the live
+  // server. On Cursor / VS Code Remote-SSH, the port-forwarder also
+  // notices and offers the same URL via Simple Browser.
+  if (args.open) {
+    const result = opener(url);
+    if (result.attempted) {
+      out(`Opening via ${result.command}\n`);
+    } else {
+      out(`(no opener for this platform; click the URL above or open it manually)\n`);
+    }
+  }
+
+  // SIGINT triggers a graceful close — keeps Ctrl+C from leaving a
+  // listening socket behind. SIGTERM too for daemon-like contexts.
+  let resolveDone!: (code: number) => void;
+  const done = new Promise<number>(r => { resolveDone = r; });
+  const shutdown = async () => {
+    try { await handle.close(); } catch { /* already closed */ }
+    resolveDone(0);
+  };
+  const offInt = onSignal("SIGINT", shutdown);
+  const offTerm = onSignal("SIGTERM", shutdown);
+
+  // Belt-and-suspenders: if the server stops for any other reason
+  // (port closed externally, parent process kill), resolve cleanly too.
+  handle.stopped.then(() => resolveDone(0));
+
+  try {
+    return await done;
+  } finally {
+    offInt();
+    offTerm();
+  }
+}
+
+function defaultOnSignal(signal: NodeJS.Signals, handler: () => void): () => void {
+  process.on(signal, handler);
+  return () => process.off(signal, handler);
 }

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -82,14 +82,23 @@ export function parseDashboardArgs(args: string[]): ParseResult {
     if (a === "--no-open") { open = false; continue; }
     if (a === "--cwd") {
       const v = args[++i];
-      if (!v) return { error: "--cwd requires a value" };
+      // Reject flag tokens used as a value — `--cwd --no-open` should
+      // be a usage error, not "set cwd to the literal string '--no-open'
+      // and silently do the wrong thing". Codex review on commit 4
+      // surfaced this: `hivemind dashboard --out --no-open` was
+      // happily writing a file named `./--no-open`.
+      if (v === undefined || v.startsWith("-")) {
+        return { error: "--cwd requires a value" };
+      }
       cwd = v;
       continue;
     }
     if (a.startsWith("--cwd=")) { cwd = a.slice("--cwd=".length); continue; }
     if (a === "--out") {
       const v = args[++i];
-      if (!v) return { error: "--out requires a value" };
+      if (v === undefined || v.startsWith("-")) {
+        return { error: "--out requires a value" };
+      }
       outPath = v;
       continue;
     }

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * CLI surface for `hivemind dashboard`.
+ *
+ * Generates a self-contained HTML page combining KPI cards (org tokens
+ * saved, skills created, memory recalls, sessions) and a force-directed
+ * codebase-graph visualization, then opens it in the user's default
+ * browser.
+ *
+ * Three flags, all optional:
+ *   --cwd <path>   Different project root (defaults to process.cwd()).
+ *   --out <path>   Custom output path (defaults to
+ *                  ~/.hivemind/dashboards/<repo-key>/index.html).
+ *                  Re-running with the same default path overwrites
+ *                  the prior dashboard — that's the desired refresh
+ *                  semantic; bookmarks stay valid.
+ *   --no-open      Write but don't try to open the browser. Useful
+ *                  for headless / CI scenarios and for users who
+ *                  want to scp the HTML somewhere else.
+ *
+ * Exits with code 2 on argument errors, 1 on unexpected runtime
+ * failure (currently only mkdir/write errors — data/render never
+ * throw by contract), 0 otherwise.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { loadDashboardData } from "../dashboard/data.js";
+import { openInBrowser } from "../dashboard/open.js";
+import { renderDashboardHtml } from "../dashboard/render.js";
+
+const USAGE = `hivemind dashboard — codebase graph + KPI dashboard (HTML)
+
+Usage:
+  hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
+      Build a self-contained HTML dashboard for this repo and open
+      it in the default browser.
+
+      --cwd <path>   Use a different project root (defaults to cwd).
+      --out <path>   Write to a custom path (defaults to
+                     ~/.hivemind/dashboards/<repo-key>/index.html).
+      --no-open      Don't open the browser; only write the file.
+
+  hivemind dashboard --help
+      Show this message.
+
+Data sources (all read-only):
+  - Graph snapshot at ~/.hivemind/graphs/<repo-key>/   (produced by
+    \`hivemind graph build\`; the dashboard works without it and shows
+    an empty-state until the producer has run)
+  - KPIs via the org stats endpoint (cached) with a local fallback
+    to ~/.deeplake/usage-stats.jsonl
+  - Skills created from ~/.claude/skills/<name>--<author>/ directories
+`;
+
+export interface DashboardArgs {
+  cwd: string;
+  /** Empty string means "use the default path under ~/.hivemind/dashboards/". */
+  outPath: string;
+  open: boolean;
+}
+
+export interface ParseResult {
+  help?: boolean;
+  args?: DashboardArgs;
+  error?: string;
+}
+
+/** Pure arg parser — extracted so tests can verify flag handling
+ *  without touching disk. */
+export function parseDashboardArgs(args: string[]): ParseResult {
+  let cwd: string | undefined;
+  let outPath = "";
+  let open = true;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--help" || a === "-h") return { help: true };
+    if (a === "--no-open") { open = false; continue; }
+    if (a === "--cwd") {
+      const v = args[++i];
+      if (!v) return { error: "--cwd requires a value" };
+      cwd = v;
+      continue;
+    }
+    if (a.startsWith("--cwd=")) { cwd = a.slice("--cwd=".length); continue; }
+    if (a === "--out") {
+      const v = args[++i];
+      if (!v) return { error: "--out requires a value" };
+      outPath = v;
+      continue;
+    }
+    if (a.startsWith("--out=")) { outPath = a.slice("--out=".length); continue; }
+    return { error: `unknown arg '${a}'` };
+  }
+
+  return {
+    args: {
+      cwd: cwd ?? process.cwd(),
+      outPath,
+      open,
+    },
+  };
+}
+
+/** Default path for the generated HTML. Lives outside the repo so it
+ *  doesn't show up in `git status` and so two checkouts of the same
+ *  repo share a dashboard. */
+export function defaultDashboardOutPath(repoKey: string): string {
+  return join(homedir(), ".hivemind", "dashboards", repoKey, "index.html");
+}
+
+export interface RunDashboardOptions {
+  /** Test injection — defaults to the real openInBrowser. */
+  opener?: typeof openInBrowser;
+  /** Where stdout messages land. Defaults to process.stdout.write. */
+  out?: (msg: string) => void;
+  /** Where errors land. Defaults to process.stderr.write. */
+  err?: (msg: string) => void;
+}
+
+export async function runDashboardCommand(
+  rawArgs: string[],
+  runOpts: RunDashboardOptions = {},
+): Promise<number> {
+  const out = runOpts.out ?? ((s: string) => { process.stdout.write(s); });
+  const err = runOpts.err ?? ((s: string) => { process.stderr.write(s); });
+  const opener = runOpts.opener ?? openInBrowser;
+
+  const parsed = parseDashboardArgs(rawArgs);
+  if (parsed.help) {
+    out(USAGE);
+    return 0;
+  }
+  if (parsed.error || !parsed.args) {
+    err(`hivemind dashboard: ${parsed.error ?? "invalid arguments"}\n`);
+    err(USAGE);
+    return 2;
+  }
+  const { cwd, outPath, open } = parsed.args;
+
+  let data;
+  try {
+    data = await loadDashboardData({ cwd });
+  } catch (e: any) {
+    // loadDashboardData has fail-soft fallbacks on every branch, but a
+    // future regression that throws shouldn't dump a stack trace into
+    // the user's terminal — surface it as a one-liner.
+    err(`hivemind dashboard: failed to load data: ${e?.message ?? String(e)}\n`);
+    return 1;
+  }
+
+  const html = renderDashboardHtml(data);
+  const finalOut = outPath || defaultDashboardOutPath(data.repoKey);
+  const absOut = resolve(finalOut);
+
+  try {
+    mkdirSync(dirname(absOut), { recursive: true });
+    writeFileSync(absOut, html, "utf-8");
+  } catch (e: any) {
+    err(`hivemind dashboard: failed to write ${absOut}: ${e?.message ?? String(e)}\n`);
+    return 1;
+  }
+
+  out(`Wrote ${absOut}\n`);
+  if (data.graph == null) {
+    out(`(no codebase graph yet — run 'hivemind graph build' to populate)\n`);
+  }
+
+  if (open) {
+    const result = opener(absOut);
+    if (result.attempted) {
+      out(`Opening via ${result.command}\n`);
+    } else {
+      out(`(no opener for this platform; open the file above manually)\n`);
+    }
+  }
+  return 0;
+}

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -148,6 +148,15 @@ export function parseDashboardArgs(args: string[]): ParseResult {
     return { error: `unknown arg '${a}'` };
   }
 
+  // --port is meaningful only in --serve mode. Accepting it silently
+  // without --serve produced confusing no-ops (`hivemind dashboard
+  // --port 9000` looked like it should start a server). Codex review
+  // on the --serve commit caught this — reject explicitly so the user
+  // sees the misconfiguration.
+  if (port !== undefined && !serve) {
+    return { error: "--port requires --serve" };
+  }
+
   return {
     args: {
       cwd: cwd ?? process.cwd(),

--- a/src/dashboard/data.ts
+++ b/src/dashboard/data.ts
@@ -1,0 +1,288 @@
+/**
+ * Data layer for `hivemind dashboard`.
+ *
+ * Loads two independent streams from local artifacts that other features
+ * (codebase-graph feature branch, notifications/usage-tracker on main)
+ * already produce — nothing here writes back. The dashboard is a
+ * read-only render over what's on disk.
+ *
+ *   1. KPI snapshot
+ *        - When creds + network are present, sums org-wide
+ *          memorySearchBytes via fetchOrgStats (HTTP, with the 1-hour
+ *          cache that notifications already maintains).
+ *        - When org stats are unreachable, falls back to the local
+ *          ~/.deeplake/usage-stats.jsonl record stream.
+ *        - When neither exists (fresh install, no creds, no captured
+ *          sessions yet), returns `tokensSource: "none"` so the
+ *          renderer shows an empty-state card instead of "0 saved".
+ *   2. Graph snapshot
+ *        - Reads ~/.hivemind/graphs/<repo-key>/latest-commit.txt and
+ *          loads the JSON it points at. Falls back to the newest *.json
+ *          under snapshots/ when the pointer is missing or stale.
+ *        - Returns null when no snapshot exists for this repo — the
+ *          renderer then shows a graph empty-state with a hint to run
+ *          `hivemind graph build` (the producer lives on the
+ *          codebase-graph feature branch; the dashboard works without
+ *          it).
+ *
+ * Why the savings formula constants are duplicated from
+ * notifications/sources/primary-banner.ts: the banner lives in a
+ * session-start hot path with no flexibility on imports, the dashboard
+ * is a separate CLI entrypoint, and extracting a shared `savings.ts`
+ * touches the banner's tested surface. Cheaper to duplicate two
+ * constants and a one-line formula than to refactor a shipped path.
+ * When the formula changes, both call sites update — grep for
+ * SAVINGS_MULTIPLIER.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { loadCredentials, type Credentials } from "../commands/auth-creds.js";
+import { fetchOrgStats, type OrgStats } from "../notifications/sources/org-stats.js";
+import {
+  countUserGeneratedSkills,
+  readUsageRecords,
+  sumMetric,
+} from "../notifications/usage-tracker.js";
+import { deriveProjectKey } from "../skillify/state.js";
+import { log as _log } from "../utils/debug.js";
+
+const log = (msg: string) => _log("dashboard-data", msg);
+
+/** BPE rule-of-thumb. Same value as primary-banner uses. */
+const BYTES_PER_TOKEN = 4;
+
+/** Published LoCoMo benchmark ratio (claude -p with hivemind uses 1/1.7
+ *  the tokens of without). Same value as primary-banner uses. */
+const SAVINGS_MULTIPLIER = 1.7;
+
+export type TokensSource = "org" | "local" | "none";
+
+export interface DashboardKpis {
+  /** Org-wide (or local) cumulative tokens saved. null when neither
+   *  source is available — distinguishes "empty install" from "0 saved". */
+  tokensSaved: number | null;
+  /** Which source produced tokensSaved. "none" => tokensSaved is null. */
+  tokensSource: TokensSource;
+  /** Skills authored by this user that are installed under
+   *  ~/.claude/skills/. Local count; misses skills generated but not
+   *  pulled to this machine. */
+  skillsCreated: number;
+  /** Memory-search count (recall hits org-wide or local). */
+  memorySearches: number;
+  /** Sessions counted in the source stream. null when source is "none". */
+  sessionsCount: number | null;
+  /** When source is "org", per-user contribution; when "local", same as
+   *  tokensSaved (local stats ARE this user's contribution). null when
+   *  source is "none". */
+  userTokensSaved: number | null;
+}
+
+export interface DashboardGraphSummary {
+  /** HEAD when the snapshot was built. null when graphify ran outside
+   *  a git repo (snapshot named by content hash instead). */
+  commitSha: string | null;
+  /** Absolute path to the loaded snapshot file — surfaced so the HTML
+   *  footer can show where the graph came from. */
+  snapshotPath: string;
+  nodeCount: number;
+  edgeCount: number;
+  /** Raw graphify-shape snapshot JSON. Embedded into the rendered HTML
+   *  as a `<script type="application/json">` payload so the page is
+   *  self-contained (no XHR back to disk). */
+  snapshot: unknown;
+}
+
+export interface DashboardData {
+  /** 16-char project key from deriveProjectKey — used as the on-disk
+   *  directory name under ~/.hivemind/graphs/<repo-key>. */
+  repoKey: string;
+  /** Human-readable project name (basename of cwd). */
+  repoProject: string;
+  /** ISO timestamp at load time — shown in the HTML footer. */
+  generatedAt: string;
+  kpis: DashboardKpis;
+  /** null when no snapshot exists yet for this repo. */
+  graph: DashboardGraphSummary | null;
+}
+
+export interface LoadDashboardDataOptions {
+  /** Project root. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Override the graphs-home dir; falls back to env HIVEMIND_GRAPHS_HOME,
+   *  then ~/.hivemind/graphs. Tests use this to point at a tmpdir. */
+  graphsHome?: string;
+  /** Override creds loading. Pass null to force "logged out" mode;
+   *  undefined (default) calls loadCredentials() like the real CLI. */
+  creds?: Credentials | null;
+}
+
+/** Resolution order for the graphs-home root:
+ *    explicit opts.graphsHome arg > HIVEMIND_GRAPHS_HOME env > ~/.hivemind/graphs.
+ *  Matches the producer's resolver on the codebase-graph branch. */
+export function graphsRoot(): string {
+  return process.env.HIVEMIND_GRAPHS_HOME ?? join(homedir(), ".hivemind", "graphs");
+}
+
+function bytesToSavedTokens(bytes: number): number {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 0;
+  const delivered = bytes / BYTES_PER_TOKEN;
+  return (SAVINGS_MULTIPLIER - 1) * delivered;
+}
+
+interface SnapshotMin {
+  nodes: unknown[];
+  links: unknown[];
+  graph?: { commit_sha?: string | null };
+}
+
+function resolveSnapshot(repoDir: string): DashboardGraphSummary | null {
+  const snapshotsDir = join(repoDir, "snapshots");
+  if (!existsSync(snapshotsDir)) return null;
+
+  let snapshotPath: string | null = null;
+
+  // Preferred path: follow latest-commit.txt. This is the canonical
+  // pointer the producer maintains atomically alongside each build.
+  const pointer = join(repoDir, "latest-commit.txt");
+  if (existsSync(pointer)) {
+    try {
+      const sha = readFileSync(pointer, "utf-8").trim();
+      if (sha) {
+        const candidate = join(snapshotsDir, `${sha}.json`);
+        if (existsSync(candidate)) snapshotPath = candidate;
+        else log(`latest-commit.txt points at missing ${sha}.json — scanning snapshots/`);
+      }
+    } catch (e: any) {
+      log(`latest-commit.txt read failed: ${e?.message ?? String(e)}`);
+    }
+  }
+
+  // Fallback: pick the most-recently-modified *.json. Covers the
+  // pre-pointer state and snapshots named by content hash (the
+  // producer's fallback when commit_sha is null).
+  if (!snapshotPath) {
+    try {
+      const candidates = readdirSync(snapshotsDir)
+        .filter(name => name.endsWith(".json"))
+        .map(name => {
+          const full = join(snapshotsDir, name);
+          return { full, mtime: statSync(full).mtimeMs };
+        })
+        .sort((a, b) => b.mtime - a.mtime);
+      if (candidates.length > 0) snapshotPath = candidates[0].full;
+    } catch (e: any) {
+      log(`snapshots/ scan failed: ${e?.message ?? String(e)}`);
+    }
+  }
+
+  if (!snapshotPath) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(snapshotPath, "utf-8");
+  } catch (e: any) {
+    log(`snapshot read failed: ${e?.message ?? String(e)}`);
+    return null;
+  }
+  let parsed: SnapshotMin;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e: any) {
+    log(`snapshot parse failed: ${e?.message ?? String(e)}`);
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object"
+      || !Array.isArray(parsed.nodes) || !Array.isArray(parsed.links)) {
+    log("snapshot shape invalid (missing nodes/links arrays)");
+    return null;
+  }
+  return {
+    commitSha: parsed.graph?.commit_sha ?? null,
+    snapshotPath,
+    nodeCount: parsed.nodes.length,
+    edgeCount: parsed.links.length,
+    snapshot: parsed,
+  };
+}
+
+async function loadKpis(creds: Credentials | null): Promise<DashboardKpis> {
+  const userName = creds?.userName;
+  const skillsCreated = countUserGeneratedSkills(userName);
+
+  const records = readUsageRecords();
+  const localBytes = sumMetric(records, "memorySearchBytes");
+  const localCount = sumMetric(records, "memorySearchCount");
+
+  let orgStats: OrgStats | null = null;
+  if (creds?.token) {
+    try {
+      orgStats = await fetchOrgStats(creds);
+    } catch (e: any) {
+      // fetchOrgStats already swallows network/parse failures and returns
+      // null, but a future regression that throws shouldn't take the
+      // dashboard down — surface the failure as "no org data" and let
+      // the local fallback do its job.
+      log(`fetchOrgStats threw: ${e?.message ?? String(e)}`);
+    }
+  }
+
+  if (orgStats) {
+    return {
+      tokensSaved: bytesToSavedTokens(orgStats.org.memorySearchBytes),
+      tokensSource: "org",
+      skillsCreated,
+      memorySearches: orgStats.org.memoryRecallCount,
+      sessionsCount: orgStats.org.sessionsCount,
+      userTokensSaved: bytesToSavedTokens(orgStats.user.memorySearchBytes),
+    };
+  }
+
+  if (records.length > 0) {
+    return {
+      tokensSaved: bytesToSavedTokens(localBytes),
+      tokensSource: "local",
+      skillsCreated,
+      memorySearches: localCount,
+      sessionsCount: records.length,
+      userTokensSaved: bytesToSavedTokens(localBytes),
+    };
+  }
+
+  return {
+    tokensSaved: null,
+    tokensSource: "none",
+    skillsCreated,
+    memorySearches: 0,
+    sessionsCount: null,
+    userTokensSaved: null,
+  };
+}
+
+/**
+ * Build the data envelope handed to the renderer. Never throws — every
+ * branch has a defined-but-empty fallback so the dashboard always
+ * produces SOME page even on a fresh install with no creds, no
+ * sessions, and no graph.
+ */
+export async function loadDashboardData(
+  opts: LoadDashboardDataOptions = {},
+): Promise<DashboardData> {
+  const cwd = opts.cwd ?? process.cwd();
+  const { key: repoKey, project: repoProject } = deriveProjectKey(cwd);
+  const repoDir = join(opts.graphsHome ?? graphsRoot(), repoKey);
+
+  const graph = resolveSnapshot(repoDir);
+  const creds = opts.creds === undefined ? loadCredentials() : opts.creds;
+  const kpis = await loadKpis(creds);
+
+  return {
+    repoKey,
+    repoProject,
+    generatedAt: new Date().toISOString(),
+    kpis,
+    graph,
+  };
+}

--- a/src/dashboard/open.ts
+++ b/src/dashboard/open.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { statSync } from "node:fs";
+import { accessSync, constants as fsConstants, statSync } from "node:fs";
 import { platform as nodePlatform } from "node:os";
 import { delimiter, join } from "node:path";
 
@@ -84,7 +84,22 @@ export function findBinaryOnPath(name: string): string | null {
       const candidate = join(dir, name + ext);
       try {
         const st = statSync(candidate);
-        if (st.isFile()) return candidate;
+        if (!st.isFile()) continue;
+        // CodeRabbit on PR #194: without an executable check, a
+        // same-named regular file on PATH (e.g. a man page, a sentinel)
+        // would claim "found" and openInBrowser would happily report
+        // attempted=true for something that can't actually run. On
+        // POSIX, require X_OK; on Windows, PATHEXT-driven extension
+        // matching is the executability signal (the OS rule is "if it
+        // ends in .EXE/.BAT/.CMD/.COM, it's a candidate"), so we
+        // accept the stat.isFile() result there.
+        if (isWin) return candidate;
+        try {
+          accessSync(candidate, fsConstants.X_OK);
+          return candidate;
+        } catch {
+          // file exists but isn't executable — keep looking
+        }
       } catch {
         // not there; keep looking
       }

--- a/src/dashboard/open.ts
+++ b/src/dashboard/open.ts
@@ -13,7 +13,9 @@
  */
 
 import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
 import { platform as nodePlatform } from "node:os";
+import { delimiter, join } from "node:path";
 
 export type OpenPlatform = "linux" | "darwin" | "win32";
 
@@ -54,6 +56,43 @@ export interface OpenResult {
   command?: string;
 }
 
+/**
+ * Walk PATH (PATHEXT on Windows) to confirm a helper binary is
+ * callable BEFORE spawning. `child_process.spawn` does NOT throw
+ * synchronously when the binary is missing — it returns a child
+ * process and emits the `error` event later, asynchronously. By
+ * then the CLI has already printed "Opening via xdg-open" and
+ * exited, so the user sees a lie. Codex review on commit 4 caught
+ * this: `PATH=/usr/bin node bundle/cli.js dashboard` on a host
+ * without xdg-open would still claim it opened the browser.
+ *
+ * Pure: no subprocess. POSIX semantics on linux/darwin (PATH split
+ * on `:`, no extension), Windows semantics on win32 (PATH split on
+ * `;`, PATHEXT-driven extension search, case-insensitive matters
+ * less because the filesystem handles it).
+ */
+export function findBinaryOnPath(name: string): string | null {
+  const PATH = process.env.PATH ?? "";
+  if (!PATH) return null;
+  const isWin = nodePlatform() === "win32";
+  const exts = isWin
+    ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").map(e => e.trim()).filter(Boolean)
+    : [""];
+  for (const dir of PATH.split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = join(dir, name + ext);
+      try {
+        const st = statSync(candidate);
+        if (st.isFile()) return candidate;
+      } catch {
+        // not there; keep looking
+      }
+    }
+  }
+  return null;
+}
+
 export interface OpenInBrowserOptions {
   /** Override platform detection. Tests only — production callers
    *  let `resolveOpenPlatform()` decide. */
@@ -61,6 +100,10 @@ export interface OpenInBrowserOptions {
   /** Injected spawner. Tests substitute this to avoid touching the
    *  real child_process. Default: node:child_process spawn. */
   spawner?: typeof spawn;
+  /** Predicate for "is this helper installed?". Tests stub it to
+   *  emulate environments with/without xdg-open. Defaults to
+   *  findBinaryOnPath. */
+  binaryExists?: (cmd: string) => boolean;
 }
 
 /**
@@ -83,12 +126,19 @@ export function openInBrowser(
   if (!p) return { attempted: false };
 
   const { command, args } = openCommandFor(p, path);
+  const exists = opts.binaryExists ?? ((cmd: string) => findBinaryOnPath(cmd) !== null);
+  // Pre-check PATH because spawn() never throws synchronously for a
+  // missing binary — it'd lie to the caller (and the user) about
+  // having launched the helper.
+  if (!exists(command)) return { attempted: false };
+
   const useSpawn = opts.spawner ?? spawn;
   try {
     const child = useSpawn(command, args, { stdio: "ignore", detached: true });
-    // The child errors AFTER spawn() returns (e.g. helper not on PATH).
-    // We don't want that to crash the parent; swallowing here is the
-    // contract: "best-effort, user already has the path on stdout".
+    // Defense-in-depth: even with PATH pre-check, the helper might
+    // crash on launch (permissions, broken alias). Swallow that —
+    // the CLI already printed the file path to stdout, so the user
+    // can open it manually.
     child.on("error", () => { /* best-effort */ });
     if (typeof (child as { unref?: () => void }).unref === "function") {
       child.unref();

--- a/src/dashboard/open.ts
+++ b/src/dashboard/open.ts
@@ -1,0 +1,100 @@
+/**
+ * Cross-platform "open this file in the default application" helper.
+ *
+ * Used by `hivemind dashboard` to launch the generated HTML in the
+ * user's browser. Best-effort by design — when we can't open it (no
+ * GUI, unknown OS, missing helper binary), the dashboard command
+ * still wrote the file to disk and surfaced the path on stdout, so
+ * the user can open it manually.
+ *
+ * The pure functions (`resolveOpenPlatform`, `openCommandFor`) are
+ * exported so tests can assert the platform mapping without
+ * monkey-patching child_process.
+ */
+
+import { spawn } from "node:child_process";
+import { platform as nodePlatform } from "node:os";
+
+export type OpenPlatform = "linux" | "darwin" | "win32";
+
+/** Map node's platform string to the subset we know how to open on.
+ *  Returns null for platforms (aix, freebsd, sunos, ...) where the
+ *  helper conventions vary too much to guess. */
+export function resolveOpenPlatform(): OpenPlatform | null {
+  const p = nodePlatform();
+  if (p === "linux" || p === "darwin" || p === "win32") return p;
+  return null;
+}
+
+export interface OpenCommand {
+  command: string;
+  args: string[];
+}
+
+/** Per-platform invocation. Pure — easy to test the matrix without
+ *  spawning anything. Windows uses `cmd /c start "" <path>`; the
+ *  empty `""` is the window title argument that `start` requires
+ *  when its first quoted arg is a path. Without it, `start "C:\..."`
+ *  treats the path AS a window title and opens a new shell. */
+export function openCommandFor(p: OpenPlatform, path: string): OpenCommand {
+  switch (p) {
+    case "linux":
+      return { command: "xdg-open", args: [path] };
+    case "darwin":
+      return { command: "open", args: [path] };
+    case "win32":
+      return { command: "cmd", args: ["/c", "start", "", path] };
+  }
+}
+
+export interface OpenResult {
+  /** Did we try to spawn a helper? false on unknown OS. */
+  attempted: boolean;
+  /** Which helper we spawned, when attempted. */
+  command?: string;
+}
+
+export interface OpenInBrowserOptions {
+  /** Override platform detection. Tests only — production callers
+   *  let `resolveOpenPlatform()` decide. */
+  platformOverride?: OpenPlatform | null;
+  /** Injected spawner. Tests substitute this to avoid touching the
+   *  real child_process. Default: node:child_process spawn. */
+  spawner?: typeof spawn;
+}
+
+/**
+ * Spawn the platform's "open <path>" helper, detached so the parent
+ * CLI exits immediately. Errors are swallowed:
+ *   - spawn throws (ENOENT, etc.) → return attempted=false
+ *   - spawn succeeds then child errors (helper missing) → ignored
+ *     via the on('error') handler — we already returned.
+ *
+ * The detached + unref pattern lets the helper survive the parent
+ * exit on POSIX. Windows doesn't need unref but it's harmless.
+ */
+export function openInBrowser(
+  path: string,
+  opts: OpenInBrowserOptions = {},
+): OpenResult {
+  const p = opts.platformOverride === undefined
+    ? resolveOpenPlatform()
+    : opts.platformOverride;
+  if (!p) return { attempted: false };
+
+  const { command, args } = openCommandFor(p, path);
+  const useSpawn = opts.spawner ?? spawn;
+  try {
+    const child = useSpawn(command, args, { stdio: "ignore", detached: true });
+    // The child errors AFTER spawn() returns (e.g. helper not on PATH).
+    // We don't want that to crash the parent; swallowing here is the
+    // contract: "best-effort, user already has the path on stdout".
+    child.on("error", () => { /* best-effort */ });
+    if (typeof (child as { unref?: () => void }).unref === "function") {
+      child.unref();
+    }
+    return { attempted: true, command };
+  } catch {
+    return { attempted: false };
+  }
+}

--- a/src/dashboard/render.ts
+++ b/src/dashboard/render.ts
@@ -1,0 +1,386 @@
+/**
+ * HTML rendering for `hivemind dashboard`.
+ *
+ * Pure string-builder: takes the DashboardData envelope produced by
+ * `./data.ts` and returns a fully self-contained HTML document. No
+ * imports of node:fs, no fetches, no DOM dependencies — every test
+ * can call this with a fixture and inspect the output.
+ *
+ * Dependency on the network is limited to one CDN-hosted script tag
+ * (vis-network ~150 KB minified). Picked vis-network over D3 because:
+ *
+ *   - One include, one constructor call — no D3 layout boilerplate.
+ *   - Handles 1k+ nodes with reasonable physics out of the box.
+ *   - Built-in zoom / pan / drag / hover tooltip.
+ *
+ * The graphify-shape snapshot is transformed into vis-network's
+ * `{ nodes, edges }` here (not in `./data.ts`) so the data layer stays
+ * data-shape-agnostic and the renderer owns its own UI concerns.
+ *
+ * Security: every string that originates from outside (project name,
+ * repo_key, snapshot JSON, file paths) goes through `escHtml` before
+ * landing in markup, or through `safeJsonForScript` before landing in
+ * an embedded `<script type="application/json">` block. We never use
+ * `<script>VAR = ...</script>` injection — the embedded JSON is parsed
+ * by a separate inline script, so a malicious `</script>` substring in
+ * data can't escape the JSON container even if it's not pre-escaped
+ * (we escape it anyway as defense-in-depth).
+ */
+
+import type { DashboardData, DashboardKpis } from "./data.js";
+
+const VIS_NETWORK_CDN = "https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js";
+
+/**
+ * Node-kind colors aligned to graphify-style palette. Each kind gets a
+ * distinct hue at low saturation so the dark background is comfortable
+ * to look at for more than a few seconds.
+ */
+const KIND_COLORS: Record<string, string> = {
+  function: "#7aa2f7", // soft blue
+  class: "#bb9af7",    // purple
+  method: "#9ece6a",   // green
+  interface: "#e0af68", // amber
+  type_alias: "#7dcfff", // cyan
+  enum: "#f7768e",      // pink
+  const: "#9d7cd8",     // muted purple
+  module: "#565f89",    // slate
+};
+const DEFAULT_NODE_COLOR = "#565f89";
+
+interface VisNode {
+  id: string;
+  label: string;
+  title: string;
+  group?: string;
+  color?: { background: string; border: string };
+}
+
+interface VisEdge {
+  from: string;
+  to: string;
+  title: string;
+  /** Showing edge labels gets noisy past ~50 edges; we omit by default. */
+  label?: string;
+}
+
+interface RawSnapshot {
+  nodes?: unknown;
+  links?: unknown;
+}
+
+interface RawNode {
+  id?: unknown;
+  label?: unknown;
+  kind?: unknown;
+  source_file?: unknown;
+  source_location?: unknown;
+}
+
+interface RawEdge {
+  source?: unknown;
+  target?: unknown;
+  relation?: unknown;
+  confidence?: unknown;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+/** Build the vis-network `{ nodes, edges }` payload from a graphify-shape
+ *  snapshot. Defensive: any node missing an `id` is dropped; any edge
+ *  whose endpoint id doesn't match a known node is dropped. The
+ *  rendered graph stays consistent even if the snapshot was generated
+ *  by an older schema. */
+export function transformSnapshotToVis(snapshot: unknown): { nodes: VisNode[]; edges: VisEdge[] } {
+  if (!isObject(snapshot)) return { nodes: [], edges: [] };
+  const raw = snapshot as RawSnapshot;
+
+  const visNodes: VisNode[] = [];
+  const ids = new Set<string>();
+  if (Array.isArray(raw.nodes)) {
+    for (const n of raw.nodes) {
+      if (!isObject(n)) continue;
+      const node = n as RawNode;
+      const id = asString(node.id);
+      if (!id) continue;
+      if (ids.has(id)) continue; // dedup defensively — snapshot.ts sorts but doesn't dedup
+      ids.add(id);
+
+      const label = asString(node.label) ?? id;
+      const kind = asString(node.kind);
+      const sourceFile = asString(node.source_file);
+      const sourceLoc = asString(node.source_location);
+      const titleParts: string[] = [];
+      if (kind) titleParts.push(kind);
+      if (sourceFile) {
+        const loc = sourceLoc ? `${sourceFile}:${sourceLoc}` : sourceFile;
+        titleParts.push(loc);
+      }
+      const color = kind && KIND_COLORS[kind] ? KIND_COLORS[kind] : DEFAULT_NODE_COLOR;
+      visNodes.push({
+        id,
+        label,
+        title: titleParts.length > 0 ? titleParts.join(" · ") : id,
+        group: kind ?? undefined,
+        color: { background: color, border: color },
+      });
+    }
+  }
+
+  const visEdges: VisEdge[] = [];
+  if (Array.isArray(raw.links)) {
+    for (const l of raw.links) {
+      if (!isObject(l)) continue;
+      const edge = l as RawEdge;
+      const from = asString(edge.source);
+      const to = asString(edge.target);
+      if (!from || !to) continue;
+      // Don't filter on `ids.has(...)` — Phase 1 emits edges with
+      // unresolved targets (cross-file calls), and surfacing those as
+      // dangling endpoints is useful information for the viewer.
+      // vis-network auto-creates ghost nodes for unknown endpoints.
+      const relation = asString(edge.relation);
+      const confidence = asString(edge.confidence);
+      const titleParts: string[] = [];
+      if (relation) titleParts.push(relation);
+      if (confidence) titleParts.push(`[${confidence}]`);
+      visEdges.push({
+        from,
+        to,
+        title: titleParts.length > 0 ? titleParts.join(" ") : `${from} → ${to}`,
+      });
+    }
+  }
+
+  return { nodes: visNodes, edges: visEdges };
+}
+
+/** HTML-attribute / text-content escape. Covers the five chars browsers
+ *  may interpret inside markup. Skips `'` deliberately — every attribute
+ *  in the rendered output uses double-quote delimiters. */
+export function escHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Serialize a value for embedding inside
+ *  `<script type="application/json">...</script>`. The standard JSON
+ *  output is HTML-safe EXCEPT for the literal substring `</`, which
+ *  would close the script tag prematurely. Replace it with `<\/` —
+ *  still valid JSON, no longer breaks out. Also escape `<!--` and
+ *  `-->` as defense against HTML comment confusion. */
+export function safeJsonForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/<\//g, "<\\/")
+    .replace(/<!--/g, "<\\!--")
+    .replace(/-->/g, "--\\>");
+}
+
+/** 1234 → "1.2k", 12345 → "12.3k", 1234567 → "1.2M". Caller decides
+ *  whether to prepend "~". 0 and negative produce "0" so the UI never
+ *  shows a misleading "-1k saved". */
+export function formatTokensCompact(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "0";
+  if (n < 1000) return `${Math.round(n)}`;
+  if (n < 100_000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1_000_000) return `${Math.round(n / 1000)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+/** 42000 → "42,000". en-US grouping; matches primary-banner's body line. */
+export function formatInt(n: number): string {
+  if (!Number.isFinite(n)) return "0";
+  return Math.round(n).toLocaleString("en-US");
+}
+
+function renderKpiCards(kpis: DashboardKpis): string {
+  const tokensValue = kpis.tokensSaved == null
+    ? "—"
+    : `~${formatTokensCompact(kpis.tokensSaved)}`;
+  const tokensSub = (() => {
+    if (kpis.tokensSource === "org") {
+      return kpis.userTokensSaved != null
+        ? `Org-wide · you ~${formatTokensCompact(kpis.userTokensSaved)}`
+        : "Org-wide";
+    }
+    if (kpis.tokensSource === "local") return "Local (this machine)";
+    return "Run a session to start tracking";
+  })();
+
+  const memoryValue = kpis.memorySearches > 0
+    ? formatInt(kpis.memorySearches)
+    : kpis.tokensSource === "none" ? "—" : "0";
+
+  const sessionsValue = kpis.sessionsCount == null
+    ? "—"
+    : formatInt(kpis.sessionsCount);
+
+  const cards = [
+    {
+      label: "Tokens saved",
+      value: tokensValue,
+      sub: tokensSub,
+    },
+    {
+      label: "Skills created",
+      value: formatInt(kpis.skillsCreated),
+      sub: "~/.claude/skills/",
+    },
+    {
+      label: "Memory recalls",
+      value: memoryValue,
+      sub: kpis.tokensSource === "org" ? "Org-wide" : kpis.tokensSource === "local" ? "Local" : "",
+    },
+    {
+      label: "Sessions",
+      value: sessionsValue,
+      sub: kpis.tokensSource === "org" ? "Org-wide" : kpis.tokensSource === "local" ? "Local" : "",
+    },
+  ];
+
+  return cards.map(c => `
+        <div class="kpi">
+          <div class="kpi-label">${escHtml(c.label)}</div>
+          <div class="kpi-value">${escHtml(c.value)}</div>
+          <div class="kpi-sub">${escHtml(c.sub)}</div>
+        </div>`).join("");
+}
+
+function renderGraphSection(data: DashboardData): string {
+  if (data.graph == null) {
+    return `
+      <div class="graph-card">
+        <h2>Codebase graph</h2>
+        <div class="empty">
+          No graph snapshot yet for this repo.<br>
+          Run <code>hivemind graph build</code> to generate one.
+        </div>
+      </div>`;
+  }
+
+  const visPayload = transformSnapshotToVis(data.graph.snapshot);
+  const commitLabel = data.graph.commitSha
+    ? `commit ${data.graph.commitSha.slice(0, 12)}`
+    : "no commit (loose dir)";
+  const meta = `${formatInt(data.graph.nodeCount)} nodes · ${formatInt(data.graph.edgeCount)} edges · ${commitLabel}`;
+
+  return `
+      <div class="graph-card">
+        <h2>Codebase graph</h2>
+        <div class="graph-meta">${escHtml(meta)}</div>
+        <div id="graph"></div>
+      </div>
+      <script type="application/json" id="hm-graph-data">${safeJsonForScript(visPayload)}</script>
+      <script src="${VIS_NETWORK_CDN}"></script>
+      <script>
+        (function () {
+          var holder = document.getElementById('hm-graph-data');
+          var container = document.getElementById('graph');
+          if (!holder || !container || typeof vis === 'undefined') return;
+          var payload;
+          try { payload = JSON.parse(holder.textContent); }
+          catch (e) { container.textContent = 'graph payload parse failed'; return; }
+          if (!payload || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
+            container.textContent = 'snapshot has no nodes';
+            return;
+          }
+          new vis.Network(container, payload, {
+            nodes: {
+              shape: 'dot',
+              size: 9,
+              font: { color: '#e8eaed', size: 11, face: 'system-ui, sans-serif' },
+              borderWidth: 1,
+            },
+            edges: {
+              color: { color: 'rgba(120, 130, 150, 0.45)', highlight: '#f5b80a', hover: '#e8eaed' },
+              arrows: { to: { enabled: true, scaleFactor: 0.45 } },
+              smooth: { enabled: true, type: 'continuous', roundness: 0.2 },
+              width: 1,
+            },
+            physics: {
+              stabilization: { iterations: 120 },
+              barnesHut: { gravitationalConstant: -2200, springLength: 80, springConstant: 0.04 },
+            },
+            interaction: { hover: true, dragNodes: true, tooltipDelay: 120 },
+          });
+        }());
+      </script>`;
+}
+
+const STYLES = `
+        :root {
+          color-scheme: dark;
+          --bg: #0b0d10;
+          --fg: #e8eaed;
+          --muted: #8b9099;
+          --accent: #f5b80a;
+          --card: #15181d;
+          --border: #22272e;
+        }
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+          font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+          background: var(--bg);
+          color: var(--fg);
+          padding: 24px;
+        }
+        .header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 24px; gap: 16px; flex-wrap: wrap; }
+        .brand { font-weight: 600; font-size: 18px; }
+        .brand .bee { color: var(--accent); margin-right: 4px; }
+        .brand .repo { color: var(--muted); font-weight: 400; margin-left: 8px; }
+        .header .ts { color: var(--muted); font-size: 12px; }
+        .kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-bottom: 32px; }
+        .kpi { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px 20px; }
+        .kpi-label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+        .kpi-value { font-size: 28px; font-weight: 600; margin-top: 6px; line-height: 1.1; }
+        .kpi-sub { color: var(--muted); font-size: 12px; margin-top: 4px; }
+        .graph-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+        .graph-card h2 { margin: 0 0 8px; font-size: 15px; font-weight: 500; }
+        .graph-meta { color: var(--muted); font-size: 12px; margin-bottom: 12px; }
+        #graph { height: 70vh; border: 1px solid var(--border); border-radius: 4px; background: #0e1116; }
+        .empty { padding: 48px 16px; text-align: center; color: var(--muted); }
+        .empty code { background: #1c2128; padding: 2px 6px; border-radius: 3px; color: var(--fg); font-family: ui-monospace, "SFMono-Regular", monospace; }
+        .footer { color: var(--muted); font-size: 11px; margin-top: 24px; text-align: right; }
+`;
+
+/**
+ * Build the complete dashboard HTML document. Pure: deterministic on
+ * the input (no Date.now() reads — `data.generatedAt` is the only
+ * timestamp surfaced, and the caller pre-stamps it).
+ */
+export function renderDashboardHtml(data: DashboardData): string {
+  const title = `Hivemind Dashboard · ${data.repoProject}`;
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${escHtml(title)}</title>
+    <style>${STYLES}</style>
+  </head>
+  <body>
+    <div class="header">
+      <div class="brand">
+        <span class="bee">\u{1F41D}</span>hivemind dashboard
+        <span class="repo">/ ${escHtml(data.repoProject)}</span>
+      </div>
+      <div class="ts">${escHtml(data.generatedAt)}</div>
+    </div>
+    <div class="kpi-grid">${renderKpiCards(data.kpis)}
+    </div>
+    ${renderGraphSection(data)}
+    <div class="footer">repo_key ${escHtml(data.repoKey)}</div>
+  </body>
+</html>
+`;
+}

--- a/src/dashboard/render.ts
+++ b/src/dashboard/render.ts
@@ -123,10 +123,17 @@ export function transformSnapshotToVis(snapshot: unknown): { nodes: VisNode[]; e
         titleParts.push(loc);
       }
       const color = kind && KIND_COLORS[kind] ? KIND_COLORS[kind] : DEFAULT_NODE_COLOR;
+      // vis-network renders `title` as HTML, NOT text — so any markup
+      // in a snapshot id / source_file / source_location would execute
+      // on hover. Pre-escape every component that lands in a tooltip
+      // string. Labels are passed to the canvas-rendered node face
+      // and are text-only by vis design, so they don't need this.
       visNodes.push({
         id,
         label,
-        title: titleParts.length > 0 ? titleParts.join(" · ") : id,
+        title: titleParts.length > 0
+          ? titleParts.map(escHtml).join(" · ")
+          : escHtml(id),
         group: kind ?? undefined,
         color: { background: color, border: color },
       });
@@ -150,10 +157,15 @@ export function transformSnapshotToVis(snapshot: unknown): { nodes: VisNode[]; e
       const titleParts: string[] = [];
       if (relation) titleParts.push(relation);
       if (confidence) titleParts.push(`[${confidence}]`);
+      // Same HTML-in-tooltip concern as nodes; escape every component
+      // that ends up in vis-network's `title`. The fallback string
+      // includes node ids, which are also potentially attacker-controlled.
       visEdges.push({
         from,
         to,
-        title: titleParts.length > 0 ? titleParts.join(" ") : `${from} → ${to}`,
+        title: titleParts.length > 0
+          ? titleParts.map(escHtml).join(" ")
+          : `${escHtml(from)} → ${escHtml(to)}`,
       });
     }
   }
@@ -174,15 +186,26 @@ export function escHtml(s: string): string {
 
 /** Serialize a value for embedding inside
  *  `<script type="application/json">...</script>`. The standard JSON
- *  output is HTML-safe EXCEPT for the literal substring `</`, which
- *  would close the script tag prematurely. Replace it with `<\/` —
- *  still valid JSON, no longer breaks out. Also escape `<!--` and
- *  `-->` as defense against HTML comment confusion. */
+ *  output is HTML-safe EXCEPT for three substrings the HTML parser
+ *  can latch onto:
+ *
+ *    - `</` could close the script tag → escape to `<\/` (a valid
+ *      JSON string escape that parses back to "</")
+ *    - `<!--` and `-->` could be reinterpreted as an HTML comment
+ *      inside the script element by legacy / lenient parsers → use
+ *      `!` and `>` (unicode escapes; valid JSON; parse back
+ *      to literal `<!--` and `-->` so callers see the original
+ *      string)
+ *
+ *  Earlier version used `<\!--` and `--\>` literals; those are NOT
+ *  valid JSON escapes (`\!` and `\>` aren't defined) so any snapshot
+ *  string containing `<!--` or `-->` made JSON.parse fail in the
+ *  browser. Codex review on this commit caught it. */
 export function safeJsonForScript(value: unknown): string {
   return JSON.stringify(value)
     .replace(/<\//g, "<\\/")
-    .replace(/<!--/g, "<\\!--")
-    .replace(/-->/g, "--\\>");
+    .replace(/<!--/g, "<\\u0021--")
+    .replace(/-->/g, "--\\u003e");
 }
 
 /** 1234 → "1.2k", 12345 → "12.3k", 1234567 → "1.2M". Caller decides

--- a/src/dashboard/serve.ts
+++ b/src/dashboard/serve.ts
@@ -1,0 +1,163 @@
+/**
+ * Minimal HTTP server for `hivemind dashboard --serve`.
+ *
+ * Why this exists: on headless hosts (VMs over SSH, containers) the
+ * default `xdg-open` path is a no-op — there's no GUI to launch.
+ * Serving the rendered HTML over localhost lets the user click a URL
+ * from their terminal:
+ *
+ *   - VS Code / Cursor Remote-SSH auto-forwards the port and shows
+ *     "Open in browser" notification → opens in the integrated
+ *     Simple Browser tab.
+ *   - Manual SSH users can `ssh -L 8123:localhost:8123` and open in
+ *     their laptop browser.
+ *   - macOS / Linux GUI users: same flow, but the opener also
+ *     launches their default browser at the URL.
+ *
+ * Loopback-only by default: binds to 127.0.0.1 so the dashboard is
+ * not exposed on the LAN even if the user runs it on a dev VM that
+ * has 0.0.0.0 reachable. No --host override in v1; that would be a
+ * footgun against credentials/skills counts that may be sensitive.
+ *
+ * Single route returns the HTML buffer that was rendered when the
+ * server started. Re-running the command is cheap (sub-second);
+ * "refresh while running" semantics are out of scope.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface ServeOptions {
+  /** Fully-rendered HTML returned at GET /. */
+  html: string;
+  /** Preferred port. Defaults to 8123. Pass 0 for an ephemeral port
+   *  chosen by the kernel (tests use this). */
+  port?: number;
+  /** Bind address. Defaults to 127.0.0.1 (loopback). */
+  host?: string;
+}
+
+export interface ServeHandle {
+  /** Actual bound port. Differs from the requested port when the
+   *  caller passed 0, or when the preferred port was EADDRINUSE and
+   *  we fell back to an ephemeral one. */
+  port: number;
+  /** Bind address — surfaced so the caller can print the URL. */
+  host: string;
+  /** Resolves when the server stops listening (Ctrl+C, manual close). */
+  stopped: Promise<void>;
+  /** Stop serving. Promise resolves once all in-flight connections drain. */
+  close(): Promise<void>;
+}
+
+const DEFAULT_PORT = 8123;
+const DEFAULT_HOST = "127.0.0.1";
+
+function handleRequest(html: string) {
+  return (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? "/";
+    // Strip the query string before route matching — `/?refresh=1` is
+    // still the dashboard root, not a 404.
+    const path = url.split("?")[0];
+    if (req.method === "GET" && (path === "/" || path === "/index.html")) {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      res.end(html);
+      return;
+    }
+    if (req.method === "GET" && path === "/health") {
+      // Plain probe surface for future "is the dashboard up?" checks
+      // (e.g. a Cursor port-forward readiness gate).
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Not found. The dashboard lives at /.\n");
+  };
+}
+
+/**
+ * Bind `server` on `host:port`. Surfaces the actual port the kernel
+ * assigned (`address().port`) — needed when caller passed 0. Errors
+ * other than EADDRINUSE bubble; EADDRINUSE is handled one level up
+ * via the explicit fallback in serveDashboardHtml.
+ */
+function tryListen(server: Server, host: string, port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => {
+      server.off("listening", onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      const addr = server.address() as AddressInfo | string | null;
+      if (!addr || typeof addr === "string") {
+        // Unix-domain-socket bind doesn't apply here — we always
+        // requested a TCP host:port — but the type union includes it,
+        // so guard for the compiler and for the impossible-but-loud case.
+        reject(new Error("server bound to a non-IP address"));
+        return;
+      }
+      resolve(addr.port);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+/**
+ * Start a dashboard server. Resolves once it's bound and ready.
+ *
+ * Port resolution order:
+ *   1. caller-supplied opts.port
+ *   2. on EADDRINUSE, fall back to port 0 (kernel-assigned)
+ *   3. other errors propagate (e.g. EACCES on privileged ports)
+ */
+export async function serveDashboardHtml(opts: ServeOptions): Promise<ServeHandle> {
+  const host = opts.host ?? DEFAULT_HOST;
+  const requested = (opts.port === undefined || !Number.isFinite(opts.port) || opts.port < 0)
+    ? DEFAULT_PORT
+    : opts.port;
+
+  const server = createServer(handleRequest(opts.html));
+
+  let bound: number;
+  try {
+    bound = await tryListen(server, host, requested);
+  } catch (e: any) {
+    if (e?.code !== "EADDRINUSE") throw e;
+    // Fresh server instance — the previous one already errored and is
+    // in a poisoned state. createServer is cheap.
+    const fallback = createServer(handleRequest(opts.html));
+    bound = await tryListen(fallback, host, 0);
+    // Swap the binding into the var the handle closes over so the
+    // caller's `close()` actually closes the bound server.
+    server.removeAllListeners();
+    return makeHandle(fallback, host, bound);
+  }
+
+  return makeHandle(server, host, bound);
+}
+
+function makeHandle(server: Server, host: string, port: number): ServeHandle {
+  let resolveStopped!: () => void;
+  const stopped = new Promise<void>(resolve => {
+    resolveStopped = resolve;
+  });
+  // 'close' fires after server.close() AND after every active
+  // connection finishes (or is destroyed). It's the right "stopped"
+  // signal — distinct from 'listening' ending.
+  server.on("close", () => resolveStopped());
+  return {
+    host,
+    port,
+    stopped,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close(err => (err ? reject(err) : resolve()));
+    }),
+  };
+}

--- a/tests/claude-code/dashboard-command.test.ts
+++ b/tests/claude-code/dashboard-command.test.ts
@@ -52,6 +52,13 @@ describe("parseDashboardArgs", () => {
     expect(parseDashboardArgs(["--cwd"]).error).toMatch(/requires a value/);
     expect(parseDashboardArgs(["--out"]).error).toMatch(/requires a value/);
   });
+  it("rejects a flag token used as the value for --cwd / --out", () => {
+    // codex review on commit 4: `--out --no-open` previously wrote a
+    // file called `./--no-open`.
+    expect(parseDashboardArgs(["--cwd", "--no-open"]).error).toMatch(/--cwd requires a value/);
+    expect(parseDashboardArgs(["--out", "--no-open"]).error).toMatch(/--out requires a value/);
+    expect(parseDashboardArgs(["--out", "-foo"]).error).toMatch(/--out requires a value/);
+  });
 });
 
 describe("defaultDashboardOutPath", () => {

--- a/tests/claude-code/dashboard-command.test.ts
+++ b/tests/claude-code/dashboard-command.test.ts
@@ -59,6 +59,21 @@ describe("parseDashboardArgs", () => {
     expect(parseDashboardArgs(["--out", "--no-open"]).error).toMatch(/--out requires a value/);
     expect(parseDashboardArgs(["--out", "-foo"]).error).toMatch(/--out requires a value/);
   });
+  it("parses --serve (default port undefined → server picks 8123)", () => {
+    const r = parseDashboardArgs(["--serve"]);
+    expect(r.args?.serve).toBe(true);
+    expect(r.args?.port).toBeUndefined();
+  });
+  it("parses --port N AND --port=N forms", () => {
+    expect(parseDashboardArgs(["--serve", "--port", "9000"]).args?.port).toBe(9000);
+    expect(parseDashboardArgs(["--serve", "--port=9000"]).args?.port).toBe(9000);
+  });
+  it("rejects non-integer / out-of-range ports", () => {
+    expect(parseDashboardArgs(["--port", "abc"]).error).toMatch(/--port must be an integer/);
+    expect(parseDashboardArgs(["--port", "-1"]).error).toMatch(/--port requires a value/); // - prefix triggers earlier guard
+    expect(parseDashboardArgs(["--port=70000"]).error).toMatch(/--port must be an integer/);
+    expect(parseDashboardArgs(["--port="]).error).toMatch(/--port requires a value/);
+  });
 });
 
 describe("defaultDashboardOutPath", () => {
@@ -169,5 +184,114 @@ describe("runDashboardCommand", () => {
     expect(stderr).toContain("failed to write");
     // No node-style stack trace in the rendered error.
     expect(stderr).not.toContain("at Object.");
+  });
+
+  describe("--serve mode", () => {
+    function makeFakeServer() {
+      let resolveStopped!: () => void;
+      const stopped = new Promise<void>(r => { resolveStopped = r; });
+      const close = vi.fn(async () => { resolveStopped(); });
+      const server = vi.fn(async (_opts: any) => ({
+        host: "127.0.0.1",
+        port: 8123,
+        stopped,
+        close,
+      }));
+      return { server, close, resolveStopped };
+    }
+
+    function makeSignalSink() {
+      let captured: { signal: NodeJS.Signals; handler: () => void } | null = null;
+      const off = vi.fn();
+      const onSignal = vi.fn((signal: NodeJS.Signals, handler: () => void) => {
+        if (signal === "SIGINT") captured = { signal, handler };
+        return off;
+      });
+      return { onSignal, off, fire: () => captured?.handler() };
+    }
+
+    it("starts the server, prints the URL, opens it (URL not path), and exits 0 on SIGINT", async () => {
+      const { server, close } = makeFakeServer();
+      const { onSignal, off, fire } = makeSignalSink();
+      const opener = vi.fn().mockReturnValue({ attempted: true, command: "xdg-open" });
+
+      const runP = runDashboardCommand(
+        ["--cwd", "/tmp", "--serve"],
+        { out, err, opener, server: server as any, onSignal },
+      );
+      // give the runner a microtask to bind handlers
+      await new Promise(r => setImmediate(r));
+      fire(); // simulate Ctrl+C
+      const code = await runP;
+
+      expect(code).toBe(0);
+      expect(server).toHaveBeenCalledWith({ html: expect.any(String), port: undefined });
+      expect(stdout).toContain("Serving dashboard at http://127.0.0.1:8123/");
+      expect(stdout).toContain("Opening via xdg-open");
+      expect(opener).toHaveBeenCalledWith("http://127.0.0.1:8123/");
+      expect(close).toHaveBeenCalled();
+      // both SIGINT and SIGTERM handlers were registered and unregistered
+      expect(onSignal).toHaveBeenCalledTimes(2);
+      expect(off).toHaveBeenCalledTimes(2);
+    });
+
+    it("--serve --no-open does NOT call the opener", async () => {
+      const { server } = makeFakeServer();
+      const { onSignal, fire } = makeSignalSink();
+      const opener = vi.fn();
+
+      const runP = runDashboardCommand(
+        ["--cwd", "/tmp", "--serve", "--no-open"],
+        { out, err, opener, server: server as any, onSignal },
+      );
+      await new Promise(r => setImmediate(r));
+      fire();
+      await runP;
+
+      expect(opener).not.toHaveBeenCalled();
+      expect(stdout).toContain("Serving dashboard at http://127.0.0.1:8123/");
+    });
+
+    it("forwards --port to the server module", async () => {
+      const { server } = makeFakeServer();
+      const { onSignal, fire } = makeSignalSink();
+
+      const runP = runDashboardCommand(
+        ["--cwd", "/tmp", "--serve", "--no-open", "--port", "9090"],
+        { out, err, opener: vi.fn(), server: server as any, onSignal },
+      );
+      await new Promise(r => setImmediate(r));
+      fire();
+      await runP;
+
+      expect(server).toHaveBeenCalledWith({ html: expect.any(String), port: 9090 });
+    });
+
+    it("exits cleanly when the server stops on its own (no SIGINT)", async () => {
+      const { server, resolveStopped } = makeFakeServer();
+      const { onSignal } = makeSignalSink();
+
+      const runP = runDashboardCommand(
+        ["--cwd", "/tmp", "--serve", "--no-open"],
+        { out, err, opener: vi.fn(), server: server as any, onSignal },
+      );
+      await new Promise(r => setImmediate(r));
+      resolveStopped(); // emulate server.close() fired by something else
+      const code = await runP;
+      expect(code).toBe(0);
+    });
+
+    it("returns 1 on server-start failure with a one-line stderr", async () => {
+      const server = vi.fn(async () => { throw new Error("EACCES bind"); });
+      const { onSignal } = makeSignalSink();
+      const code = await runDashboardCommand(
+        ["--cwd", "/tmp", "--serve"],
+        { out, err, opener: vi.fn(), server: server as any, onSignal },
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("failed to start server");
+      expect(stderr).toContain("EACCES");
+      expect(stderr).not.toContain("at Object.");
+    });
   });
 });

--- a/tests/claude-code/dashboard-command.test.ts
+++ b/tests/claude-code/dashboard-command.test.ts
@@ -1,0 +1,166 @@
+/**
+ * End-to-end-ish tests for `hivemind dashboard`. fetchOrgStats is
+ * mocked at the module boundary; everything else (data loading,
+ * rendering, file IO) runs for real against tmpdir + overridden
+ * HOME. The opener is injected as a stub so no browser actually
+ * launches during tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { orgStatsMock } = vi.hoisted(() => ({ orgStatsMock: vi.fn() }));
+vi.mock("../../src/notifications/sources/org-stats.js", () => ({
+  fetchOrgStats: orgStatsMock,
+}));
+
+import {
+  defaultDashboardOutPath,
+  parseDashboardArgs,
+  runDashboardCommand,
+} from "../../src/commands/dashboard.js";
+import { deriveProjectKey } from "../../src/skillify/state.js";
+
+describe("parseDashboardArgs", () => {
+  it("returns help for --help / -h", () => {
+    expect(parseDashboardArgs(["--help"]).help).toBe(true);
+    expect(parseDashboardArgs(["-h"]).help).toBe(true);
+  });
+  it("defaults cwd to process.cwd(), open=true, outPath empty", () => {
+    const r = parseDashboardArgs([]);
+    expect(r.args?.cwd).toBe(process.cwd());
+    expect(r.args?.open).toBe(true);
+    expect(r.args?.outPath).toBe("");
+  });
+  it("parses --no-open", () => {
+    expect(parseDashboardArgs(["--no-open"]).args?.open).toBe(false);
+  });
+  it("parses --cwd <value> AND --cwd=value forms", () => {
+    expect(parseDashboardArgs(["--cwd", "/foo"]).args?.cwd).toBe("/foo");
+    expect(parseDashboardArgs(["--cwd=/bar"]).args?.cwd).toBe("/bar");
+  });
+  it("parses --out <value> AND --out=value forms", () => {
+    expect(parseDashboardArgs(["--out", "/o.html"]).args?.outPath).toBe("/o.html");
+    expect(parseDashboardArgs(["--out=/p.html"]).args?.outPath).toBe("/p.html");
+  });
+  it("errors on unknown flags", () => {
+    expect(parseDashboardArgs(["--nope"]).error).toMatch(/unknown/);
+  });
+  it("errors on a dangling --cwd / --out with no value", () => {
+    expect(parseDashboardArgs(["--cwd"]).error).toMatch(/requires a value/);
+    expect(parseDashboardArgs(["--out"]).error).toMatch(/requires a value/);
+  });
+});
+
+describe("defaultDashboardOutPath", () => {
+  it("lives under HOME/.hivemind/dashboards/<repo-key>/index.html", () => {
+    const home = process.env.HOME ?? "";
+    expect(defaultDashboardOutPath("deadbeef")).toBe(
+      join(home, ".hivemind", "dashboards", "deadbeef", "index.html"),
+    );
+  });
+});
+
+describe("runDashboardCommand", () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+  let stdout: string;
+  let stderr: string;
+  const out = (s: string) => { stdout += s; };
+  const err = (s: string) => { stderr += s; };
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "hm-dash-cli-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    stdout = "";
+    stderr = "";
+    orgStatsMock.mockReset();
+    orgStatsMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("--help prints USAGE and returns 0", async () => {
+    const code = await runDashboardCommand(["--help"], { out, err });
+    expect(code).toBe(0);
+    expect(stdout).toContain("hivemind dashboard");
+    expect(stdout).toContain("Usage:");
+    expect(stderr).toBe("");
+  });
+
+  it("returns 2 and prints USAGE on unknown flag", async () => {
+    const code = await runDashboardCommand(["--bogus"], { out, err });
+    expect(code).toBe(2);
+    expect(stderr).toContain("unknown arg");
+    expect(stderr).toContain("Usage:");
+  });
+
+  it("writes the HTML to the default path under HOME and reports it", async () => {
+    const opener = vi.fn().mockReturnValue({ attempted: true, command: "xdg-open" });
+    const code = await runDashboardCommand(["--cwd", "/tmp"], { out, err, opener });
+    expect(code).toBe(0);
+    const { key } = deriveProjectKey("/tmp");
+    const expectedPath = join(homeDir, ".hivemind", "dashboards", key, "index.html");
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(stdout).toContain(`Wrote ${expectedPath}`);
+    expect(stdout).toContain("Opening via xdg-open");
+    const html = readFileSync(expectedPath, "utf-8");
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("hivemind dashboard");
+    // Empty-state for graph because we never built one
+    expect(html).toContain("No graph snapshot yet");
+    // Empty-state for KPIs because no creds and no usage stats
+    expect(html).toContain("Run a session to start tracking");
+  });
+
+  it("respects --out and writes to the requested path", async () => {
+    const outPath = join(homeDir, "custom", "dash.html");
+    const opener = vi.fn().mockReturnValue({ attempted: false });
+    const code = await runDashboardCommand(
+      ["--cwd", "/tmp", "--out", outPath, "--no-open"],
+      { out, err, opener },
+    );
+    expect(code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+    expect(opener).not.toHaveBeenCalled();
+    expect(stdout).not.toContain("Opening via");
+  });
+
+  it("--no-open does NOT call the opener", async () => {
+    const opener = vi.fn();
+    await runDashboardCommand(["--cwd", "/tmp", "--no-open"], { out, err, opener });
+    expect(opener).not.toHaveBeenCalled();
+  });
+
+  it("reports the 'open manually' line when the opener returns attempted=false", async () => {
+    const opener = vi.fn().mockReturnValue({ attempted: false });
+    await runDashboardCommand(["--cwd", "/tmp"], { out, err, opener });
+    expect(stdout).toContain("no opener for this platform");
+  });
+
+  it("surfaces a runtime write failure as a one-line stderr instead of a stack", async () => {
+    // --out points at a child of an existing FILE (not a directory).
+    // mkdir -p there fails with ENOTDIR; the catch block must convert
+    // that into a one-liner rather than letting node print a stack.
+    const { writeFileSync } = await import("node:fs");
+    const fileMasqueradingAsDir = join(homeDir, "iamafile");
+    writeFileSync(fileMasqueradingAsDir, "x");
+    const bogusOut = join(fileMasqueradingAsDir, "nested", "dash.html");
+
+    const code = await runDashboardCommand(
+      ["--cwd", "/tmp", "--out", bogusOut, "--no-open"],
+      { out, err, opener: vi.fn() },
+    );
+    expect(code).toBe(1);
+    expect(stderr).toContain("failed to write");
+    // No node-style stack trace in the rendered error.
+    expect(stderr).not.toContain("at Object.");
+  });
+});

--- a/tests/claude-code/dashboard-command.test.ts
+++ b/tests/claude-code/dashboard-command.test.ts
@@ -69,10 +69,16 @@ describe("parseDashboardArgs", () => {
     expect(parseDashboardArgs(["--serve", "--port=9000"]).args?.port).toBe(9000);
   });
   it("rejects non-integer / out-of-range ports", () => {
-    expect(parseDashboardArgs(["--port", "abc"]).error).toMatch(/--port must be an integer/);
-    expect(parseDashboardArgs(["--port", "-1"]).error).toMatch(/--port requires a value/); // - prefix triggers earlier guard
-    expect(parseDashboardArgs(["--port=70000"]).error).toMatch(/--port must be an integer/);
-    expect(parseDashboardArgs(["--port="]).error).toMatch(/--port requires a value/);
+    expect(parseDashboardArgs(["--serve", "--port", "abc"]).error).toMatch(/--port must be an integer/);
+    expect(parseDashboardArgs(["--serve", "--port", "-1"]).error).toMatch(/--port requires a value/); // - prefix triggers earlier guard
+    expect(parseDashboardArgs(["--serve", "--port=70000"]).error).toMatch(/--port must be an integer/);
+    expect(parseDashboardArgs(["--serve", "--port="]).error).toMatch(/--port requires a value/);
+  });
+  it("rejects --port unless --serve is also passed (codex review on serve commit)", () => {
+    expect(parseDashboardArgs(["--port", "9000"]).error).toMatch(/--port requires --serve/);
+    expect(parseDashboardArgs(["--port=9000"]).error).toMatch(/--port requires --serve/);
+    // sanity: with --serve it parses cleanly
+    expect(parseDashboardArgs(["--serve", "--port", "9000"]).error).toBeUndefined();
   });
 });
 

--- a/tests/claude-code/dashboard-data.test.ts
+++ b/tests/claude-code/dashboard-data.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for the dashboard data layer. Mocks fetchOrgStats at the
+ * module boundary (matches the pattern used in
+ * notifications-primary-banner.test.ts) and uses HOME + graphsHome
+ * overrides so no test touches the real user filesystem.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { orgStatsMock } = vi.hoisted(() => ({ orgStatsMock: vi.fn() }));
+vi.mock("../../src/notifications/sources/org-stats.js", () => ({
+  fetchOrgStats: orgStatsMock,
+}));
+
+import { loadDashboardData } from "../../src/dashboard/data.js";
+import { deriveProjectKey } from "../../src/skillify/state.js";
+
+function snapshotsDirFor(graphsHome: string, cwd: string): { repoDir: string; snapshotsDir: string } {
+  const { key } = deriveProjectKey(cwd);
+  const repoDir = join(graphsHome, key);
+  return { repoDir, snapshotsDir: join(repoDir, "snapshots") };
+}
+
+describe("loadDashboardData", () => {
+  let graphsHome: string;
+  let homeDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    graphsHome = mkdtempSync(join(tmpdir(), "hm-dash-graphs-"));
+    homeDir = mkdtempSync(join(tmpdir(), "hm-dash-home-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    orgStatsMock.mockReset();
+    orgStatsMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(graphsHome, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("returns graph=null when no snapshots/ dir exists for the repo", async () => {
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).toBeNull();
+    expect(result.kpis.tokensSource).toBe("none");
+    expect(result.kpis.tokensSaved).toBeNull();
+    expect(result.kpis.skillsCreated).toBe(0);
+    expect(result.repoKey).toMatch(/^[0-9a-f]{16}$/);
+    expect(typeof result.repoProject).toBe("string");
+  });
+
+  it("loads snapshot pointed to by latest-commit.txt", async () => {
+    const { repoDir, snapshotsDir } = snapshotsDirFor(graphsHome, "/tmp");
+    mkdirSync(snapshotsDir, { recursive: true });
+    const snapshot = {
+      directed: true,
+      multigraph: true,
+      graph: { commit_sha: "abc123", repo_key: "ignored" },
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      links: [
+        { source: "a", target: "b", relation: "calls" },
+        { source: "b", target: "c", relation: "imports" },
+      ],
+    };
+    writeFileSync(join(snapshotsDir, "abc123.json"), JSON.stringify(snapshot));
+    writeFileSync(join(repoDir, "latest-commit.txt"), "abc123\n");
+
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).not.toBeNull();
+    expect(result.graph!.nodeCount).toBe(3);
+    expect(result.graph!.edgeCount).toBe(2);
+    expect(result.graph!.commitSha).toBe("abc123");
+    expect(result.graph!.snapshotPath.endsWith("abc123.json")).toBe(true);
+    expect(result.graph!.snapshot).toEqual(snapshot);
+  });
+
+  it("falls back to newest snapshot when latest-commit.txt is missing", async () => {
+    const { snapshotsDir } = snapshotsDirFor(graphsHome, "/tmp");
+    mkdirSync(snapshotsDir, { recursive: true });
+    const older = { directed: true, multigraph: true, graph: {}, nodes: [{ id: "x" }], links: [] };
+    const newer = { directed: true, multigraph: true, graph: {}, nodes: [{ id: "y" }, { id: "z" }], links: [] };
+    const olderPath = join(snapshotsDir, "older.json");
+    const newerPath = join(snapshotsDir, "newer.json");
+    writeFileSync(olderPath, JSON.stringify(older));
+    // Force older to actually be older — same mtime causes deterministic
+    // tiebreak ambiguity, which the test should not rely on.
+    const past = new Date(Date.now() - 60_000);
+    const futime = (path: string, when: Date) => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { utimesSync } = require("node:fs");
+      utimesSync(path, when, when);
+    };
+    futime(olderPath, past);
+    writeFileSync(newerPath, JSON.stringify(newer));
+
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).not.toBeNull();
+    expect(result.graph!.nodeCount).toBe(2);
+    expect(result.graph!.commitSha).toBeNull();
+    expect(result.graph!.snapshotPath.endsWith("newer.json")).toBe(true);
+  });
+
+  it("falls back from a dangling latest-commit.txt to the snapshot scan", async () => {
+    const { repoDir, snapshotsDir } = snapshotsDirFor(graphsHome, "/tmp");
+    mkdirSync(snapshotsDir, { recursive: true });
+    writeFileSync(join(repoDir, "latest-commit.txt"), "missing-sha\n");
+    const snap = { directed: true, multigraph: true, graph: {}, nodes: [{ id: "p" }], links: [] };
+    writeFileSync(join(snapshotsDir, "actual.json"), JSON.stringify(snap));
+
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).not.toBeNull();
+    expect(result.graph!.nodeCount).toBe(1);
+    expect(result.graph!.snapshotPath.endsWith("actual.json")).toBe(true);
+  });
+
+  it("rejects malformed snapshot shape gracefully (no nodes/links arrays)", async () => {
+    const { snapshotsDir } = snapshotsDirFor(graphsHome, "/tmp");
+    mkdirSync(snapshotsDir, { recursive: true });
+    writeFileSync(join(snapshotsDir, "bad.json"), JSON.stringify({ hello: "world" }));
+
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).toBeNull();
+  });
+
+  it("rejects unparseable snapshot JSON gracefully", async () => {
+    const { snapshotsDir } = snapshotsDirFor(graphsHome, "/tmp");
+    mkdirSync(snapshotsDir, { recursive: true });
+    writeFileSync(join(snapshotsDir, "garbled.json"), "{ not valid json");
+
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.graph).toBeNull();
+  });
+
+  it("uses org stats when fetchOrgStats returns data", async () => {
+    orgStatsMock.mockResolvedValue({
+      org: { sessionsCount: 5, memoryRecallCount: 100, memorySearchBytes: 40_000 },
+      user: { sessionsCount: 2, memoryRecallCount: 50, memorySearchBytes: 20_000 },
+    });
+    const result = await loadDashboardData({
+      cwd: "/tmp",
+      graphsHome,
+      creds: { token: "t", orgId: "o", userName: "user", savedAt: "2026-01-01T00:00:00Z" },
+    });
+    expect(result.kpis.tokensSource).toBe("org");
+    // 40000 / 4 = 10000 delivered; 0.7 * 10000 = 7000 saved
+    expect(result.kpis.tokensSaved).toBe(7000);
+    expect(result.kpis.memorySearches).toBe(100);
+    expect(result.kpis.sessionsCount).toBe(5);
+    // 20000 / 4 = 5000 delivered; 0.7 * 5000 = 3500 saved
+    expect(result.kpis.userTokensSaved).toBe(3500);
+  });
+
+  it("falls back to local stats when fetchOrgStats returns null", async () => {
+    orgStatsMock.mockResolvedValue(null);
+    mkdirSync(join(homeDir, ".deeplake"), { recursive: true });
+    const records = [
+      { endedAt: "2026-01-01T00:00:00Z", sessionId: "a", memorySearchBytes: 8_000, memorySearchCount: 4 },
+      { endedAt: "2026-01-02T00:00:00Z", sessionId: "b", memorySearchBytes: 4_000, memorySearchCount: 2 },
+    ];
+    writeFileSync(
+      join(homeDir, ".deeplake", "usage-stats.jsonl"),
+      records.map(r => JSON.stringify(r)).join("\n") + "\n",
+    );
+
+    const result = await loadDashboardData({
+      cwd: "/tmp",
+      graphsHome,
+      creds: { token: "t", orgId: "o", savedAt: "x" },
+    });
+    expect(result.kpis.tokensSource).toBe("local");
+    // (8000 + 4000) / 4 = 3000 delivered; 0.7 * 3000 = 2100 saved
+    expect(result.kpis.tokensSaved).toBe(2100);
+    expect(result.kpis.memorySearches).toBe(6);
+    expect(result.kpis.sessionsCount).toBe(2);
+    expect(result.kpis.userTokensSaved).toBe(2100);
+  });
+
+  it("returns tokensSource='none' when no creds and no local records", async () => {
+    const result = await loadDashboardData({ cwd: "/tmp", graphsHome, creds: null });
+    expect(result.kpis.tokensSource).toBe("none");
+    expect(result.kpis.tokensSaved).toBeNull();
+    expect(result.kpis.userTokensSaved).toBeNull();
+    expect(result.kpis.sessionsCount).toBeNull();
+  });
+
+  it("treats a fetchOrgStats throw as 'no org data' instead of crashing", async () => {
+    orgStatsMock.mockRejectedValue(new Error("boom"));
+    const result = await loadDashboardData({
+      cwd: "/tmp",
+      graphsHome,
+      creds: { token: "t", orgId: "o", savedAt: "x" },
+    });
+    // No local records either => "none"
+    expect(result.kpis.tokensSource).toBe("none");
+  });
+
+  it("does NOT call fetchOrgStats when creds lack a token", async () => {
+    await loadDashboardData({
+      cwd: "/tmp",
+      graphsHome,
+      creds: { token: "", orgId: "o", savedAt: "x" },
+    });
+    expect(orgStatsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/claude-code/dashboard-open.test.ts
+++ b/tests/claude-code/dashboard-open.test.ts
@@ -138,4 +138,38 @@ describe("findBinaryOnPath", () => {
   it("returns null for a clearly non-existent binary name", () => {
     expect(findBinaryOnPath("definitely-not-a-real-helper-xxx-12345")).toBeNull();
   });
+  it("ignores a same-named non-executable file on PATH (POSIX)", async () => {
+    // Codex/CodeRabbit on PR #194: without an X_OK check, a man page
+    // or sentinel file named the same as the helper would claim
+    // "found". Stage a fake binary that's NOT marked executable and
+    // verify the helper doesn't accept it.
+    if (nodePlatform() !== "linux" && nodePlatform() !== "darwin") return; // skip on win32
+    const { mkdtempSync, writeFileSync, chmodSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "hm-path-probe-"));
+    try {
+      const bin = join(dir, "fake-not-exec-helper-xyz");
+      writeFileSync(bin, "#!/bin/sh\necho hi\n");
+      chmodSync(bin, 0o644); // explicitly NON-executable
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${dir}${":"}${originalPath ?? ""}`;
+      try {
+        expect(findBinaryOnPath("fake-not-exec-helper-xyz")).toBeNull();
+        // Then mark it executable and expect it to be found.
+        chmodSync(bin, 0o755);
+        expect(findBinaryOnPath("fake-not-exec-helper-xyz")).toBe(bin);
+      } finally {
+        if (originalPath === undefined) delete process.env.PATH;
+        else process.env.PATH = originalPath;
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
+
+// Import node:os platform for the conditional skip above. Imported at
+// the bottom because the test block needs it but we don't want it
+// polluting the top of the file for tests that don't reference it.
+import { platform as nodePlatform } from "node:os";

--- a/tests/claude-code/dashboard-open.test.ts
+++ b/tests/claude-code/dashboard-open.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 
 import {
+  findBinaryOnPath,
   openCommandFor,
   openInBrowser,
   resolveOpenPlatform,
@@ -55,6 +56,7 @@ describe("openInBrowser", () => {
     const result = openInBrowser("/tmp/dash.html", {
       platformOverride: "linux",
       spawner: spawner as any,
+      binaryExists: () => true,
     });
     expect(result.attempted).toBe(true);
     expect(result.command).toBe("xdg-open");
@@ -66,20 +68,49 @@ describe("openInBrowser", () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it("returns attempted=false when spawner throws (helper not installed)", () => {
+  it("returns attempted=false WITHOUT spawning when the helper isn't on PATH", () => {
+    // codex review on commit 4: spawn() doesn't throw synchronously
+    // for missing binaries, so the CLI was lying about opening.
+    const spawner = vi.fn();
+    const result = openInBrowser("/tmp/dash.html", {
+      platformOverride: "linux",
+      spawner: spawner as any,
+      binaryExists: () => false,
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.command).toBeUndefined();
+    expect(spawner).not.toHaveBeenCalled();
+  });
+
+  it("passes the platform's helper name to binaryExists", () => {
+    const seen: string[] = [];
+    const binaryExists = (cmd: string) => { seen.push(cmd); return true; };
+    const child = fakeChild();
+    openInBrowser("/x", { platformOverride: "darwin", binaryExists, spawner: vi.fn().mockReturnValue(child) as any });
+    openInBrowser("/x", { platformOverride: "linux",  binaryExists, spawner: vi.fn().mockReturnValue(child) as any });
+    openInBrowser("/x", { platformOverride: "win32",  binaryExists, spawner: vi.fn().mockReturnValue(child) as any });
+    expect(seen).toEqual(["open", "xdg-open", "cmd"]);
+  });
+
+  it("returns attempted=false when spawner throws (defense-in-depth)", () => {
     const spawner = vi.fn(() => { throw new Error("ENOENT xdg-open"); });
     const result = openInBrowser("/tmp/dash.html", {
       platformOverride: "linux",
       spawner: spawner as any,
+      binaryExists: () => true,
     });
     expect(result.attempted).toBe(false);
     expect(result.command).toBeUndefined();
   });
 
-  it("swallows post-spawn 'error' events so a missing helper doesn't crash the CLI", () => {
+  it("swallows post-spawn 'error' events so a flaky helper doesn't crash the CLI", () => {
     const child = fakeChild();
     const spawner = vi.fn().mockReturnValue(child);
-    openInBrowser("/tmp/dash.html", { platformOverride: "darwin", spawner: spawner as any });
+    openInBrowser("/tmp/dash.html", {
+      platformOverride: "darwin",
+      spawner: spawner as any,
+      binaryExists: () => true,
+    });
     // Fire the error AFTER the call returned — the handler attached
     // inside openInBrowser should absorb it without re-throwing.
     expect(() => child.emit("error", new Error("helper crashed"))).not.toThrow();
@@ -91,6 +122,20 @@ describe("openInBrowser", () => {
     expect(() => openInBrowser("/tmp/dash.html", {
       platformOverride: "linux",
       spawner: spawner as any,
+      binaryExists: () => true,
     })).not.toThrow();
+  });
+});
+
+describe("findBinaryOnPath", () => {
+  it("locates a binary that is in PATH (uses /usr/bin/env or /bin/sh as probe)", () => {
+    // Use a binary essentially guaranteed to exist on POSIX hosts and
+    // CI. If neither is present (extremely minimal container) the test
+    // is environment-dependent; in that case skip.
+    const candidate = findBinaryOnPath("sh") ?? findBinaryOnPath("env");
+    expect(candidate).not.toBeNull();
+  });
+  it("returns null for a clearly non-existent binary name", () => {
+    expect(findBinaryOnPath("definitely-not-a-real-helper-xxx-12345")).toBeNull();
   });
 });

--- a/tests/claude-code/dashboard-open.test.ts
+++ b/tests/claude-code/dashboard-open.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the cross-platform open helper. The pure mappings get
+ * exhaustive coverage; the spawn-wrapping `openInBrowser` is tested
+ * via an injected stub so no real child process starts during tests.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+import {
+  openCommandFor,
+  openInBrowser,
+  resolveOpenPlatform,
+} from "../../src/dashboard/open.js";
+
+function fakeChild() {
+  const ee = new EventEmitter() as EventEmitter & { unref: () => void };
+  ee.unref = vi.fn();
+  return ee;
+}
+
+describe("openCommandFor", () => {
+  it("uses xdg-open on linux", () => {
+    expect(openCommandFor("linux", "/x/y.html"))
+      .toEqual({ command: "xdg-open", args: ["/x/y.html"] });
+  });
+  it("uses open on darwin", () => {
+    expect(openCommandFor("darwin", "/x/y.html"))
+      .toEqual({ command: "open", args: ["/x/y.html"] });
+  });
+  it("uses 'cmd /c start \"\" <path>' on win32 to dodge the title-arg trap", () => {
+    expect(openCommandFor("win32", "C:\\x\\y.html"))
+      .toEqual({ command: "cmd", args: ["/c", "start", "", "C:\\x\\y.html"] });
+  });
+});
+
+describe("resolveOpenPlatform", () => {
+  it("returns one of the known platforms when called on this host", () => {
+    const got = resolveOpenPlatform();
+    expect(got === null || got === "linux" || got === "darwin" || got === "win32").toBe(true);
+  });
+});
+
+describe("openInBrowser", () => {
+  it("returns attempted=false when platformOverride is null (unknown OS)", () => {
+    const spawner = vi.fn();
+    const result = openInBrowser("/whatever", { platformOverride: null, spawner: spawner as any });
+    expect(result.attempted).toBe(false);
+    expect(spawner).not.toHaveBeenCalled();
+  });
+
+  it("spawns the linux helper and reports the command name", () => {
+    const child = fakeChild();
+    const spawner = vi.fn().mockReturnValue(child);
+    const result = openInBrowser("/tmp/dash.html", {
+      platformOverride: "linux",
+      spawner: spawner as any,
+    });
+    expect(result.attempted).toBe(true);
+    expect(result.command).toBe("xdg-open");
+    expect(spawner).toHaveBeenCalledWith(
+      "xdg-open",
+      ["/tmp/dash.html"],
+      expect.objectContaining({ stdio: "ignore", detached: true }),
+    );
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it("returns attempted=false when spawner throws (helper not installed)", () => {
+    const spawner = vi.fn(() => { throw new Error("ENOENT xdg-open"); });
+    const result = openInBrowser("/tmp/dash.html", {
+      platformOverride: "linux",
+      spawner: spawner as any,
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.command).toBeUndefined();
+  });
+
+  it("swallows post-spawn 'error' events so a missing helper doesn't crash the CLI", () => {
+    const child = fakeChild();
+    const spawner = vi.fn().mockReturnValue(child);
+    openInBrowser("/tmp/dash.html", { platformOverride: "darwin", spawner: spawner as any });
+    // Fire the error AFTER the call returned — the handler attached
+    // inside openInBrowser should absorb it without re-throwing.
+    expect(() => child.emit("error", new Error("helper crashed"))).not.toThrow();
+  });
+
+  it("works even when the returned child lacks unref (older platforms)", () => {
+    const ee = new EventEmitter() as EventEmitter & { unref?: () => void };
+    const spawner = vi.fn().mockReturnValue(ee);
+    expect(() => openInBrowser("/tmp/dash.html", {
+      platformOverride: "linux",
+      spawner: spawner as any,
+    })).not.toThrow();
+  });
+});

--- a/tests/claude-code/dashboard-render.test.ts
+++ b/tests/claude-code/dashboard-render.test.ts
@@ -248,6 +248,27 @@ describe("renderDashboardHtml", () => {
     expect(html).toContain("Run a session to start tracking");
   });
 
+  it("shows 'Local (this machine)' sub when source=local (no creds, local-only KPIs)", () => {
+    // CodeRabbit nitpick on PR #194: source=org and source=none were
+    // covered; the local-fallback branch wasn't asserted directly.
+    const html = renderDashboardHtml(baseData({
+      kpis: {
+        tokensSaved: 5000,
+        tokensSource: "local",
+        skillsCreated: 2,
+        memorySearches: 10,
+        sessionsCount: 3,
+        userTokensSaved: 5000,
+      },
+    }));
+    expect(html).toContain("~5.0k");
+    expect(html).toContain("Local (this machine)");
+    // Other cards should also reflect the local source label.
+    expect(html).toContain("Local");
+    // And the "Org-wide" copy must NOT appear in local mode.
+    expect(html).not.toContain("Org-wide");
+  });
+
   it("renders graph empty-state when data.graph is null", () => {
     const html = renderDashboardHtml(baseData({ graph: null }));
     expect(html).toContain("No graph snapshot yet for this repo.");

--- a/tests/claude-code/dashboard-render.test.ts
+++ b/tests/claude-code/dashboard-render.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for the dashboard HTML renderer. Pure-function tests
+ * against fixtures — no IO, no mocks. Each test inspects substrings of
+ * the output rather than asserting against a snapshot, so cosmetic
+ * edits to the markup don't break the suite.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DashboardData } from "../../src/dashboard/data.js";
+import {
+  escHtml,
+  formatInt,
+  formatTokensCompact,
+  renderDashboardHtml,
+  safeJsonForScript,
+  transformSnapshotToVis,
+} from "../../src/dashboard/render.js";
+
+function baseData(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    repoKey: "abcdef0123456789",
+    repoProject: "demo-repo",
+    generatedAt: "2026-05-21T00:00:00Z",
+    kpis: {
+      tokensSaved: 7000,
+      tokensSource: "org",
+      skillsCreated: 3,
+      memorySearches: 42,
+      sessionsCount: 5,
+      userTokensSaved: 3500,
+    },
+    graph: {
+      commitSha: "abc123def456789",
+      snapshotPath: "/tmp/x/abc.json",
+      nodeCount: 2,
+      edgeCount: 1,
+      snapshot: {
+        directed: true,
+        multigraph: true,
+        graph: { commit_sha: "abc123def456789" },
+        nodes: [
+          { id: "a", label: "funcA", kind: "function", source_file: "src/a.ts", source_location: "L10" },
+          { id: "b", label: "ClassB", kind: "class", source_file: "src/b.ts", source_location: "L1-50" },
+        ],
+        links: [
+          { source: "a", target: "b", relation: "calls", confidence: "EXTRACTED" },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("escHtml", () => {
+  it("escapes the standard set of HTML-sensitive characters", () => {
+    expect(escHtml(`<a href="x">&</a>`)).toBe("&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;");
+  });
+  it("returns input unchanged when it contains no unsafe characters", () => {
+    expect(escHtml("plain text 123")).toBe("plain text 123");
+  });
+});
+
+describe("safeJsonForScript", () => {
+  it("escapes `</` so a malicious '</script>' substring can't close the tag", () => {
+    const out = safeJsonForScript({ msg: "</script><img src=x>" });
+    expect(out).not.toContain("</script>");
+    expect(out).toContain("<\\/script>");
+  });
+  it("escapes HTML comments to avoid script-block confusion", () => {
+    const out = safeJsonForScript({ a: "<!-- evil -->" });
+    expect(out).not.toContain("<!--");
+    expect(out).not.toContain("-->");
+  });
+  it("round-trips through JSON.parse after unwinding the escape", () => {
+    const value = { a: "</nope>", b: 1, c: ["nested", null] };
+    const escaped = safeJsonForScript(value);
+    // The browser-side parse is JSON.parse(textContent); textContent
+    // returns the literal characters, NOT the escape sequences. So we
+    // emulate by replacing `<\/` with `</` and parsing.
+    const decoded = JSON.parse(escaped.replace(/<\\\//g, "</").replace(/<\\!--/g, "<!--").replace(/--\\>/g, "-->"));
+    expect(decoded).toEqual(value);
+  });
+});
+
+describe("formatTokensCompact", () => {
+  it("returns '0' for non-positive or non-finite inputs", () => {
+    expect(formatTokensCompact(0)).toBe("0");
+    expect(formatTokensCompact(-100)).toBe("0");
+    expect(formatTokensCompact(NaN)).toBe("0");
+    expect(formatTokensCompact(Infinity)).toBe("0");
+  });
+  it("formats sub-1k values as rounded integers", () => {
+    expect(formatTokensCompact(950)).toBe("950");
+  });
+  it("formats 1k-100k with one decimal place", () => {
+    expect(formatTokensCompact(1234)).toBe("1.2k");
+    expect(formatTokensCompact(12345)).toBe("12.3k");
+  });
+  it("formats 100k-1M as rounded thousands", () => {
+    expect(formatTokensCompact(123_456)).toBe("123k");
+  });
+  it("formats 1M+ as decimal millions", () => {
+    expect(formatTokensCompact(2_500_000)).toBe("2.5M");
+  });
+});
+
+describe("formatInt", () => {
+  it("groups with en-US thousands separators", () => {
+    expect(formatInt(42_000)).toBe("42,000");
+    expect(formatInt(0)).toBe("0");
+  });
+  it("rounds non-integers", () => {
+    expect(formatInt(99.6)).toBe("100");
+  });
+  it("returns '0' on non-finite inputs", () => {
+    expect(formatInt(NaN)).toBe("0");
+  });
+});
+
+describe("transformSnapshotToVis", () => {
+  it("maps graphify nodes to vis-network nodes with kind-based color and title", () => {
+    const snapshot = {
+      nodes: [{ id: "n1", label: "myFn", kind: "function", source_file: "src/x.ts", source_location: "L5" }],
+      links: [],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.nodes).toHaveLength(1);
+    expect(out.nodes[0].id).toBe("n1");
+    expect(out.nodes[0].label).toBe("myFn");
+    expect(out.nodes[0].group).toBe("function");
+    expect(out.nodes[0].title).toContain("function");
+    expect(out.nodes[0].title).toContain("src/x.ts:L5");
+    expect(out.nodes[0].color).toBeDefined();
+  });
+  it("maps edges and surfaces relation + confidence in the title", () => {
+    const snapshot = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      links: [{ source: "a", target: "b", relation: "calls", confidence: "EXTRACTED" }],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.edges).toHaveLength(1);
+    expect(out.edges[0].from).toBe("a");
+    expect(out.edges[0].to).toBe("b");
+    expect(out.edges[0].title).toBe("calls [EXTRACTED]");
+  });
+  it("drops nodes without a string id and edges without both endpoints", () => {
+    const snapshot = {
+      nodes: [{ id: "ok" }, { label: "no-id" }, { id: 42 }],
+      links: [{ source: "ok" }, { target: "ok" }, { source: "ok", target: "ok" }],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.nodes.map(n => n.id)).toEqual(["ok"]);
+    expect(out.edges).toHaveLength(1);
+  });
+  it("deduplicates nodes with repeated ids", () => {
+    const snapshot = {
+      nodes: [{ id: "a" }, { id: "a" }, { id: "b" }],
+      links: [],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.nodes.map(n => n.id)).toEqual(["a", "b"]);
+  });
+  it("returns empty arrays for non-object snapshots", () => {
+    expect(transformSnapshotToVis(null)).toEqual({ nodes: [], edges: [] });
+    expect(transformSnapshotToVis("string")).toEqual({ nodes: [], edges: [] });
+    expect(transformSnapshotToVis(42)).toEqual({ nodes: [], edges: [] });
+  });
+  it("keeps edges whose target is not a known node (Phase 1 cross-file)", () => {
+    const snapshot = {
+      nodes: [{ id: "a" }],
+      links: [{ source: "a", target: "external", relation: "calls" }],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.edges).toHaveLength(1);
+    expect(out.edges[0].to).toBe("external");
+  });
+});
+
+describe("renderDashboardHtml", () => {
+  it("produces a valid HTML5 document with the project name in the title", () => {
+    const html = renderDashboardHtml(baseData());
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain("<title>Hivemind Dashboard · demo-repo</title>");
+    expect(html).toContain(`repo_key abcdef0123456789`);
+  });
+
+  it("renders KPI cards with formatted values", () => {
+    const html = renderDashboardHtml(baseData());
+    expect(html).toContain("Tokens saved");
+    expect(html).toContain("~7.0k"); // 7000 → 7.0k
+    expect(html).toContain("Skills created");
+    expect(html).toContain(">3<");
+    expect(html).toContain("Org-wide");
+  });
+
+  it("shows em-dash and 'Run a session' sub when source=none", () => {
+    const html = renderDashboardHtml(baseData({
+      kpis: {
+        tokensSaved: null, tokensSource: "none",
+        skillsCreated: 0, memorySearches: 0,
+        sessionsCount: null, userTokensSaved: null,
+      },
+    }));
+    expect(html).toContain("—");
+    expect(html).toContain("Run a session to start tracking");
+  });
+
+  it("renders graph empty-state when data.graph is null", () => {
+    const html = renderDashboardHtml(baseData({ graph: null }));
+    expect(html).toContain("No graph snapshot yet for this repo.");
+    expect(html).toContain("<code>hivemind graph build</code>");
+    expect(html).not.toContain("hm-graph-data");
+    expect(html).not.toContain("vis-network");
+  });
+
+  it("embeds the graph data, vis-network script tag, and an initializer when graph is present", () => {
+    const html = renderDashboardHtml(baseData());
+    expect(html).toContain(`id="hm-graph-data"`);
+    expect(html).toContain("unpkg.com/vis-network");
+    expect(html).toContain("new vis.Network(container");
+    expect(html).toContain("commit abc123def456");
+    expect(html).toContain("2 nodes · 1 edges");
+  });
+
+  it("escapes a malicious project name so it cannot inject markup", () => {
+    const html = renderDashboardHtml(baseData({ repoProject: `<script>alert(1)</script>` }));
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("escapes a malicious snapshot value so it cannot close the JSON script tag", () => {
+    const html = renderDashboardHtml(baseData({
+      graph: {
+        commitSha: null, snapshotPath: "/x", nodeCount: 1, edgeCount: 0,
+        snapshot: {
+          nodes: [{ id: "n", label: "</script><img src=x onerror=alert(1)>" }],
+          links: [],
+        },
+      },
+    }));
+    // The literal sequence "</script>" must not appear inside the
+    // JSON PAYLOAD (between the opening application/json tag and its
+    // first closing tag). If escaping failed, the payload would
+    // contain the attacker's </script> AND get truncated at it.
+    const openMarker = `id="hm-graph-data">`;
+    const payloadStart = html.indexOf(openMarker) + openMarker.length;
+    const payloadEnd = html.indexOf("</script>", payloadStart);
+    const payload = html.slice(payloadStart, payloadEnd);
+    expect(payload).not.toContain("</script>");
+    expect(payload).toContain("<\\/script>");
+    // And it should still parse as JSON (rough check: starts with {).
+    expect(payload.trimStart().startsWith("{")).toBe(true);
+  });
+
+  it("renders the loose-dir commit label when commitSha is null", () => {
+    const html = renderDashboardHtml(baseData({
+      graph: {
+        commitSha: null, snapshotPath: "/x", nodeCount: 0, edgeCount: 0,
+        snapshot: { nodes: [], links: [] },
+      },
+    }));
+    expect(html).toContain("no commit (loose dir)");
+  });
+});

--- a/tests/claude-code/dashboard-render.test.ts
+++ b/tests/claude-code/dashboard-render.test.ts
@@ -67,19 +67,32 @@ describe("safeJsonForScript", () => {
     expect(out).not.toContain("</script>");
     expect(out).toContain("<\\/script>");
   });
-  it("escapes HTML comments to avoid script-block confusion", () => {
+  it("escapes HTML comments to avoid script-block confusion (no literal bytes)", () => {
     const out = safeJsonForScript({ a: "<!-- evil -->" });
     expect(out).not.toContain("<!--");
     expect(out).not.toContain("-->");
   });
-  it("round-trips through JSON.parse after unwinding the escape", () => {
-    const value = { a: "</nope>", b: 1, c: ["nested", null] };
+  it("produces JSON that the browser's JSON.parse(textContent) can read directly", () => {
+    // The browser-side path is JSON.parse(scriptEl.textContent). textContent
+    // returns the literal bytes of the element, so JSON.parse must accept
+    // the output as-is. The earlier '<\!--' / '--\>' escapes were not
+    // valid JSON; codex caught that.
+    const value = {
+      a: "</nope>",
+      b: "<!-- comment -->",
+      c: ["before -->", "<!-- between", "after"],
+      d: 1,
+    };
     const escaped = safeJsonForScript(value);
-    // The browser-side parse is JSON.parse(textContent); textContent
-    // returns the literal characters, NOT the escape sequences. So we
-    // emulate by replacing `<\/` with `</` and parsing.
-    const decoded = JSON.parse(escaped.replace(/<\\\//g, "</").replace(/<\\!--/g, "<!--").replace(/--\\>/g, "-->"));
+    const decoded = JSON.parse(escaped); // must NOT throw
     expect(decoded).toEqual(value);
+  });
+  it("preserves the original string values through encode+parse for `<!--` and `-->`", () => {
+    const value = { weird: "x <!-- y --> z" };
+    const escaped = safeJsonForScript(value);
+    expect(escaped).not.toContain("<!--");
+    expect(escaped).not.toContain("-->");
+    expect(JSON.parse(escaped).weird).toBe("x <!-- y --> z");
   });
 });
 
@@ -174,6 +187,35 @@ describe("transformSnapshotToVis", () => {
     const out = transformSnapshotToVis(snapshot);
     expect(out.edges).toHaveLength(1);
     expect(out.edges[0].to).toBe("external");
+  });
+  it("HTML-escapes node tooltip text (vis renders title as HTML)", () => {
+    // If the snapshot is built from a file path / id with HTML in it,
+    // and we pass the raw string to vis as `title`, the hover tooltip
+    // would render the markup. Codex review on commit 2 flagged this.
+    const snapshot = {
+      nodes: [{
+        id: "<img src=x onerror=alert(1)>",
+        label: "ok",
+        kind: "function",
+        source_file: "src/<bad>.ts",
+        source_location: "L1",
+      }],
+      links: [],
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.nodes[0].title).not.toContain("<img");
+    expect(out.nodes[0].title).not.toContain("<bad>");
+    expect(out.nodes[0].title).toContain("&lt;bad&gt;.ts");
+  });
+  it("HTML-escapes edge tooltip text", () => {
+    const snapshot = {
+      nodes: [{ id: "<x>" }, { id: "<y>" }],
+      links: [{ source: "<x>", target: "<y>" }], // no relation/confidence => fallback title path
+    };
+    const out = transformSnapshotToVis(snapshot);
+    expect(out.edges[0].title).not.toContain("<x>");
+    expect(out.edges[0].title).toContain("&lt;x&gt;");
+    expect(out.edges[0].title).toContain("&lt;y&gt;");
   });
 });
 

--- a/tests/claude-code/dashboard-serve.test.ts
+++ b/tests/claude-code/dashboard-serve.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the dashboard HTTP server. Each test binds to an
+ * ephemeral port (port: 0) so CI doesn't fight over fixed ports and
+ * tests can run in parallel.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { serveDashboardHtml, type ServeHandle } from "../../src/dashboard/serve.js";
+
+async function fetchText(url: string): Promise<{ status: number; body: string; contentType: string | null }> {
+  const r = await fetch(url);
+  return { status: r.status, body: await r.text(), contentType: r.headers.get("content-type") };
+}
+
+describe("serveDashboardHtml", () => {
+  let handles: ServeHandle[] = [];
+
+  afterEach(async () => {
+    await Promise.all(handles.map(h => h.close().catch(() => { /* already closed */ })));
+    handles = [];
+  });
+
+  it("binds to an ephemeral port and serves the HTML at GET /", async () => {
+    const h = await serveDashboardHtml({ html: "<!doctype html><h1>hello</h1>", port: 0 });
+    handles.push(h);
+    expect(h.port).toBeGreaterThan(0);
+    expect(h.host).toBe("127.0.0.1");
+    const r = await fetchText(`http://127.0.0.1:${h.port}/`);
+    expect(r.status).toBe(200);
+    expect(r.body).toContain("<h1>hello</h1>");
+    expect(r.contentType).toContain("text/html");
+  });
+
+  it("treats /index.html and /?refresh=1 as the dashboard root", async () => {
+    const h = await serveDashboardHtml({ html: "<!doctype html><b>root</b>", port: 0 });
+    handles.push(h);
+    const r1 = await fetchText(`http://127.0.0.1:${h.port}/index.html`);
+    const r2 = await fetchText(`http://127.0.0.1:${h.port}/?refresh=1`);
+    expect(r1.status).toBe(200);
+    expect(r1.body).toContain("<b>root</b>");
+    expect(r2.status).toBe(200);
+    expect(r2.body).toContain("<b>root</b>");
+  });
+
+  it("returns 204 on GET /health for readiness probes", async () => {
+    const h = await serveDashboardHtml({ html: "x", port: 0 });
+    handles.push(h);
+    const r = await fetch(`http://127.0.0.1:${h.port}/health`);
+    expect(r.status).toBe(204);
+  });
+
+  it("returns 404 for unknown paths with a hint to /", async () => {
+    const h = await serveDashboardHtml({ html: "x", port: 0 });
+    handles.push(h);
+    const r = await fetchText(`http://127.0.0.1:${h.port}/whatever`);
+    expect(r.status).toBe(404);
+    expect(r.body).toMatch(/lives at \//);
+  });
+
+  it("rejects non-GET methods (POST)", async () => {
+    const h = await serveDashboardHtml({ html: "x", port: 0 });
+    handles.push(h);
+    const r = await fetch(`http://127.0.0.1:${h.port}/`, { method: "POST" });
+    expect(r.status).toBe(404);
+  });
+
+  it("falls back to an ephemeral port when the preferred port is in use", async () => {
+    // Grab a port first, then ask for the SAME port. The fallback
+    // should pick a different ephemeral port and still bind.
+    const first = await serveDashboardHtml({ html: "first", port: 0 });
+    handles.push(first);
+    const second = await serveDashboardHtml({ html: "second", port: first.port });
+    handles.push(second);
+    expect(second.port).not.toBe(first.port);
+    expect(second.port).toBeGreaterThan(0);
+    const r = await fetchText(`http://127.0.0.1:${second.port}/`);
+    expect(r.body).toBe("second");
+  });
+
+  it("close() resolves and `stopped` resolves once the server shuts down", async () => {
+    const h = await serveDashboardHtml({ html: "x", port: 0 });
+    await h.close();
+    await h.stopped; // must NOT hang
+    // A second close() is a no-op-equivalent — the underlying server.close()
+    // returns an error on a non-listening server; we swallow it in afterEach.
+  });
+
+  it("defaults the bind address to 127.0.0.1 (loopback only — no LAN exposure)", async () => {
+    const h = await serveDashboardHtml({ html: "x", port: 0 });
+    handles.push(h);
+    expect(h.host).toBe("127.0.0.1");
+    // sanity: try fetching from the loopback name — should resolve
+    const r = await fetch(`http://127.0.0.1:${h.port}/`);
+    expect(r.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `hivemind dashboard`: a single command that builds a self-contained HTML page combining KPI cards (tokens saved, skills created, memory recalls, sessions) and a force-directed visualization of the codebase graph produced by the `feat/codebase-graph-phase1-extractor` branch, then opens it in the default browser. Read-only over disk artifacts already written by other features.

Default output: `~/.hivemind/dashboards/<repo-key>/index.html` — re-running refreshes in place so bookmarks stay valid.

```
hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
```

## How it composes

```
┌──────────────────┐    ┌──────────────────────┐
│ ~/.hivemind/     │───▶│ src/dashboard/data   │
│ graphs/<key>/    │    │   - graph snapshot   │
│ snapshots/*.json │    │   - KPIs (org/local) │
└──────────────────┘    └──────────┬───────────┘
                                    │
┌──────────────────┐                ▼
│ ~/.deeplake/     │───────▶┌──────────────────┐    ┌──────────────────┐
│ usage-stats.jsonl│        │ src/dashboard/   │───▶│ index.html       │
│ + fetchOrgStats  │        │ render (vis-net) │    │ (self-contained) │
└──────────────────┘        └──────────────────┘    └────────┬─────────┘
                                                              │
                                                              ▼
                                                    ┌──────────────────┐
                                                    │ xdg-open / open  │
                                                    │ / cmd start ""   │
                                                    └──────────────────┘
```

- **Data** (`src/dashboard/data.ts`): reads `latest-commit.txt` then `snapshots/<sha>.json` from the graph producer, falls back to the newest `.json`. Loads KPIs via `fetchOrgStats` (cached 1h) with a local `usage-stats.jsonl` fallback; distinguishes "no data yet" from "0 saved" with a tri-state `tokensSource: org | local | none`.
- **Render** (`src/dashboard/render.ts`): pure string-builder. vis-network 9.x via unpkg CDN. graphify-shape snapshot → `{nodes, edges}` mapped here so the data layer stays UI-agnostic. Defensive transform: drops nodes without string ids, dedups repeated ids, keeps edges with unresolved targets (Phase 1 cross-file). HTML-escapes everything that lands in markup; `safeJsonForScript` defends against `</script>`, `<!--`, `-->` substrings in the JSON payload.
- **Open** (`src/dashboard/open.ts`): linux=xdg-open, darwin=open, win32=`cmd /c start "" <path>`. Pre-checks PATH for the helper (spawn never throws sync on missing binary) so the CLI doesn't lie about having opened the browser.
- **CLI** (`src/commands/dashboard.ts` + wiring in `src/cli/index.ts`): parser extracted as a pure function. Runtime errors surface as one-line stderr, not stack traces.

## Commits (5)

| # | Commit | What |
|---|---|---|
| 1 | `feat(dashboard): data layer` | snapshot + KPI loader, 11 tests |
| 2 | `feat(dashboard): HTML render layer` | pure render, vis-network, 26 tests |
| 3 | `fix(dashboard): codex review fixes for the render layer` | invalid JSON escapes for `<!--`/`-->`, vis tooltip XSS hardening |
| 4 | `feat(dashboard): CLI + cross-platform browser open` | command, opener, wiring, smoke e2e, 13 tests |
| 5 | `fix(dashboard): codex review fixes for the CLI commit` | parser accepted flag tokens as values; opener lied when helper missing |

All four feature commits ran through `codex review --base HEAD~1`. Both fix commits address findings codex produced; tests added for each regression.

## Empty states

- No graph snapshot for this repo → card with `Run `hivemind graph build`` hint
- No org creds + no local usage records → KPI value `—` with `Run a session to start tracking`
- No browser opener detected (headless / minimal container) → CLI prints `open the file above manually` and returns 0
- Helper binary missing on PATH → same "open manually" branch (verified by stripping PATH)

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 145 files, 2912 tests pass (was 2907; 65 added)
- [x] `npm run build` — 12 CC + 10 Codex + 9 Cursor + 9 Hermes + 1 OpenClaw + 1 MCP + 1 CLI + 1 standalone-daemon bundles
- [x] `node bundle/cli.js dashboard --help` — prints USAGE
- [x] `node bundle/cli.js dashboard --out /tmp/x.html --no-open` — writes valid HTML (verified `<!DOCTYPE html>`, vis-network script tag, hm-graph-data payload)
- [x] `--out --no-open` and `--cwd --out` — exit 2 with USAGE
- [x] xdg-open present → `Opening via xdg-open`
- [x] xdg-open stripped from PATH → `no opener for this platform; open the file above manually`
- [x] Synthetic 5-node/4-edge snapshot → 6.4 KB HTML, payload contains expected node colors/titles

## Out of scope / follow-ups

- Per-agent SessionStart injection blocks (`hivemind dashboard` advertised to the model in each agent's hooks) — mechanical change across 4-5 files; deferred to keep this PR focused on the user-facing command.
- Snapshot truncation for very large graphs (10k+ nodes): currently render the full snapshot inline. vis-network handles 1k+ comfortably; if we see real repos producing huge graphs we can cap by degree in a follow-up.
- The token-savings formula constants (`BYTES_PER_TOKEN`, `SAVINGS_MULTIPLIER`) are duplicated from `src/notifications/sources/primary-banner.ts`. When we want to change them, grep `SAVINGS_MULTIPLIER` for both call sites. Extracting a shared `savings.ts` would touch the banner's session-start tested path; not worth it for two constants today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hivemind dashboard` CLI command to generate an HTML dashboard for your repository, featuring KPI metrics and interactive code graph visualization. Supports customizable output location and automatic browser opening on Linux, macOS, and Windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->