### PR TITLE
feat(skillify): concrete-insight banner at SessionStart pre-auth

### DIFF
--- a/src/commands/mine-local.ts
+++ b/src/commands/mine-local.ts
@@ -298,12 +298,20 @@ export function parseMultiVerdict(raw: string): MultiVerdict | null {
     const description = typeof s.description === "string" ? s.description.trim() : "";
     const body = typeof s.body === "string" ? s.body.trim() : "";
     const trigger = typeof s.trigger === "string" ? s.trigger.trim() : undefined;
-    // Insight is optional — the gate omits it when it can't ground a
-    // concrete + quantified line. Empty / whitespace-only strings collapse
-    // to undefined so the manifest entry stays free of an empty-string
-    // sentinel that downstream code would treat as "present".
-    const rawInsight = typeof s.insight === "string" ? s.insight.trim() : "";
-    const insight = rawInsight.length > 0 ? rawInsight : undefined;
+    // Insight is optional and is unbounded model output — apply
+    // sanitization at this parse boundary so the manifest can be trusted
+    // by every downstream consumer (banner renderer, future surfaces,
+    // hook payload size budgets). Collapse all whitespace to a single
+    // space (drops embedded newlines that could carry prompt-like
+    // instructions into future SessionStart context) and cap length so
+    // a pathological gate output can't bloat the hook payload. Empty /
+    // whitespace-only strings collapse to undefined so the manifest
+    // entry stays free of an empty-string sentinel.
+    const rawInsight = typeof s.insight === "string" ? s.insight : "";
+    const normalizedInsight = rawInsight.replace(/\s+/g, " ").trim();
+    const insight = normalizedInsight.length > 0
+      ? normalizedInsight.slice(0, 280)
+      : undefined;
     if (!name || !body) continue;
     out.push({ name, description, body, trigger, insight });
   }

--- a/src/commands/mine-local.ts
+++ b/src/commands/mine-local.ts
@@ -208,11 +208,26 @@ function buildSessionPrompt(pairs: Pair[], session: SessionFile, verdictPath: st
     `- A skill qualifies if it captures a concrete, repeatable workflow OR a non-obvious`,
     `  constraint/gotcha a future engineer would benefit from knowing. Intra-session is fine —`,
     `  one deep dive yielding a generalizable takeaway counts.`,
+    `- Especially valuable: REPEATABLE-MISTAKE patterns. Cases where the assistant declared`,
+    `  work "done"/"fixed"/"verified" and the user came back to the same problem later; where`,
+    `  the same class of mistake recurs (forgot to run tests, mishandled async state,`,
+    `  hallucinated function/file existence, re-asked for confirmation on already-authorized`,
+    `  work, jumped to plans without checking with the user, etc.); where the user manually`,
+    `  corrected the same kind of error >1 time. These are the highest-value catches.`,
     `- Skip patterns that are obvious from reading the codebase or already in CLAUDE.md.`,
     `- Each body uses short sections (When to use, Workflow, Anti-patterns), concrete commands`,
     `  / paths / snippets drawn from the exchanges below, no marketing, no emojis.`,
     `- Each body under ~3000 characters.`,
     `- Skill names are kebab-case slugs (lowercase letters/digits/hyphens only).`,
+    `- For each skill, also emit a one-line "insight": a concrete, quantified, second-person`,
+    `  sentence describing what hivemind found that prompted the skill. Examples:`,
+    `    "You revisited 4 merged PRs in the last month because the assistant declared 'done'`,
+    `     before checking test output."`,
+    `    "You corrected the same env-mismatch (beta vs prod) twice in the same week before`,
+    `     deciding to switch deployment targets."`,
+    `  The insight is what users will see at next SessionStart, so it must be honest — only`,
+    `  assert counts and patterns you can ground in THIS session's exchanges. Omit the field`,
+    `  if you cannot write a concrete, quantified line.`,
     ``,
     `=== EXCHANGES (user prompts + assistant final answers, tool calls stripped) ===`,
     renderPairsBlock(pairs),
@@ -231,7 +246,8 @@ function buildSessionPrompt(pairs: Pair[], session: SessionFile, verdictPath: st
     `      "name": "<kebab-case>",`,
     `      "description": "<one-line>",`,
     `      "trigger": "<short trigger>",`,
-    `      "body": "<full SKILL.md body without frontmatter>"`,
+    `      "body": "<full SKILL.md body without frontmatter>",`,
+    `      "insight": "<one-line, concrete + quantified + second person; OPTIONAL>"`,
     `    },`,
     `    ... up to 3 entries, or [] if nothing qualifies`,
     `  ]`,
@@ -246,6 +262,13 @@ export interface MinedSkill {
   description: string;
   trigger?: string;
   body: string;
+  /**
+   * One-line user-facing sentence describing what the gate found in the
+   * source session. Surfaced by the SessionStart banner when this skill is
+   * the most-recent insight-bearing entry. Optional — the gate omits it
+   * when it cannot ground a concrete + quantified line.
+   */
+  insight?: string;
 }
 
 export interface MultiVerdict {
@@ -275,8 +298,14 @@ export function parseMultiVerdict(raw: string): MultiVerdict | null {
     const description = typeof s.description === "string" ? s.description.trim() : "";
     const body = typeof s.body === "string" ? s.body.trim() : "";
     const trigger = typeof s.trigger === "string" ? s.trigger.trim() : undefined;
+    // Insight is optional — the gate omits it when it can't ground a
+    // concrete + quantified line. Empty / whitespace-only strings collapse
+    // to undefined so the manifest entry stays free of an empty-string
+    // sentinel that downstream code would treat as "present".
+    const rawInsight = typeof s.insight === "string" ? s.insight.trim() : "";
+    const insight = rawInsight.length > 0 ? rawInsight : undefined;
     if (!name || !body) continue;
-    out.push({ name, description, body, trigger });
+    out.push({ name, description, body, trigger, insight });
   }
   return { reason: typeof parsed.reason === "string" ? parsed.reason : undefined, skills: out };
 }
@@ -649,6 +678,11 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
       gate_agent: gateAgent,
       created_at: result.createdAt,
       uploaded: false,
+      // Persist the one-line insight when the gate produced one. Omitted
+      // (undefined → absent in JSON) when the gate couldn't ground a
+      // concrete line, so the SessionStart banner falls back to the
+      // count-only surface for entries written before this field landed.
+      ...(skill.insight ? { insight: skill.insight } : {}),
     }));
     saveManifest({
       created_at: existing?.created_at ?? new Date().toISOString(),

--- a/src/hooks/session-notifications.ts
+++ b/src/hooks/session-notifications.ts
@@ -16,7 +16,7 @@ import { loadCredentials } from "../commands/auth.js";
 import { readStdin } from "../utils/stdin.js";
 import { drainSessionStart, registerRule } from "../notifications/index.js";
 import { localMinedRule } from "../notifications/rules/local-mined.js";
-import { countLocalManifestEntries } from "../skillify/local-manifest.js";
+import { countLocalManifestEntries, getLatestInsightEntry } from "../skillify/local-manifest.js";
 import { log as _log } from "../utils/debug.js";
 
 const log = (msg: string) => _log("session-notifications", msg);
@@ -52,14 +52,19 @@ async function main(): Promise<void> {
   const sessionId = rawSessionId.length > 0 ? rawSessionId : undefined;
 
   const creds = loadCredentials();
-  // Read the local-mined count here (rules stay pure / IO-free).
-  // countLocalManifestEntries returns 0 when the manifest is missing or
-  // malformed — we coerce to null in that case so the rule can
-  // distinguish "no mining run yet" from "ran, found 0".
+  // Read the local-mined count + latest insight entry here (rules stay
+  // pure / IO-free). countLocalManifestEntries returns 0 when the manifest
+  // is missing or malformed — we coerce to null in that case so the rule
+  // can distinguish "no mining run yet" from "ran, found 0".
+  // getLatestInsightEntry returns null cleanly when no insight-bearing
+  // entry exists, so the rule's concrete-insight branch stays gated.
   let localSkillsCount: number | null = null;
+  let latestInsightEntry: ReturnType<typeof getLatestInsightEntry> = null;
   try { localSkillsCount = countLocalManifestEntries(); }
   catch { /* keep null */ }
-  await drainSessionStart({ agent: "claude-code", creds, sessionId, localSkillsCount });
+  try { latestInsightEntry = getLatestInsightEntry(); }
+  catch { /* keep null */ }
+  await drainSessionStart({ agent: "claude-code", creds, sessionId, localSkillsCount, latestInsightEntry });
 }
 
 main().catch((e) => { log(`fatal: ${e?.message ?? String(e)}`); process.exit(0); });

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -20,7 +20,7 @@ import { makeWikiLogger } from "../utils/wiki-log.js";
 import { autoUpdate } from "./shared/autoupdate.js";
 import { autoPullSkills } from "../skillify/auto-pull.js";
 import { renderSkillifyCommands } from "../cli/skillify-spec.js";
-import { countLocalManifestEntries, getLatestInsightEntry } from "../skillify/local-manifest.js";
+import { countLocalManifestEntries } from "../skillify/local-manifest.js";
 import { renderLocalMinedNote } from "../skillify/local-mined-banner.js";
 import { maybeAutoMineLocal } from "../skillify/spawn-mine-local-worker.js";
 const log = (msg: string) => _log("session-start", msg);
@@ -216,17 +216,15 @@ async function main(): Promise<void> {
   // No placeholder substitution needed — inject uses bare `hivemind <sub>` form.
   const resolvedContext = context;
   // When the user hasn't signed in but has mined skills locally with
-  // `hivemind skillify mine-local`, surface either a concrete finding (when
-  // the gate emitted a quantified insight string for a recent entry) or
-  // fall back to the generic count surface. Stays empty (and silent) when
-  // no manifest exists, so first-time non-mined users don't see an
-  // unhelpful "0 skills" line. Both branches are inside renderLocalMinedNote
-  // so the conditional copy lives in one unit-testable place.
+  // `hivemind skillify mine-local`, surface a count + sign-in CTA in
+  // the model-visible context. The rich concrete-insight banner is
+  // delivered on the user-visible systemMessage channel by the
+  // notifications rule (src/notifications/rules/local-mined.ts) — it
+  // is intentionally NOT rendered here because `insight` originates
+  // from haiku's gate output and feeding LLM-derived prose back into
+  // `additionalContext` is a prompt-injection vector (codex P1).
   const localMined = countLocalManifestEntries();
-  const localMinedNote = renderLocalMinedNote({
-    insightEntry: getLatestInsightEntry(),
-    totalCount: localMined,
-  });
+  const localMinedNote = renderLocalMinedNote({ totalCount: localMined });
   const additionalContext = creds?.token
     ? `${resolvedContext}\n\nLogged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})${updateNotice}`
     : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /hivemind:login to authenticate.${localMinedNote}${updateNotice}`;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -20,7 +20,8 @@ import { makeWikiLogger } from "../utils/wiki-log.js";
 import { autoUpdate } from "./shared/autoupdate.js";
 import { autoPullSkills } from "../skillify/auto-pull.js";
 import { renderSkillifyCommands } from "../cli/skillify-spec.js";
-import { countLocalManifestEntries } from "../skillify/local-manifest.js";
+import { countLocalManifestEntries, getLatestInsightEntry } from "../skillify/local-manifest.js";
+import { renderLocalMinedNote } from "../skillify/local-mined-banner.js";
 import { maybeAutoMineLocal } from "../skillify/spawn-mine-local-worker.js";
 const log = (msg: string) => _log("session-start", msg);
 
@@ -215,14 +216,17 @@ async function main(): Promise<void> {
   // No placeholder substitution needed — inject uses bare `hivemind <sub>` form.
   const resolvedContext = context;
   // When the user hasn't signed in but has mined skills locally with
-  // `hivemind skillify mine-local`, surface the count so the model can
-  // mention the next sharing step. Stays empty (and silent) when no
-  // manifest exists, so first-time non-mined users don't see an
-  // unhelpful "0 skills" line.
+  // `hivemind skillify mine-local`, surface either a concrete finding (when
+  // the gate emitted a quantified insight string for a recent entry) or
+  // fall back to the generic count surface. Stays empty (and silent) when
+  // no manifest exists, so first-time non-mined users don't see an
+  // unhelpful "0 skills" line. Both branches are inside renderLocalMinedNote
+  // so the conditional copy lives in one unit-testable place.
   const localMined = countLocalManifestEntries();
-  const localMinedNote = localMined > 0
-    ? `\n\n${localMined} local skill${localMined === 1 ? "" : "s"} from past 'hivemind skillify mine-local' run(s) live in ~/.claude/skills/. Run 'hivemind login' to start sharing new mining results with your team.`
-    : "";
+  const localMinedNote = renderLocalMinedNote({
+    insightEntry: getLatestInsightEntry(),
+    totalCount: localMined,
+  });
   const additionalContext = creds?.token
     ? `${resolvedContext}\n\nLogged in to Deeplake as org: ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"})${updateNotice}`
     : `${resolvedContext}\n\n⚠️ Not logged in to Deeplake. Memory search will not work. Ask the user to run /hivemind:login to authenticate.${localMinedNote}${updateNotice}`;

--- a/src/notifications/delivery/claude-code.ts
+++ b/src/notifications/delivery/claude-code.ts
@@ -34,7 +34,11 @@ import type { Notification } from "../types.js";
 import { renderNotifications } from "../format.js";
 
 export function emitClaudeCode(notifications: Notification[]): void {
-  if (notifications.length === 0) return;
+  // The empty-array short-circuit lives in delivery/index.ts:emit;
+  // adapters are guaranteed to receive at least one notification.
+  // Rendering an empty list still produces "", which the ternary
+  // below handles, but the dispatcher guard keeps the contract
+  // explicit and the coverage matrix tight.
   const modelSafe = notifications.filter(n => !n.userVisibleOnly);
   const modelRendered = renderNotifications(modelSafe);
   const userRendered = renderNotifications(notifications);
@@ -42,9 +46,6 @@ export function emitClaudeCode(notifications: Notification[]): void {
   // Omit additionalContext entirely when every notification in the
   // batch is user-only — there's nothing safe to send to the model.
   // Claude Code accepts a missing additionalContext field gracefully.
-  // userRendered is always non-empty here: renderNotifications only
-  // returns "" for an empty input array, and we already short-circuit
-  // that case on the first line.
   process.stdout.write(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "SessionStart",

--- a/src/notifications/delivery/claude-code.ts
+++ b/src/notifications/delivery/claude-code.ts
@@ -42,12 +42,14 @@ export function emitClaudeCode(notifications: Notification[]): void {
   // Omit additionalContext entirely when every notification in the
   // batch is user-only — there's nothing safe to send to the model.
   // Claude Code accepts a missing additionalContext field gracefully.
-  const payload: Record<string, unknown> = {
+  // userRendered is always non-empty here: renderNotifications only
+  // returns "" for an empty input array, and we already short-circuit
+  // that case on the first line.
+  process.stdout.write(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "SessionStart",
       ...(modelRendered ? { additionalContext: modelRendered } : {}),
     },
-  };
-  if (userRendered) payload.systemMessage = userRendered;
-  process.stdout.write(JSON.stringify(payload));
+    systemMessage: userRendered,
+  }));
 }

--- a/src/notifications/delivery/claude-code.ts
+++ b/src/notifications/delivery/claude-code.ts
@@ -17,16 +17,37 @@
  *     in an attachment array). Earlier reports of dropped second-hook stdout
  *     (issue #13650) appear resolved in 2.1.x.
  *
+ * Channel split (codex P1 prompt-injection finding):
+ *   Notifications can opt into user-visible-only delivery by setting
+ *   `userVisibleOnly: true`. The renderer emits the user-visible block
+ *   (which carries LLM-derived prose) ONLY to `systemMessage`; the
+ *   model-visible `additionalContext` carries the subset of notifications
+ *   whose bodies are statically authored and safe to feed back into the
+ *   model's system prompt. Without this split, an insight derived from
+ *   adversarial session content could prompt-inject the next session.
+ *
  * Cap: 10,000 chars per channel (per CC docs). renderNotifications output
  * stays well under that for v1 content.
  */
 
-export function emitClaudeCode(rendered: string): void {
-  process.stdout.write(JSON.stringify({
+import type { Notification } from "../types.js";
+import { renderNotifications } from "../format.js";
+
+export function emitClaudeCode(notifications: Notification[]): void {
+  if (notifications.length === 0) return;
+  const modelSafe = notifications.filter(n => !n.userVisibleOnly);
+  const modelRendered = renderNotifications(modelSafe);
+  const userRendered = renderNotifications(notifications);
+
+  // Omit additionalContext entirely when every notification in the
+  // batch is user-only — there's nothing safe to send to the model.
+  // Claude Code accepts a missing additionalContext field gracefully.
+  const payload: Record<string, unknown> = {
     hookSpecificOutput: {
       hookEventName: "SessionStart",
-      additionalContext: rendered,
+      ...(modelRendered ? { additionalContext: modelRendered } : {}),
     },
-    systemMessage: rendered,
-  }));
+  };
+  if (userRendered) payload.systemMessage = userRendered;
+  process.stdout.write(JSON.stringify(payload));
 }

--- a/src/notifications/delivery/index.ts
+++ b/src/notifications/delivery/index.ts
@@ -15,16 +15,22 @@
  * needs to do.
  */
 
-import type { Agent } from "../types.js";
+import type { Agent, Notification } from "../types.js";
 import { emitClaudeCode } from "./claude-code.js";
 
-export type EmitFn = (rendered: string) => void;
+// Adapters now take notifications, not a pre-rendered string, so each
+// agent can decide per-channel rendering (e.g. user-visible-only items
+// are kept out of Claude Code's model-visible additionalContext). The
+// previous string-based signature collapsed both channels to the same
+// content, which leaked LLM-derived insight prose into the model's
+// system prompt (codex P1).
+export type EmitFn = (notifications: Notification[]) => void;
 
 const ADAPTERS: Record<Agent, EmitFn> = {
   "claude-code": emitClaudeCode,
 };
 
-export function emit(agent: Agent, rendered: string): void {
-  if (!rendered) return;
-  ADAPTERS[agent](rendered);
+export function emit(agent: Agent, notifications: Notification[]): void {
+  if (notifications.length === 0) return;
+  ADAPTERS[agent](notifications);
 }

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -15,6 +15,7 @@
 
 import type { Credentials } from "../commands/auth-creds.js";
 import type { Agent, Notification, NotificationContext } from "./types.js";
+import type { LocalManifestEntry } from "../skillify/local-manifest.js";
 import { evaluateRules } from "./rules/registry.js";
 import { readQueue, writeQueue } from "./queue.js";
 import { readState, writeState, alreadyShown, markShown, tryClaim, releaseClaim } from "./state.js";
@@ -42,6 +43,12 @@ export interface DrainOptions {
    * read the local-mined manifest themselves (rules contract: no IO).
    */
   localSkillsCount?: number | null;
+  /**
+   * Most recent insight-bearing manifest entry; powers the concrete-insight
+   * branch of localMinedRule. Populated by the hook entry point so rules
+   * stay IO-free.
+   */
+  latestInsightEntry?: LocalManifestEntry | null;
 }
 
 /**
@@ -69,6 +76,7 @@ export async function drainSessionStart(opts: DrainOptions): Promise<void> {
       creds: opts.creds,
       state,
       localSkillsCount: opts.localSkillsCount ?? null,
+      latestInsightEntry: opts.latestInsightEntry ?? null,
     };
 
     const fromRules = evaluateRules("session_start", ctx);

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -19,7 +19,6 @@ import type { LocalManifestEntry } from "../skillify/local-manifest.js";
 import { evaluateRules } from "./rules/registry.js";
 import { readQueue, writeQueue } from "./queue.js";
 import { readState, writeState, alreadyShown, markShown, tryClaim, releaseClaim } from "./state.js";
-import { renderNotifications } from "./format.js";
 import { emit } from "./delivery/index.js";
 import { fetchBackendNotifications } from "./sources/backend.js";
 import { pickPrimaryBanner } from "./sources/primary-banner.js";
@@ -113,8 +112,10 @@ export async function drainSessionStart(opts: DrainOptions): Promise<void> {
       return;
     }
 
-    const rendered = renderNotifications(claimed);
-    emit(opts.agent, rendered);
+    // Adapter decides per-channel rendering (some notifications go only
+    // to user-visible channels). See delivery/claude-code.ts for the
+    // model-vs-user split that closes the codex prompt-injection P1.
+    emit(opts.agent, claimed);
 
     // Persist state for non-transient notifications. Transient ones (see
     // Notification.transient docstring) are self-clearing — their enqueue

--- a/src/notifications/rules/local-mined.ts
+++ b/src/notifications/rules/local-mined.ts
@@ -1,17 +1,26 @@
 /**
  * Surfaces locally-mined skills to fresh, not-signed-in users — the
  * user-visible half of the "wow effect" pair. The not-logged-in branch of
- * session-start.ts already injects the count into `additionalContext` so
- * the MODEL sees it; this rule turns the same info into a `systemMessage`
- * so the USER sees it in their terminal too, exactly like the welcome
- * line shown right after `hivemind login`.
+ * session-start.ts already injects the same content into `additionalContext`
+ * so the MODEL sees it; this rule turns it into a `systemMessage` so the
+ * USER sees it in their terminal too, exactly like the welcome line shown
+ * right after `hivemind login`.
+ *
+ * Two branches:
+ *   1. A recent manifest entry carries an `insight` string → render the
+ *      concrete-insight banner (the gate's quantified finding + the
+ *      minted skill name + sign-in CTA). This is the conversion surface —
+ *      a real pattern from the user's own work, not an abstract count.
+ *   2. No insight available (legacy manifest, gate didn't emit one) →
+ *      fall back to the legacy "🎉 N skills mined" copy. Behavior on
+ *      pre-insight manifests is unchanged.
  *
  * Suppression: stays silent once creds are present (logged-in users see
  * the welcome rule instead) or when the manifest is absent / empty.
  *
- * Dedup: keyed on the integer count so the message re-fires the next time
- * the worker adds new skills (e.g. user re-runs mine-local after coding
- * in new projects).
+ * Dedup: insight branch keys on skill_name + created_at so a new insight
+ * refires next session; count branch keys on the integer count so an
+ * incrementing N refires too.
  */
 
 import type { Rule } from "../types.js";
@@ -19,9 +28,40 @@ import type { Rule } from "../types.js";
 export const localMinedRule: Rule = {
   id: "local-mined-surfaced",
   trigger: "session_start",
-  evaluate({ creds, localSkillsCount }) {
+  evaluate({ creds, localSkillsCount, latestInsightEntry }) {
     if (creds?.token) return null;
     if (typeof localSkillsCount !== "number" || localSkillsCount <= 0) return null;
+
+    // Concrete-insight branch — the surface the install→signup-conversion
+    // play is built around. Only fires when the manifest has an entry
+    // whose insight is non-empty (getLatestInsightEntry already filters
+    // empty/whitespace, but the rule double-checks since a malformed
+    // entry could slip a non-string through at the type-system boundary).
+    const insight = typeof latestInsightEntry?.insight === "string"
+      ? latestInsightEntry.insight.trim()
+      : "";
+    if (latestInsightEntry && insight.length > 0) {
+      const name = latestInsightEntry.skill_name;
+      return {
+        id: "local-mined-surfaced",
+        severity: "info",
+        // format.ts prepends the severity icon (info → 🐝), so the title
+        // itself stays icon-free — otherwise the rendered line shows
+        // "🐝 🐝 Hivemind found..." (two bees, one from format, one from us).
+        title: `Hivemind found a pattern in your past sessions`,
+        body:
+          `${insight}\n` +
+          `Minted skill \`${name}\` to catch it next time — try \`claude -p '/${name} <your prompt>'\`.\n` +
+          `Run 'hivemind login' to keep these skills across machines and share with your team.`,
+        // Dedup on the entry's identity so a new insight refires next
+        // session, while a re-run with the same entry still dedupes.
+        dedupKey: { skill_name: name, created_at: latestInsightEntry.created_at },
+      };
+    }
+
+    // Fallback — legacy "N skills mined" copy. Preserves the existing
+    // user experience for manifests written before the insight field
+    // landed, and for users whose gate calls didn't produce an insight.
     const noun = localSkillsCount === 1 ? "skill" : "skills";
     return {
       id: "local-mined-surfaced",

--- a/src/notifications/rules/local-mined.ts
+++ b/src/notifications/rules/local-mined.ts
@@ -25,6 +25,24 @@
 
 import type { Rule } from "../types.js";
 
+/**
+ * Maximum length for the rendered insight line. Picked empirically:
+ * ~90 chars fits two terminal-line-wraps at typical widths, which keeps
+ * the banner compact. Long gate outputs (haiku tends to over-explain)
+ * get cut at a word boundary with an ellipsis so the cut doesn't land
+ * mid-word.
+ */
+const MAX_INSIGHT_CHARS = 90;
+
+function truncateInsight(raw: string): string {
+  const cleaned = raw.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= MAX_INSIGHT_CHARS) return cleaned;
+  const slice = cleaned.slice(0, MAX_INSIGHT_CHARS - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > MAX_INSIGHT_CHARS / 2 ? lastSpace : MAX_INSIGHT_CHARS - 1;
+  return slice.slice(0, cut).trimEnd() + "…";
+}
+
 export const localMinedRule: Rule = {
   id: "local-mined-surfaced",
   trigger: "session_start",
@@ -42,17 +60,18 @@ export const localMinedRule: Rule = {
       : "";
     if (latestInsightEntry && insight.length > 0) {
       const name = latestInsightEntry.skill_name;
+      // Three indented, emoji-prefixed lines: what we found, the artifact,
+      // the action. Each line is independently scannable so the user
+      // doesn't have to read prose to extract the takeaway. format.ts
+      // prepends 🐝 to the title; the title itself stays icon-free.
       return {
         id: "local-mined-surfaced",
         severity: "info",
-        // format.ts prepends the severity icon (info → 🐝), so the title
-        // itself stays icon-free — otherwise the rendered line shows
-        // "🐝 🐝 Hivemind found..." (two bees, one from format, one from us).
         title: `Hivemind found a pattern in your past sessions`,
         body:
-          `${insight}\n` +
-          `Minted skill \`${name}\` to catch it next time — try \`claude -p '/${name} <your prompt>'\`.\n` +
-          `Run 'hivemind login' to keep these skills across machines and share with your team.`,
+          `   📌 ${truncateInsight(insight)}\n` +
+          `   ✨ Skill \`${name}\` ready to catch it next time\n` +
+          `   🔐 Run \`hivemind login\` to share with your team`,
         // Dedup on the entry's identity so a new insight refires next
         // session, while a re-run with the same entry still dedupes.
         dedupKey: { skill_name: name, created_at: latestInsightEntry.created_at },

--- a/src/notifications/rules/local-mined.ts
+++ b/src/notifications/rules/local-mined.ts
@@ -75,6 +75,13 @@ export const localMinedRule: Rule = {
         // Dedup on the entry's identity so a new insight refires next
         // session, while a re-run with the same entry still dedupes.
         dedupKey: { skill_name: name, created_at: latestInsightEntry.created_at },
+        // The body carries LLM-derived insight prose: keep it OUT of
+        // the model-visible additionalContext channel. Without this
+        // flag, an adversarial session could influence haiku into
+        // emitting imperative text that prompt-injects future sessions
+        // (codex P1). The user still sees this notification in their
+        // terminal via systemMessage; the model just doesn't.
+        userVisibleOnly: true,
       };
     }
 

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Credentials } from "../commands/auth-creds.js";
+import type { LocalManifestEntry } from "../skillify/local-manifest.js";
 
 export type Severity = "info" | "warn" | "error";
 
@@ -50,6 +51,14 @@ export interface NotificationContext {
    * when the manifest is absent or malformed; 0 when present but empty.
    */
   localSkillsCount?: number | null;
+  /**
+   * Most recent manifest entry whose `insight` field is non-empty, or null.
+   * Powers the concrete-insight branch of the local-mined notification —
+   * when present, the rule renders the gate's quantified finding instead
+   * of the generic count. Read by the hook entry point so rules remain
+   * IO-free.
+   */
+  latestInsightEntry?: LocalManifestEntry | null;
 }
 
 export interface Rule {

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -38,6 +38,25 @@ export interface Notification {
    * behavior used by welcome, savings recap, backend pushes, etc.
    */
   transient?: boolean;
+  /**
+   * When true, the notification is delivered ONLY to the user-visible
+   * channel (Claude Code's `systemMessage`, surfacing as the
+   * `SessionStart:startup says:` terminal block) and is suppressed from
+   * the model-visible `additionalContext`.
+   *
+   * Use for notifications whose body carries content derived from
+   * untrusted LLM output that we don't want re-injected into a future
+   * session's system prompt — e.g. the concrete-insight banner whose
+   * `insight` field comes from haiku's gate output. Without this flag,
+   * an adversarial session could influence haiku into emitting
+   * imperative prose that then prompt-injects subsequent sessions.
+   *
+   * Default (omitted/false) preserves the existing dual-channel
+   * behavior (additionalContext + systemMessage carry the same text)
+   * used by static-copy rules like welcome and savings recap, where
+   * the body is hard-coded and safe to model-inject.
+   */
+  userVisibleOnly?: boolean;
 }
 
 export interface NotificationContext {

--- a/src/skillify/local-manifest.ts
+++ b/src/skillify/local-manifest.ts
@@ -110,10 +110,20 @@ export function getLatestInsightEntry(
   const m = readLocalManifest(path);
   if (!m || !Array.isArray(m.entries)) return null;
   let best: LocalManifestEntry | null = null;
+  let bestTs = Number.NEGATIVE_INFINITY;
   for (const e of m.entries) {
     if (!e || typeof e.insight !== "string" || e.insight.trim().length === 0) continue;
-    if (!best || (e.created_at ?? "") > (best.created_at ?? "")) {
+    // Compare as parsed timestamps, not raw ISO strings: lexical sort
+    // works for canonical UTC `Z` form but mis-orders when entries use
+    // different timezone offsets (e.g. `+00:00` vs `Z`) or when a
+    // future schema embeds non-ISO date variants. Date.parse returns
+    // NaN for unparseable strings; we skip those entries so a single
+    // malformed row can't shadow valid ones.
+    const ts = Date.parse(e.created_at ?? "");
+    if (!Number.isFinite(ts)) continue;
+    if (ts > bestTs) {
       best = e;
+      bestTs = ts;
     }
   }
   return best;

--- a/src/skillify/local-manifest.ts
+++ b/src/skillify/local-manifest.ts
@@ -104,23 +104,45 @@ export function countLocalManifestEntries(path: string = LOCAL_MANIFEST_PATH): n
  * `insight` field landed, so the banner can fall back to the count surface
  * without branching on a sentinel.
  */
+/**
+ * Window (ms) used to cluster manifest entries into "the most recent
+ * mine-local run." Each invocation writes its rows within milliseconds
+ * of each other, and subsequent runs typically happen at least minutes
+ * apart. 5 minutes is generous enough to cover slow disk writes /
+ * synchronization slack but tight enough to clearly separate distinct
+ * runs.
+ */
+const LATEST_RUN_WINDOW_MS = 5 * 60 * 1000;
+
 export function getLatestInsightEntry(
   path: string = LOCAL_MANIFEST_PATH,
 ): LocalManifestEntry | null {
   const m = readLocalManifest(path);
   if (!m || !Array.isArray(m.entries)) return null;
+  // First pass: find the absolute-newest entry timestamp (insight or
+  // not). This anchors the "latest run" cluster. Without this anchor,
+  // a stale historical insight would forever shadow newer runs that
+  // happened to produce no insight — and the rule's dedup state
+  // would suppress the count fallback that should have fired
+  // instead (codex P2).
+  let newestTs = Number.NEGATIVE_INFINITY;
+  for (const e of m.entries) {
+    if (!e) continue;
+    const ts = Date.parse(e.created_at ?? "");
+    if (Number.isFinite(ts) && ts > newestTs) newestTs = ts;
+  }
+  if (!Number.isFinite(newestTs)) return null;
+  // Second pass: pick the newest insight-bearing entry within the
+  // latest-run window. Date.parse handles timezone-offset variants;
+  // unparseable created_at rows are skipped so a single malformed
+  // entry can't shadow valid ones.
   let best: LocalManifestEntry | null = null;
   let bestTs = Number.NEGATIVE_INFINITY;
   for (const e of m.entries) {
     if (!e || typeof e.insight !== "string" || e.insight.trim().length === 0) continue;
-    // Compare as parsed timestamps, not raw ISO strings: lexical sort
-    // works for canonical UTC `Z` form but mis-orders when entries use
-    // different timezone offsets (e.g. `+00:00` vs `Z`) or when a
-    // future schema embeds non-ISO date variants. Date.parse returns
-    // NaN for unparseable strings; we skip those entries so a single
-    // malformed row can't shadow valid ones.
     const ts = Date.parse(e.created_at ?? "");
     if (!Number.isFinite(ts)) continue;
+    if (newestTs - ts > LATEST_RUN_WINDOW_MS) continue;
     if (ts > bestTs) {
       best = e;
       bestTs = ts;

--- a/src/skillify/local-manifest.ts
+++ b/src/skillify/local-manifest.ts
@@ -35,6 +35,16 @@ export interface LocalManifestEntry {
   created_at: string;
   /** False until a future `push-local` flow uploads the row to the org table. */
   uploaded: boolean;
+  /**
+   * One-line user-facing insight emitted by the gate alongside the skill —
+   * concrete and counted, addressed to the user in second person ("You
+   * revisited 4 merged PRs in the last month..."). Surfaced by the
+   * SessionStart banner when present so unauthenticated users see a real
+   * finding instead of an abstract skill count. Optional for backward
+   * compatibility — entries written before this field landed parse fine
+   * and fall back to the count-only banner.
+   */
+  insight?: string;
 }
 
 export interface LocalManifest {
@@ -81,4 +91,30 @@ export function countLocalManifestEntries(path: string = LOCAL_MANIFEST_PATH): n
   // Defend against malformed manifests where `entries` is present but not
   // an array (e.g. a string like "oops" would otherwise leak `.length`).
   return Array.isArray(m?.entries) ? m!.entries.length : 0;
+}
+
+/**
+ * Return the most recent manifest entry that has a non-empty `insight`, or
+ * null when none exists. "Most recent" = highest `created_at` ISO timestamp
+ * among entries that carry an insight (we don't assume manifest order).
+ *
+ * Powers the SessionStart concrete-insight banner: when the gate produced a
+ * quantified user-facing finding, we surface that instead of the generic
+ * count. Returns null cleanly for legacy manifests written before the
+ * `insight` field landed, so the banner can fall back to the count surface
+ * without branching on a sentinel.
+ */
+export function getLatestInsightEntry(
+  path: string = LOCAL_MANIFEST_PATH,
+): LocalManifestEntry | null {
+  const m = readLocalManifest(path);
+  if (!m || !Array.isArray(m.entries)) return null;
+  let best: LocalManifestEntry | null = null;
+  for (const e of m.entries) {
+    if (!e || typeof e.insight !== "string" || e.insight.trim().length === 0) continue;
+    if (!best || (e.created_at ?? "") > (best.created_at ?? "")) {
+      best = e;
+    }
+  }
+  return best;
 }

--- a/src/skillify/local-mined-banner.ts
+++ b/src/skillify/local-mined-banner.ts
@@ -1,61 +1,37 @@
 /**
  * Pure renderer for the SessionStart "local mined" surface — the text the
- * Claude Code hook appends to its additionalContext when the user hasn't
- * signed in but `hivemind skillify mine-local` has produced at least one
- * skill.
+ * Claude Code hook appends to its model-visible `additionalContext` when
+ * the user hasn't signed in but `hivemind skillify mine-local` has
+ * produced at least one skill.
  *
- * Two branches:
- *   1. We have a recent manifest entry carrying a `insight` string — render
- *      the concrete-insight surface (the pattern hivemind found, the skill
- *      minted to catch it, the sign-in CTA).
- *   2. We don't — fall back to the legacy count-only surface so users on
- *      pre-insight manifests (or whose gate skipped the insight field) still
- *      get a useful "N skills exist" hint.
+ * MODEL-SAFE BY CONSTRUCTION: this output goes into the model's system
+ * prompt, so it must contain only statically-authored copy. We do NOT
+ * render the `insight` field here, even when a manifest entry has one:
+ * `insight` originates from haiku's gate output and could be influenced
+ * by adversarial session content (codex P1 prompt-injection finding).
+ * The rich insight banner lives in `src/notifications/rules/local-mined.ts`
+ * with `userVisibleOnly: true`, which keeps it on the user-visible
+ * `systemMessage` channel only.
  *
- * Both branches end with the same sign-in CTA so unauthenticated users see a
- * concrete reason to run `hivemind login`. The string is appended to the
- * "Not logged in" warning block, so it must lead with a newline gap.
- *
- * Kept as a pure function (no fs reads, no env, no defaults) so unit tests
- * can drive both branches with synthetic inputs and assert on the rendered
- * text without standing up a tmp HOME.
+ * Kept as a pure function (no fs reads, no env, no defaults) so unit
+ * tests can drive both branches with synthetic inputs.
  */
 
-import type { LocalManifestEntry } from "./local-manifest.js";
-
 export interface LocalMinedBannerInput {
-  /** Most recent manifest entry whose `insight` is non-empty, or null. */
-  insightEntry: LocalManifestEntry | null;
   /** Total entries in the manifest (insight-bearing or not). */
   totalCount: number;
 }
 
 /**
- * Render the SessionStart "local mined" note. Returns an empty string when
- * there are no entries at all — the hook then emits no extra block.
+ * Render the SessionStart "local mined" note. Returns an empty string
+ * when there are no entries at all — the hook then emits no extra
+ * block. When entries exist, renders a count-only line with a sign-in
+ * CTA. The text is appended to the "Not logged in" warning block, so
+ * it must lead with a newline gap.
  */
 export function renderLocalMinedNote(input: LocalMinedBannerInput): string {
-  const { insightEntry, totalCount } = input;
+  const { totalCount } = input;
   if (totalCount <= 0) return "";
-
-  if (insightEntry && insightEntry.insight && insightEntry.insight.trim().length > 0) {
-    const insight = insightEntry.insight.trim();
-    const name = insightEntry.skill_name;
-    // Three lines: the finding (congratulatory), the actionable next step,
-    // and the sign-in CTA. Matches the gamification north star (always a
-    // congratulatory verb + call-to-action) while keeping the existing
-    // emoji-light style of the file.
-    return (
-      `\n\nHivemind found a pattern in your past sessions: ${insight}\n` +
-      `Minted skill \`${name}\` to catch it next time — try \`claude -p '/${name} <your prompt>'\`.\n` +
-      `Run 'hivemind login' to keep these skills across machines and share with your team.`
-    );
-  }
-
-  // Fallback: same shape as the pre-insight banner so behavior on legacy
-  // manifests is unchanged. We do NOT silently drop the surface when an
-  // entry exists without an insight — users still get the "you have N
-  // skills, sign in to share" prompt.
   const plural = totalCount === 1 ? "" : "s";
   return (
     `\n\n${totalCount} local skill${plural} from past 'hivemind skillify mine-local' run(s) live in ~/.claude/skills/. ` +

--- a/src/skillify/local-mined-banner.ts
+++ b/src/skillify/local-mined-banner.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure renderer for the SessionStart "local mined" surface — the text the
+ * Claude Code hook appends to its additionalContext when the user hasn't
+ * signed in but `hivemind skillify mine-local` has produced at least one
+ * skill.
+ *
+ * Two branches:
+ *   1. We have a recent manifest entry carrying a `insight` string — render
+ *      the concrete-insight surface (the pattern hivemind found, the skill
+ *      minted to catch it, the sign-in CTA).
+ *   2. We don't — fall back to the legacy count-only surface so users on
+ *      pre-insight manifests (or whose gate skipped the insight field) still
+ *      get a useful "N skills exist" hint.
+ *
+ * Both branches end with the same sign-in CTA so unauthenticated users see a
+ * concrete reason to run `hivemind login`. The string is appended to the
+ * "Not logged in" warning block, so it must lead with a newline gap.
+ *
+ * Kept as a pure function (no fs reads, no env, no defaults) so unit tests
+ * can drive both branches with synthetic inputs and assert on the rendered
+ * text without standing up a tmp HOME.
+ */
+
+import type { LocalManifestEntry } from "./local-manifest.js";
+
+export interface LocalMinedBannerInput {
+  /** Most recent manifest entry whose `insight` is non-empty, or null. */
+  insightEntry: LocalManifestEntry | null;
+  /** Total entries in the manifest (insight-bearing or not). */
+  totalCount: number;
+}
+
+/**
+ * Render the SessionStart "local mined" note. Returns an empty string when
+ * there are no entries at all — the hook then emits no extra block.
+ */
+export function renderLocalMinedNote(input: LocalMinedBannerInput): string {
+  const { insightEntry, totalCount } = input;
+  if (totalCount <= 0) return "";
+
+  if (insightEntry && insightEntry.insight && insightEntry.insight.trim().length > 0) {
+    const insight = insightEntry.insight.trim();
+    const name = insightEntry.skill_name;
+    // Three lines: the finding (congratulatory), the actionable next step,
+    // and the sign-in CTA. Matches the gamification north star (always a
+    // congratulatory verb + call-to-action) while keeping the existing
+    // emoji-light style of the file.
+    return (
+      `\n\nHivemind found a pattern in your past sessions: ${insight}\n` +
+      `Minted skill \`${name}\` to catch it next time — try \`claude -p '/${name} <your prompt>'\`.\n` +
+      `Run 'hivemind login' to keep these skills across machines and share with your team.`
+    );
+  }
+
+  // Fallback: same shape as the pre-insight banner so behavior on legacy
+  // manifests is unchanged. We do NOT silently drop the surface when an
+  // entry exists without an insight — users still get the "you have N
+  // skills, sign in to share" prompt.
+  const plural = totalCount === 1 ? "" : "s";
+  return (
+    `\n\n${totalCount} local skill${plural} from past 'hivemind skillify mine-local' run(s) live in ~/.claude/skills/. ` +
+    `Run 'hivemind login' to start sharing new mining results with your team.`
+  );
+}

--- a/tests/claude-code/local-manifest.test.ts
+++ b/tests/claude-code/local-manifest.test.ts
@@ -205,10 +205,11 @@ describe("getLatestInsightEntry", () => {
     expect(getLatestInsightEntry(path)).toBeNull();
   });
 
-  it("handles entries with missing `created_at` via the empty-string fallback", () => {
-    // Branch coverage for the `(e.created_at ?? "")` fallback chain —
-    // tie-breaks across entries that legitimately lack the field
-    // without throwing on undefined comparison.
+  it("skips entries with missing or unparseable `created_at`", () => {
+    // Date.parse returns NaN for unparseable / missing strings. We
+    // SKIP such entries rather than ordering them at -Infinity so a
+    // single malformed row can't shadow valid ones — and entries with
+    // a real timestamp win deterministically over those without.
     const path = manifestPath("missing-created-at");
     writeFileSync(path, JSON.stringify({
       created_at: "x",
@@ -222,7 +223,19 @@ describe("getLatestInsightEntry", () => {
           source_agent: "claude_code",
           gate_agent: "claude_code",
           uploaded: false,
-          insight: "First found.",
+          insight: "Skipped — no parseable date.",
+        },
+        {
+          skill_name: "unparseable-date",
+          canonical_path: "/x/C/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "not-a-date",
+          uploaded: false,
+          insight: "Also skipped.",
         },
         {
           skill_name: "with-date",
@@ -234,13 +247,51 @@ describe("getLatestInsightEntry", () => {
           gate_agent: "claude_code",
           created_at: "2026-05-22T00:00:00.000Z",
           uploaded: false,
-          insight: "Newer.",
+          insight: "Picked.",
         },
       ],
     }));
     const latest = getLatestInsightEntry(path);
-    // Entry with a real created_at wins the > comparison against "".
     expect(latest!.skill_name).toBe("with-date");
+  });
+
+  it("orders timezone-variant timestamps correctly via Date.parse, not lexical comparison", () => {
+    // Coderabbit regression guard: raw-string comparison would order
+    // "2026-05-21T23:59:00+00:00" AFTER "2026-05-22T00:00:00Z" because
+    // '+' < 'Z' lexically. Date.parse normalizes both to the same
+    // numeric instant, so the chronologically-later entry wins.
+    const path = manifestPath("tz-variants");
+    writeFileSync(path, JSON.stringify({
+      created_at: "x",
+      entries: [
+        {
+          skill_name: "older-tz-offset",
+          canonical_path: "/x/A/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-21T23:59:00+00:00",
+          uploaded: false,
+          insight: "Older instant.",
+        },
+        {
+          skill_name: "newer-z-form",
+          canonical_path: "/x/B/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T00:00:00Z",
+          uploaded: false,
+          insight: "Newer instant.",
+        },
+      ],
+    }));
+    const latest = getLatestInsightEntry(path);
+    expect(latest!.skill_name).toBe("newer-z-form");
   });
 
   it("picks the most recent insight-bearing entry across mixed entries", () => {

--- a/tests/claude-code/local-manifest.test.ts
+++ b/tests/claude-code/local-manifest.test.ts
@@ -255,6 +255,110 @@ describe("getLatestInsightEntry", () => {
     expect(latest!.skill_name).toBe("with-date");
   });
 
+  it("returns null when the latest mine-local run produced no insight, even if an older run did", () => {
+    // Codex P2 regression guard: getLatestInsightEntry must NOT
+    // surface a stale historical insight when subsequent runs added
+    // only non-insight entries. Without this, the localMinedRule
+    // would keep returning the same insight + dedupKey, and
+    // alreadyShown would suppress fresh count notifications,
+    // hiding new skills from the user entirely.
+    const path = manifestPath("stale-insight");
+    writeFileSync(path, JSON.stringify({
+      created_at: "x",
+      entries: [
+        // Old run: had insight.
+        {
+          skill_name: "old-insight",
+          canonical_path: "/x/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s1"],
+          source_session_paths: ["/x/s1.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-20T00:00:00.000Z",
+          uploaded: false,
+          insight: "Old insight from 2 days ago.",
+        },
+        // Newer run: no insight.
+        {
+          skill_name: "new-no-insight-a",
+          canonical_path: "/x/A/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s2"],
+          source_session_paths: ["/x/s2.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T10:00:00.000Z",
+          uploaded: false,
+        },
+        {
+          skill_name: "new-no-insight-b",
+          canonical_path: "/x/B/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s3"],
+          source_session_paths: ["/x/s3.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T10:00:00.100Z",
+          uploaded: false,
+        },
+      ],
+    }));
+    // Latest run (10:00:00.100Z) is way past the 5-min window from
+    // the old insight (2 days earlier), so the old insight is
+    // outside the latest-run cluster → return null → rule falls
+    // back to count branch.
+    expect(getLatestInsightEntry(path)).toBeNull();
+  });
+
+  it("picks the insight when the latest run produced one (alongside non-insight entries from the same batch)", () => {
+    // Sanity guard for the common case: one mine-local run produces
+    // 8 candidates, 4 with insight and 4 without. All written within
+    // ms of each other. Accessor returns the newest of the
+    // insight-bearing ones.
+    const path = manifestPath("mixed-same-batch");
+    writeFileSync(path, JSON.stringify({
+      created_at: "x",
+      entries: [
+        {
+          skill_name: "no-insight-a",
+          canonical_path: "/x/A/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s1"],
+          source_session_paths: ["/x/s1.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T10:00:00.000Z",
+          uploaded: false,
+        },
+        {
+          skill_name: "with-insight",
+          canonical_path: "/x/B/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s2"],
+          source_session_paths: ["/x/s2.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T10:00:00.050Z",
+          uploaded: false,
+          insight: "Found pattern.",
+        },
+        {
+          skill_name: "no-insight-c",
+          canonical_path: "/x/C/SKILL.md",
+          symlinks: [],
+          source_session_ids: ["s3"],
+          source_session_paths: ["/x/s3.jsonl"],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T10:00:00.100Z",
+          uploaded: false,
+        },
+      ],
+    }));
+    expect(getLatestInsightEntry(path)?.skill_name).toBe("with-insight");
+  });
+
   it("orders timezone-variant timestamps correctly via Date.parse, not lexical comparison", () => {
     // Coderabbit regression guard: raw-string comparison would order
     // "2026-05-21T23:59:00+00:00" AFTER "2026-05-22T00:00:00Z" because

--- a/tests/claude-code/local-manifest.test.ts
+++ b/tests/claude-code/local-manifest.test.ts
@@ -9,9 +9,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   countLocalManifestEntries,
+  getLatestInsightEntry,
   readLocalManifest,
   writeLocalManifest,
   type LocalManifest,
+  type LocalManifestEntry,
 } from "../../src/skillify/local-manifest.js";
 
 const TMP = mkdtempSync(join(tmpdir(), "local-manifest-test-"));
@@ -90,5 +92,104 @@ describe("readLocalManifest", () => {
     const nested = join(TMP, "a", "b", "c", "manifest.json");
     writeLocalManifest(makeManifest(1), nested);
     expect(readLocalManifest(nested)?.entries).toHaveLength(1);
+  });
+
+  it("round-trips the `insight` field on entries that carry one", () => {
+    // Schema-extension guard: writing an entry with an `insight` string
+    // must survive write → read. Without this, downstream callers
+    // (SessionStart banner) get the entry but `.insight` comes back
+    // undefined → silent fallback to count surface.
+    const path = manifestPath("insight-roundtrip");
+    const entry: LocalManifestEntry = {
+      skill_name: "verify-before-done",
+      canonical_path: "/x/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["sid"],
+      source_session_paths: ["/x/sid.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-22T00:00:00.000Z",
+      uploaded: false,
+      insight: "You revisited 4 merged PRs in the last month because tests weren't run.",
+    };
+    writeLocalManifest({ created_at: "2026-05-22T00:00:00.000Z", entries: [entry] }, path);
+    const read = readLocalManifest(path);
+    expect(read!.entries[0].insight).toBe(entry.insight);
+  });
+});
+
+describe("getLatestInsightEntry", () => {
+  it("returns null when the manifest is missing", () => {
+    expect(getLatestInsightEntry(manifestPath("nope-insight"))).toBeNull();
+  });
+
+  it("returns null when no entry carries an insight (legacy manifest)", () => {
+    // Pre-insight manifest: every entry lacks `insight`. Accessor must
+    // return null so the banner falls back to the count-only surface
+    // instead of rendering an `undefined` interpolation.
+    const path = manifestPath("legacy");
+    writeLocalManifest(makeManifest(3), path);
+    expect(getLatestInsightEntry(path)).toBeNull();
+  });
+
+  it("returns null when entries' insight strings are all empty / whitespace", () => {
+    // Belt-and-suspenders: parseMultiVerdict already collapses empty
+    // strings to undefined, but a hand-edited or future-format manifest
+    // could still carry an empty insight. Accessor treats empty/whitespace
+    // as "no insight" so the banner doesn't render a vacuous line.
+    const path = manifestPath("empty-insights");
+    const m = makeManifest(2);
+    m.entries[0].insight = "";
+    m.entries[1].insight = "   \t  ";
+    writeLocalManifest(m, path);
+    expect(getLatestInsightEntry(path)).toBeNull();
+  });
+
+  it("picks the most recent insight-bearing entry across mixed entries", () => {
+    // Mixed manifest: some entries have insight, some don't. We must
+    // return the one with the highest created_at AMONG insight-bearing
+    // entries — not the most recent overall (which might lack insight).
+    const path = manifestPath("mixed");
+    const m = makeManifest(0);
+    m.entries.push({
+      skill_name: "old-with-insight",
+      canonical_path: "/x/old/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["s1"],
+      source_session_paths: ["/x/s1.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-10T00:00:00.000Z",
+      uploaded: false,
+      insight: "Old insight.",
+    });
+    m.entries.push({
+      skill_name: "newer-without-insight",
+      canonical_path: "/x/new/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["s2"],
+      source_session_paths: ["/x/s2.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-21T00:00:00.000Z",
+      uploaded: false,
+    });
+    m.entries.push({
+      skill_name: "newest-with-insight",
+      canonical_path: "/x/newest/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["s3"],
+      source_session_paths: ["/x/s3.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-22T00:00:00.000Z",
+      uploaded: false,
+      insight: "Newest insight.",
+    });
+    writeLocalManifest(m, path);
+    const latest = getLatestInsightEntry(path);
+    expect(latest).not.toBeNull();
+    expect(latest!.skill_name).toBe("newest-with-insight");
+    expect(latest!.insight).toBe("Newest insight.");
   });
 });

--- a/tests/claude-code/local-manifest.test.ts
+++ b/tests/claude-code/local-manifest.test.ts
@@ -145,6 +145,104 @@ describe("getLatestInsightEntry", () => {
     expect(getLatestInsightEntry(path)).toBeNull();
   });
 
+  it("returns null when manifest exists but entries is not an array (malformed file)", () => {
+    // Defensive branch: a hand-edited manifest could swap `entries` from
+    // an array to a string/object. Accessor must coerce that to null
+    // rather than throw inside the for...of loop.
+    const path = manifestPath("entries-not-array-insight");
+    writeFileSync(path, JSON.stringify({ created_at: "x", entries: "oops" }));
+    expect(getLatestInsightEntry(path)).toBeNull();
+  });
+
+  it("skips null / non-object entries inside the array", () => {
+    // Mirrors parseMultiVerdict's defensive `if (!e || typeof e !== "object")`
+    // check — guards against a manifest where an entry was set to null,
+    // a string, or otherwise non-object by hand or by a future
+    // refactor accidentally pushing the wrong shape.
+    const path = manifestPath("null-entries");
+    writeFileSync(path, JSON.stringify({
+      created_at: "x",
+      entries: [
+        null,
+        "not an object",
+        {
+          skill_name: "good",
+          canonical_path: "/x/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T00:00:00.000Z",
+          uploaded: false,
+          insight: "Real insight.",
+        },
+      ],
+    }));
+    const latest = getLatestInsightEntry(path);
+    expect(latest).not.toBeNull();
+    expect(latest!.skill_name).toBe("good");
+  });
+
+  it("skips entries with non-string insight values", () => {
+    // Belt-and-suspenders against a future schema where insight is
+    // accidentally serialized as a number, array, or object.
+    const path = manifestPath("non-string-insights");
+    const m = makeManifest(0);
+    m.entries.push({
+      skill_name: "bad-insight-type",
+      canonical_path: "/x/SKILL.md",
+      symlinks: [],
+      source_session_ids: [],
+      source_session_paths: [],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-22T00:00:00.000Z",
+      uploaded: false,
+      insight: 42 as unknown as string,
+    });
+    writeLocalManifest(m, path);
+    expect(getLatestInsightEntry(path)).toBeNull();
+  });
+
+  it("handles entries with missing `created_at` via the empty-string fallback", () => {
+    // Branch coverage for the `(e.created_at ?? "")` fallback chain —
+    // tie-breaks across entries that legitimately lack the field
+    // without throwing on undefined comparison.
+    const path = manifestPath("missing-created-at");
+    writeFileSync(path, JSON.stringify({
+      created_at: "x",
+      entries: [
+        {
+          skill_name: "no-date",
+          canonical_path: "/x/A/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          uploaded: false,
+          insight: "First found.",
+        },
+        {
+          skill_name: "with-date",
+          canonical_path: "/x/B/SKILL.md",
+          symlinks: [],
+          source_session_ids: [],
+          source_session_paths: [],
+          source_agent: "claude_code",
+          gate_agent: "claude_code",
+          created_at: "2026-05-22T00:00:00.000Z",
+          uploaded: false,
+          insight: "Newer.",
+        },
+      ],
+    }));
+    const latest = getLatestInsightEntry(path);
+    // Entry with a real created_at wins the > comparison against "".
+    expect(latest!.skill_name).toBe("with-date");
+  });
+
   it("picks the most recent insight-bearing entry across mixed entries", () => {
     // Mixed manifest: some entries have insight, some don't. We must
     // return the one with the highest created_at AMONG insight-bearing

--- a/tests/claude-code/local-mined-banner.test.ts
+++ b/tests/claude-code/local-mined-banner.test.ts
@@ -1,109 +1,59 @@
 /**
- * Unit tests for src/skillify/local-mined-banner.ts — the pure renderer
- * the Claude Code SessionStart hook calls when the user hasn't signed in
- * but has run `hivemind skillify mine-local`. Both branches (concrete
- * insight present vs. count-only fallback) must be exercised because
- * they're the only conditional copy in the hook's user-visible surface.
+ * Unit tests for src/skillify/local-mined-banner.ts — the model-safe
+ * count renderer consumed by the Claude Code SessionStart hook's
+ * `additionalContext`.
+ *
+ * IMPORTANT: renderLocalMinedNote is deliberately count-only. The rich
+ * concrete-insight banner is delivered exclusively on the user-visible
+ * `systemMessage` channel by the notifications rule; LLM-derived
+ * insight prose must never reach the model-visible additionalContext
+ * to avoid a self-prompt-injection path (codex P1). These tests
+ * encode that invariant.
  */
 
 import { describe, it, expect } from "vitest";
 import { renderLocalMinedNote } from "../../src/skillify/local-mined-banner.js";
-import type { LocalManifestEntry } from "../../src/skillify/local-manifest.js";
 
-function makeEntry(over: Partial<LocalManifestEntry> = {}): LocalManifestEntry {
-  return {
-    skill_name: "verify-before-done",
-    canonical_path: "/home/x/.claude/skills/verify-before-done/SKILL.md",
-    symlinks: [],
-    source_session_ids: ["sid"],
-    source_session_paths: ["/x/sid.jsonl"],
-    source_agent: "claude_code",
-    gate_agent: "claude_code",
-    created_at: "2026-05-22T00:00:00.000Z",
-    uploaded: false,
-    ...over,
-  };
-}
-
-describe("renderLocalMinedNote", () => {
+describe("renderLocalMinedNote (model-safe count surface)", () => {
   it("returns empty string when no entries exist", () => {
     // No banner at all when nothing's been mined — the surrounding hook
     // would otherwise emit an unhelpful "0 skills" line.
-    expect(renderLocalMinedNote({ insightEntry: null, totalCount: 0 })).toBe("");
+    expect(renderLocalMinedNote({ totalCount: 0 })).toBe("");
   });
 
-  describe("concrete-insight branch", () => {
-    const insightEntry = makeEntry({
-      skill_name: "verify-before-done",
-      insight: "You revisited 4 merged PRs in the last month because tests weren't run before merge.",
-    });
-
-    it("renders the insight, skill name, and sign-in CTA", () => {
-      const out = renderLocalMinedNote({ insightEntry, totalCount: 3 });
-      // Concrete + quantified line surfaced verbatim
-      expect(out).toContain(
-        "Hivemind found a pattern in your past sessions: You revisited 4 merged PRs",
-      );
-      // Skill name surfaced + actionable claude -p invocation
-      expect(out).toContain("`verify-before-done`");
-      expect(out).toContain("claude -p '/verify-before-done");
-      // Sign-in CTA — the whole reason this surface exists pre-auth
-      expect(out).toContain("hivemind login");
-      // Negative pattern: the legacy count line MUST NOT appear when an
-      // insight is present (we replaced it, not appended to it)
-      expect(out).not.toMatch(/\d+ local skill/);
-    });
-
-    it("starts with a blank-line separator so it appends cleanly to the warning block", () => {
-      // The hook appends this to a "Not logged in" line — without the
-      // leading "\n\n" the banner glues onto the warning sentence and
-      // becomes unreadable.
-      const out = renderLocalMinedNote({ insightEntry, totalCount: 1 });
-      expect(out.startsWith("\n\n")).toBe(true);
-    });
-
-    it("trims surrounding whitespace from the insight before rendering", () => {
-      // The accessor (getLatestInsightEntry) returns the entry as-stored;
-      // the renderer is the last guard before user-visible copy. If a
-      // future code path lets a padded insight through, we still render
-      // a clean line.
-      const padded = makeEntry({
-        insight: "   You hit the same env-mismatch twice this week.   \n",
-      });
-      const out = renderLocalMinedNote({ insightEntry: padded, totalCount: 1 });
-      expect(out).toContain(": You hit the same env-mismatch twice this week.");
-      expect(out).not.toContain(":    You hit");
-    });
+  it("renders the legacy count surface with the sign-in CTA", () => {
+    const out = renderLocalMinedNote({ totalCount: 5 });
+    expect(out).toContain("5 local skills from past 'hivemind skillify mine-local'");
+    expect(out).toContain("hivemind login");
   });
 
-  describe("count-only fallback branch", () => {
-    it("renders the legacy count surface when no insight-bearing entry is present", () => {
-      // Mirrors what existing pre-insight users see today — must keep
-      // working byte-for-byte for entries written before the field landed.
-      const out = renderLocalMinedNote({ insightEntry: null, totalCount: 5 });
-      expect(out).toContain("5 local skills from past 'hivemind skillify mine-local'");
-      expect(out).toContain("hivemind login");
-      // Negative pattern: must NOT mention "found a pattern" / a skill
-      // name / a `claude -p` invocation — those belong only to the
-      // insight branch and would be hallucinated copy in the fallback.
-      expect(out).not.toContain("found a pattern");
-      expect(out).not.toContain("claude -p");
-    });
+  it("uses singular noun for exactly one entry", () => {
+    const out = renderLocalMinedNote({ totalCount: 1 });
+    expect(out).toContain("1 local skill from past");
+    expect(out).not.toContain("1 local skills");
+  });
 
-    it("uses singular noun for exactly one entry", () => {
-      const out = renderLocalMinedNote({ insightEntry: null, totalCount: 1 });
-      expect(out).toContain("1 local skill from past");
-      expect(out).not.toContain("1 local skills");
-    });
+  it("starts with a blank-line separator so it appends cleanly to the warning block", () => {
+    // The hook appends this to a "Not logged in" line — without the
+    // leading "\n\n" the banner glues onto the warning sentence and
+    // becomes unreadable.
+    const out = renderLocalMinedNote({ totalCount: 1 });
+    expect(out.startsWith("\n\n")).toBe(true);
+  });
 
-    it("falls back to count surface when the insight string is empty / whitespace", () => {
-      // Defense-in-depth: getLatestInsightEntry already filters these,
-      // but if a caller ever passes a malformed entry directly we must
-      // not render `: ` with nothing after it.
-      const empty = makeEntry({ insight: "   " });
-      const out = renderLocalMinedNote({ insightEntry: empty, totalCount: 2 });
-      expect(out).toContain("2 local skills from past");
-      expect(out).not.toContain("found a pattern");
-    });
+  it("MUST NOT mention any insight content (security invariant)", () => {
+    // Regression guard for codex P1: this function is consumed by
+    // session-start.js → additionalContext (model-visible). It must
+    // never include LLM-derived prose, skill names from gate output,
+    // or anything else that could carry adversarial content. The
+    // signature was explicitly narrowed to drop the insightEntry
+    // parameter — assert the rendered output never trips known
+    // insight-branch markers either.
+    const out = renderLocalMinedNote({ totalCount: 7 });
+    expect(out).not.toContain("found a pattern");
+    expect(out).not.toContain("📌");
+    expect(out).not.toContain("✨");
+    expect(out).not.toContain("Minted skill");
+    expect(out).not.toContain("claude -p");
   });
 });

--- a/tests/claude-code/local-mined-banner.test.ts
+++ b/tests/claude-code/local-mined-banner.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for src/skillify/local-mined-banner.ts — the pure renderer
+ * the Claude Code SessionStart hook calls when the user hasn't signed in
+ * but has run `hivemind skillify mine-local`. Both branches (concrete
+ * insight present vs. count-only fallback) must be exercised because
+ * they're the only conditional copy in the hook's user-visible surface.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderLocalMinedNote } from "../../src/skillify/local-mined-banner.js";
+import type { LocalManifestEntry } from "../../src/skillify/local-manifest.js";
+
+function makeEntry(over: Partial<LocalManifestEntry> = {}): LocalManifestEntry {
+  return {
+    skill_name: "verify-before-done",
+    canonical_path: "/home/x/.claude/skills/verify-before-done/SKILL.md",
+    symlinks: [],
+    source_session_ids: ["sid"],
+    source_session_paths: ["/x/sid.jsonl"],
+    source_agent: "claude_code",
+    gate_agent: "claude_code",
+    created_at: "2026-05-22T00:00:00.000Z",
+    uploaded: false,
+    ...over,
+  };
+}
+
+describe("renderLocalMinedNote", () => {
+  it("returns empty string when no entries exist", () => {
+    // No banner at all when nothing's been mined — the surrounding hook
+    // would otherwise emit an unhelpful "0 skills" line.
+    expect(renderLocalMinedNote({ insightEntry: null, totalCount: 0 })).toBe("");
+  });
+
+  describe("concrete-insight branch", () => {
+    const insightEntry = makeEntry({
+      skill_name: "verify-before-done",
+      insight: "You revisited 4 merged PRs in the last month because tests weren't run before merge.",
+    });
+
+    it("renders the insight, skill name, and sign-in CTA", () => {
+      const out = renderLocalMinedNote({ insightEntry, totalCount: 3 });
+      // Concrete + quantified line surfaced verbatim
+      expect(out).toContain(
+        "Hivemind found a pattern in your past sessions: You revisited 4 merged PRs",
+      );
+      // Skill name surfaced + actionable claude -p invocation
+      expect(out).toContain("`verify-before-done`");
+      expect(out).toContain("claude -p '/verify-before-done");
+      // Sign-in CTA — the whole reason this surface exists pre-auth
+      expect(out).toContain("hivemind login");
+      // Negative pattern: the legacy count line MUST NOT appear when an
+      // insight is present (we replaced it, not appended to it)
+      expect(out).not.toMatch(/\d+ local skill/);
+    });
+
+    it("starts with a blank-line separator so it appends cleanly to the warning block", () => {
+      // The hook appends this to a "Not logged in" line — without the
+      // leading "\n\n" the banner glues onto the warning sentence and
+      // becomes unreadable.
+      const out = renderLocalMinedNote({ insightEntry, totalCount: 1 });
+      expect(out.startsWith("\n\n")).toBe(true);
+    });
+
+    it("trims surrounding whitespace from the insight before rendering", () => {
+      // The accessor (getLatestInsightEntry) returns the entry as-stored;
+      // the renderer is the last guard before user-visible copy. If a
+      // future code path lets a padded insight through, we still render
+      // a clean line.
+      const padded = makeEntry({
+        insight: "   You hit the same env-mismatch twice this week.   \n",
+      });
+      const out = renderLocalMinedNote({ insightEntry: padded, totalCount: 1 });
+      expect(out).toContain(": You hit the same env-mismatch twice this week.");
+      expect(out).not.toContain(":    You hit");
+    });
+  });
+
+  describe("count-only fallback branch", () => {
+    it("renders the legacy count surface when no insight-bearing entry is present", () => {
+      // Mirrors what existing pre-insight users see today — must keep
+      // working byte-for-byte for entries written before the field landed.
+      const out = renderLocalMinedNote({ insightEntry: null, totalCount: 5 });
+      expect(out).toContain("5 local skills from past 'hivemind skillify mine-local'");
+      expect(out).toContain("hivemind login");
+      // Negative pattern: must NOT mention "found a pattern" / a skill
+      // name / a `claude -p` invocation — those belong only to the
+      // insight branch and would be hallucinated copy in the fallback.
+      expect(out).not.toContain("found a pattern");
+      expect(out).not.toContain("claude -p");
+    });
+
+    it("uses singular noun for exactly one entry", () => {
+      const out = renderLocalMinedNote({ insightEntry: null, totalCount: 1 });
+      expect(out).toContain("1 local skill from past");
+      expect(out).not.toContain("1 local skills");
+    });
+
+    it("falls back to count surface when the insight string is empty / whitespace", () => {
+      // Defense-in-depth: getLatestInsightEntry already filters these,
+      // but if a caller ever passes a malformed entry directly we must
+      // not render `: ` with nothing after it.
+      const empty = makeEntry({ insight: "   " });
+      const out = renderLocalMinedNote({ insightEntry: empty, totalCount: 2 });
+      expect(out).toContain("2 local skills from past");
+      expect(out).not.toContain("found a pattern");
+    });
+  });
+});

--- a/tests/claude-code/mine-local-helpers.test.ts
+++ b/tests/claude-code/mine-local-helpers.test.ts
@@ -244,6 +244,45 @@ describe("parseMultiVerdict", () => {
     expect(mv!.skills[1].insight).toBeUndefined();
   });
 
+  it("normalizes embedded whitespace (drops newlines that could carry prompt-like text)", () => {
+    // Sanitization-at-the-boundary: gate output is unbounded model text.
+    // Multi-line insight that gets stored verbatim could leak prompt-like
+    // instructions into future SessionStart context. We collapse any run
+    // of whitespace to a single space before persisting.
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [
+        {
+          name: "k",
+          description: "d",
+          body: "b",
+          insight: "Line one.\n\nLine two.\tTabbed.   Multi-spaced.",
+        },
+      ],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills[0].insight).toBe(
+      "Line one. Line two. Tabbed. Multi-spaced.",
+    );
+    expect(mv!.skills[0].insight).not.toContain("\n");
+    expect(mv!.skills[0].insight).not.toContain("\t");
+  });
+
+  it("caps insight at 280 chars to bound hook payload size", () => {
+    // Pathological gate outputs (haiku occasionally returns 1k+ chars)
+    // would bloat the manifest and every SessionStart hook stdout. Hard
+    // cap at the parse boundary so downstream consumers see a bounded
+    // string regardless of model behavior.
+    const long = "x".repeat(500);
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [{ name: "k", description: "d", body: "b", insight: long }],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills[0].insight!.length).toBe(280);
+    expect(mv!.skills[0].insight).toBe("x".repeat(280));
+  });
+
   it("ignores non-string insight values", () => {
     const raw = JSON.stringify({
       reason: "ok",

--- a/tests/claude-code/mine-local-helpers.test.ts
+++ b/tests/claude-code/mine-local-helpers.test.ts
@@ -195,4 +195,66 @@ describe("parseMultiVerdict", () => {
     expect(mv!.skills).toHaveLength(1);
     expect(mv!.skills[0].name).toBe("kept");
   });
+
+  it("picks up `insight` when present and trims it", () => {
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [
+        {
+          name: "verify-before-done",
+          description: "verify before declaring done",
+          body: "## body",
+          insight: "  You revisited 4 merged PRs because tests weren't run before merge.  ",
+        },
+      ],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills[0].insight).toBe(
+      "You revisited 4 merged PRs because tests weren't run before merge.",
+    );
+  });
+
+  it("omits `insight` when missing entirely", () => {
+    // Cover the absence branch — manifest entry must persist `undefined`,
+    // not an empty string sentinel, so the SessionStart banner falls back
+    // cleanly to the count surface for entries that don't carry an insight.
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [{ name: "k", description: "d", body: "b" }],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills[0].insight).toBeUndefined();
+  });
+
+  it("collapses empty / whitespace-only insight to undefined", () => {
+    // Anti-pattern guard: an empty-string insight would still satisfy
+    // `typeof s.insight === "string"` in the manifest write site and leak
+    // a vacuous entry into the SessionStart banner. parseMultiVerdict
+    // normalizes both empty and pure-whitespace inputs to undefined.
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [
+        { name: "a", description: "x", body: "y", insight: "" },
+        { name: "b", description: "x", body: "y", insight: "    " },
+      ],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills).toHaveLength(2);
+    expect(mv!.skills[0].insight).toBeUndefined();
+    expect(mv!.skills[1].insight).toBeUndefined();
+  });
+
+  it("ignores non-string insight values", () => {
+    const raw = JSON.stringify({
+      reason: "ok",
+      skills: [
+        { name: "k", description: "x", body: "y", insight: 42 },
+        { name: "l", description: "x", body: "y", insight: { wat: "no" } },
+        { name: "m", description: "x", body: "y", insight: ["array"] },
+      ],
+    });
+    const mv = parseMultiVerdict(raw);
+    expect(mv!.skills).toHaveLength(3);
+    for (const s of mv!.skills) expect(s.insight).toBeUndefined();
+  });
 });

--- a/tests/claude-code/notifications-coverage.test.ts
+++ b/tests/claude-code/notifications-coverage.test.ts
@@ -146,15 +146,101 @@ describe("rules registry — edge cases", () => {
 // delivery/index.ts: empty-string short-circuit
 // ---------------------------------------------------------------------------
 
-describe("delivery dispatch — empty rendered short-circuit", () => {
-  it("emit() returns silently when rendered is empty string", () => {
+describe("delivery dispatch — empty short-circuit", () => {
+  it("emit() returns silently when notifications array is empty", () => {
+    // The dispatch now takes notifications (not a pre-rendered string)
+    // so per-agent adapters can split content per channel — see the
+    // model/user split in delivery/claude-code.ts. An empty list still
+    // short-circuits without writing anything to stdout.
     const writes: string[] = [];
     vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
       writes.push(typeof c === "string" ? c : c.toString());
       return true;
     });
-    emit("claude-code", "");
+    emit("claude-code", []);
     expect(writes).toEqual([]);
+    vi.restoreAllMocks();
+  });
+
+  it("routes userVisibleOnly notifications to systemMessage ONLY, never to additionalContext (codex P1 guard)", () => {
+    // Security invariant: notifications carrying LLM-derived content
+    // set userVisibleOnly so their body never reaches the model's
+    // additionalContext channel. The user still sees the message in
+    // the terminal via systemMessage. Without this split an
+    // adversarial gate output could prompt-inject the next session.
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
+      writes.push(typeof c === "string" ? c : c.toString());
+      return true;
+    });
+    emit("claude-code", [
+      {
+        id: "user-only",
+        severity: "info",
+        title: "User-visible title",
+        body: "BODY-WITH-LLM-PROSE",
+        dedupKey: { x: 1 },
+        userVisibleOnly: true,
+      },
+    ]);
+    expect(writes).toHaveLength(1);
+    const payload = JSON.parse(writes[0]);
+    expect(payload.systemMessage).toContain("BODY-WITH-LLM-PROSE");
+    expect(payload.hookSpecificOutput.additionalContext).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  it("routes non-user-only notifications to BOTH channels (legacy behavior)", () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
+      writes.push(typeof c === "string" ? c : c.toString());
+      return true;
+    });
+    emit("claude-code", [
+      {
+        id: "regular",
+        severity: "info",
+        title: "Static title",
+        body: "STATIC-BODY",
+        dedupKey: { x: 1 },
+      },
+    ]);
+    const payload = JSON.parse(writes[0]);
+    expect(payload.systemMessage).toContain("STATIC-BODY");
+    expect(payload.hookSpecificOutput.additionalContext).toContain("STATIC-BODY");
+    vi.restoreAllMocks();
+  });
+
+  it("emits a mixed batch correctly: only safe items reach additionalContext, all items reach systemMessage", () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
+      writes.push(typeof c === "string" ? c : c.toString());
+      return true;
+    });
+    emit("claude-code", [
+      {
+        id: "safe",
+        severity: "info",
+        title: "Safe",
+        body: "STATIC-BODY",
+        dedupKey: { x: 1 },
+      },
+      {
+        id: "unsafe",
+        severity: "info",
+        title: "Unsafe",
+        body: "LLM-DERIVED",
+        dedupKey: { x: 2 },
+        userVisibleOnly: true,
+      },
+    ]);
+    const payload = JSON.parse(writes[0]);
+    // additionalContext (model channel) has ONLY the safe body
+    expect(payload.hookSpecificOutput.additionalContext).toContain("STATIC-BODY");
+    expect(payload.hookSpecificOutput.additionalContext).not.toContain("LLM-DERIVED");
+    // systemMessage (user channel) has BOTH
+    expect(payload.systemMessage).toContain("STATIC-BODY");
+    expect(payload.systemMessage).toContain("LLM-DERIVED");
     vi.restoreAllMocks();
   });
 });

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -191,6 +191,100 @@ describe("localMinedRule", () => {
     });
     expect(r5!.dedupKey).not.toEqual(r7!.dedupKey);
   });
+
+  it("fires the concrete-insight branch when latestInsightEntry is populated", () => {
+    // Conversion-surface guard: when the gate produced a quantified
+    // insight, we MUST render it instead of the abstract count copy.
+    // The whole install→signup pitch depends on this branch firing.
+    const result = localMinedRule.evaluate({
+      agent: "claude-code",
+      creds: null,
+      state: { shown: {} },
+      localSkillsCount: 11,
+      latestInsightEntry: {
+        skill_name: "verify-before-done",
+        canonical_path: "/x/SKILL.md",
+        symlinks: [],
+        source_session_ids: ["sid"],
+        source_session_paths: ["/x/sid.jsonl"],
+        source_agent: "claude_code",
+        gate_agent: "claude_code",
+        created_at: "2026-05-22T08:58:07.613Z",
+        uploaded: false,
+        insight: "You revisited 4 merged PRs in the last month because tests weren't run before merge.",
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain("Hivemind found a pattern");
+    // Title MUST NOT carry the bee — format.ts prepends the severity icon
+    // (info → 🐝), so double-bee output is the bug we're guarding against.
+    expect(result!.title).not.toContain("🐝");
+    expect(result!.body).toContain("You revisited 4 merged PRs");
+    expect(result!.body).toContain("`verify-before-done`");
+    expect(result!.body).toContain("claude -p '/verify-before-done");
+    expect(result!.body).toContain("hivemind login");
+    // Negative: must NOT carry the abstract count phrasing when an
+    // insight is being rendered — that branch is mutually exclusive.
+    expect(result!.title).not.toContain("11 skills");
+    // Dedup keyed on the entry identity, not the count: a new insight
+    // refires, the same entry dedupes.
+    expect(result!.dedupKey).toEqual({
+      skill_name: "verify-before-done",
+      created_at: "2026-05-22T08:58:07.613Z",
+    });
+  });
+
+  it("falls back to the count branch when latestInsightEntry has empty insight", () => {
+    // Defense-in-depth: getLatestInsightEntry filters empty strings, but
+    // a malformed manifest could slip a non-trimmed entry through. The
+    // rule double-checks and falls back to the legacy count surface
+    // rather than rendering a vacuous "Hivemind found a pattern: " line.
+    const result = localMinedRule.evaluate({
+      agent: "claude-code",
+      creds: null,
+      state: { shown: {} },
+      localSkillsCount: 3,
+      latestInsightEntry: {
+        skill_name: "verify-before-done",
+        canonical_path: "/x/SKILL.md",
+        symlinks: [],
+        source_session_ids: ["sid"],
+        source_session_paths: ["/x/sid.jsonl"],
+        source_agent: "claude_code",
+        gate_agent: "claude_code",
+        created_at: "2026-05-22T08:58:07.613Z",
+        uploaded: false,
+        insight: "   ",
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain("3 skills");
+    expect(result!.title).not.toContain("Hivemind found a pattern");
+    expect(result!.dedupKey).toEqual({ count: 3 });
+  });
+
+  it("insight-branch dedupKey changes across distinct insights so a fresh insight re-fires", () => {
+    const entryA = {
+      skill_name: "verify-before-done",
+      canonical_path: "/x/A/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["s1"],
+      source_session_paths: ["/x/s1.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-22T08:00:00.000Z",
+      uploaded: false,
+      insight: "Insight A.",
+    };
+    const entryB = { ...entryA, skill_name: "ask-first-propose-second", canonical_path: "/x/B/SKILL.md", insight: "Insight B." };
+    const a = localMinedRule.evaluate({
+      agent: "claude-code", creds: null, state: { shown: {} }, localSkillsCount: 1, latestInsightEntry: entryA,
+    });
+    const b = localMinedRule.evaluate({
+      agent: "claude-code", creds: null, state: { shown: {} }, localSkillsCount: 1, latestInsightEntry: entryB,
+    });
+    expect(a!.dedupKey).not.toEqual(b!.dedupKey);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -219,13 +219,24 @@ describe("localMinedRule", () => {
     // Title MUST NOT carry the bee — format.ts prepends the severity icon
     // (info → 🐝), so double-bee output is the bug we're guarding against.
     expect(result!.title).not.toContain("🐝");
+    // Three-line structured body: each line independently scannable with
+    // its own emoji prefix.
+    expect(result!.body).toContain("📌");
     expect(result!.body).toContain("You revisited 4 merged PRs");
+    expect(result!.body).toContain("✨");
     expect(result!.body).toContain("`verify-before-done`");
-    expect(result!.body).toContain("claude -p '/verify-before-done");
+    expect(result!.body).toContain("🔐");
     expect(result!.body).toContain("hivemind login");
-    // Negative: must NOT carry the abstract count phrasing when an
-    // insight is being rendered — that branch is mutually exclusive.
+    // Negative patterns:
+    // - The verbose `claude -p '/skill <prompt>'` invocation was dropped;
+    //   users won't act on it and it clutters the surface.
+    expect(result!.body).not.toContain("claude -p");
+    // - Abstract count phrasing is mutually exclusive with insight branch.
     expect(result!.title).not.toContain("11 skills");
+    // - Body lines must be indented so wrapping renders cleanly under
+    //   each emoji marker.
+    expect(result!.body).toMatch(/\n {3}✨/);
+    expect(result!.body).toMatch(/\n {3}🔐/);
     // Dedup keyed on the entry identity, not the count: a new insight
     // refires, the same entry dedupes.
     expect(result!.dedupKey).toEqual({
@@ -261,6 +272,67 @@ describe("localMinedRule", () => {
     expect(result!.title).toContain("3 skills");
     expect(result!.title).not.toContain("Hivemind found a pattern");
     expect(result!.dedupKey).toEqual({ count: 3 });
+  });
+
+  it("truncates over-long insights at a word boundary with an ellipsis", () => {
+    // Haiku often returns 40+ word paragraphs. The banner is single-slot
+    // session-start surface — long prose buries the takeaway. Rule must
+    // truncate to ≤~90 chars at a word boundary so the user-visible line
+    // stays scannable.
+    const longInsight =
+      "You traced npm corruption back to SessionStart hooks calling autoUpdate() twice per session without inter-process locks, exposing a documented-but-unimplemented follow-up that caused cascading failures across every session restart.";
+    const result = localMinedRule.evaluate({
+      agent: "claude-code",
+      creds: null,
+      state: { shown: {} },
+      localSkillsCount: 1,
+      latestInsightEntry: {
+        skill_name: "concurrent-subprocess-serialization-pattern",
+        canonical_path: "/x/SKILL.md",
+        symlinks: [],
+        source_session_ids: ["sid"],
+        source_session_paths: ["/x/sid.jsonl"],
+        source_agent: "claude_code",
+        gate_agent: "claude_code",
+        created_at: "2026-05-22T08:58:07.618Z",
+        uploaded: false,
+        insight: longInsight,
+      },
+    });
+    expect(result).not.toBeNull();
+    const insightLine = result!.body.split("\n").find(l => l.includes("📌"))!;
+    // Truncated line stays ≤ ~94 chars total (3 indent + 📌 + space + 90).
+    expect(insightLine.length).toBeLessThanOrEqual(100);
+    expect(insightLine.endsWith("…")).toBe(true);
+    // Word-boundary truncation: must NOT cut mid-word. The last visible
+    // word before the ellipsis must be a complete token from the input.
+    const beforeEllipsis = insightLine.slice(0, -1).trim();
+    const lastWord = beforeEllipsis.split(" ").pop()!;
+    expect(longInsight).toContain(lastWord);
+  });
+
+  it("short insights pass through untouched", () => {
+    const short = "You hit npm corruption twice this week.";
+    const result = localMinedRule.evaluate({
+      agent: "claude-code",
+      creds: null,
+      state: { shown: {} },
+      localSkillsCount: 1,
+      latestInsightEntry: {
+        skill_name: "npm-corruption-guard",
+        canonical_path: "/x/SKILL.md",
+        symlinks: [],
+        source_session_ids: ["sid"],
+        source_session_paths: ["/x/sid.jsonl"],
+        source_agent: "claude_code",
+        gate_agent: "claude_code",
+        created_at: "2026-05-22T08:58:07.618Z",
+        uploaded: false,
+        insight: short,
+      },
+    });
+    expect(result!.body).toContain(short);
+    expect(result!.body).not.toContain("…");
   });
 
   it("insight-branch dedupKey changes across distinct insights so a fresh insight re-fires", () => {

--- a/tests/claude-code/notifications.test.ts
+++ b/tests/claude-code/notifications.test.ts
@@ -166,6 +166,10 @@ describe("localMinedRule", () => {
     expect(result!.title).toContain("5 skills");
     expect(result!.body).toContain("hivemind login");
     expect(result!.dedupKey).toEqual({ count: 5 });
+    // Fallback count branch uses fully static copy — safe for both
+    // channels, so userVisibleOnly stays absent (default = false).
+    // The model can know "5 skills exist" without security risk.
+    expect(result!.userVisibleOnly).toBeUndefined();
   });
 
   it("fires with singular noun when count === 1", () => {
@@ -219,6 +223,13 @@ describe("localMinedRule", () => {
     // Title MUST NOT carry the bee — format.ts prepends the severity icon
     // (info → 🐝), so double-bee output is the bug we're guarding against.
     expect(result!.title).not.toContain("🐝");
+    // SECURITY INVARIANT (codex P1): this body carries LLM-derived
+    // prose, so the notification framework MUST keep it off the
+    // model-visible additionalContext channel. The rule signals that
+    // by setting userVisibleOnly. Without this flag the delivery
+    // adapter would push the insight into both channels and create a
+    // self-prompt-injection vector.
+    expect(result!.userVisibleOnly).toBe(true);
     // Three-line structured body: each line independently scannable with
     // its own emoji prefix.
     expect(result!.body).toContain("📌");

--- a/tests/claude-code/session-start-hook.test.ts
+++ b/tests/claude-code/session-start-hook.test.ts
@@ -79,6 +79,20 @@ vi.mock("../../src/skillify/local-manifest.js", async (importOriginal) => {
   };
 });
 
+// maybeAutoMineLocal mocked so the un-authed branch's both outcomes are
+// reachable without doing real file IO. Real call returns
+// `triggered: false, reason: "no-claude-sessions"` in the test env, which
+// leaves the `triggered === true` branch on session-start.ts:145
+// uncovered — a coverage gap CI's branch threshold (≥90%) flags.
+const maybeAutoMineLocalMock = vi.fn();
+vi.mock("../../src/skillify/spawn-mine-local-worker.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/skillify/spawn-mine-local-worker.js")>();
+  return {
+    ...actual,
+    maybeAutoMineLocal: (...a: unknown[]) => maybeAutoMineLocalMock(...a),
+  };
+});
+
 let stdoutLines: string[] = [];
 const stdoutSpy = vi.spyOn(process.stdout, "write");
 
@@ -134,6 +148,10 @@ beforeEach(() => {
   // the new concrete-insight rendering.
   countLocalManifestEntriesMock.mockReset().mockReturnValue(0);
   getLatestInsightEntryMock.mockReset().mockReturnValue(null);
+  // Default: auto-mine guards trip (no claude sessions) — matches the
+  // common test scenario where the developer's HOME has no local
+  // sessions visible to the test runner.
+  maybeAutoMineLocalMock.mockReset().mockReturnValue({ triggered: false, reason: "no-claude-sessions" });
   // Disable auto-pull during this test: autoPullSkills would otherwise issue
   // an extra SQL query (against `skills`) through the same DeeplakeApi mock,
   // breaking the placeholder-branching call-count assertions. The auto-pull
@@ -385,6 +403,17 @@ describe("session-start hook — context shape edge cases", () => {
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("5 local skills from past");
     expect(ctx).toContain("hivemind login");
+  });
+
+  it("logs `auto-mine: triggered (background)` when maybeAutoMineLocal returns triggered=true", async () => {
+    // Coverage guard for the ternary on src/hooks/session-start.ts:145.
+    // The "triggered=true" branch is what runs on real fresh-install
+    // flows — a coverage gap there means the path the conversion play
+    // depends on isn't asserted.
+    loadCredsMock.mockReturnValue(null);
+    maybeAutoMineLocalMock.mockReturnValueOnce({ triggered: true });
+    await runHook();
+    expect(debugLogMock).toHaveBeenCalledWith("auto-mine: triggered (background)");
   });
 
   it("renders the CONCRETE INSIGHT branch when getLatestInsightEntry returns a populated entry", async () => {

--- a/tests/claude-code/session-start-hook.test.ts
+++ b/tests/claude-code/session-start-hook.test.ts
@@ -63,19 +63,11 @@ vi.mock("../../src/utils/version-check.js", async (importOriginal) => {
 // N>1 → "N local skills") without depending on the developer's real
 // ~/.claude/hivemind/local-mined.json.
 const countLocalManifestEntriesMock = vi.fn();
-const getLatestInsightEntryMock = vi.fn();
 vi.mock("../../src/skillify/local-manifest.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/skillify/local-manifest.js")>();
   return {
     ...actual,
     countLocalManifestEntries: (...a: unknown[]) => countLocalManifestEntriesMock(...a),
-    // Mock the insight accessor too: without this the session-start hook
-    // reads the developer's real ~/.claude/hivemind/local-mined.json at
-    // test time, leaking real-disk insight strings into a test that only
-    // mocked the count. CI runners with a pre-populated manifest would
-    // see the insight branch fire when the test expected the count
-    // fallback, producing a misleading red.
-    getLatestInsightEntry: (...a: unknown[]) => getLatestInsightEntryMock(...a),
   };
 });
 
@@ -142,12 +134,11 @@ beforeEach(() => {
   queryMock.mockReset().mockResolvedValue([]); // "no existing summary"
   autoUpdateMock.mockReset().mockResolvedValue(undefined);
   getInstalledVersionMock.mockReset().mockReturnValue("9.9.9");
-  // Default: no manifest → 0 mined skills, no insight entry. Individual
-  // tests override either or both. The insight mock MUST default to null
-  // so existing "legacy count branch" assertions don't accidentally trip
-  // the new concrete-insight rendering.
+  // Default: no manifest → 0 mined skills. Individual tests override.
+  // The hook's model-visible additionalContext NEVER renders insight
+  // prose (security invariant — see local-mined-banner.ts docstring),
+  // so we don't need a getLatestInsightEntry mock here.
   countLocalManifestEntriesMock.mockReset().mockReturnValue(0);
-  getLatestInsightEntryMock.mockReset().mockReturnValue(null);
   // Default: auto-mine guards trip (no claude sessions) — matches the
   // common test scenario where the developer's HOME has no local
   // sessions visible to the test runner.
@@ -416,36 +407,30 @@ describe("session-start hook — context shape edge cases", () => {
     expect(debugLogMock).toHaveBeenCalledWith("auto-mine: triggered (background)");
   });
 
-  it("renders the CONCRETE INSIGHT branch when getLatestInsightEntry returns a populated entry", async () => {
-    // Conversion-surface guard for the model-visible additionalContext.
-    // The user-visible side is covered by the notifications-rule tests;
-    // this one ensures the hook itself swaps in the insight rendering
-    // when an entry carries a non-empty `insight` field.
+  it("MUST NOT render insight prose in additionalContext, even when manifest is full (security invariant)", async () => {
+    // Codex P1 regression guard: the hook's model-visible
+    // additionalContext channel must never carry LLM-derived insight
+    // strings. session-start.js used to call getLatestInsightEntry()
+    // and feed the gate's prose into additionalContext, which is a
+    // prompt-injection vector. The rich insight banner now lives
+    // exclusively on the user-visible systemMessage channel via the
+    // notifications rule. Test by simulating a populated manifest
+    // and asserting the count surface fires, not the insight one.
     loadCredsMock.mockReturnValue(null);
     countLocalManifestEntriesMock.mockReturnValue(7);
-    getLatestInsightEntryMock.mockReturnValue({
-      skill_name: "verify-before-done",
-      canonical_path: "/x/SKILL.md",
-      symlinks: [],
-      source_session_ids: ["sid"],
-      source_session_paths: ["/x/sid.jsonl"],
-      source_agent: "claude_code",
-      gate_agent: "claude_code",
-      created_at: "2026-05-22T08:58:07.613Z",
-      uploaded: false,
-      insight: "You revisited 4 merged PRs in the last month because tests weren't run before merge.",
-    });
     const out = await runHook();
     const parsed = JSON.parse(out!);
     const ctx = parsed.hookSpecificOutput.additionalContext;
-    // Insight branch took over → user sees the concrete pattern, not a
-    // bare count. Negative pattern: the legacy "N local skills" phrasing
-    // MUST NOT appear when insight branch fires (mutually exclusive).
-    expect(ctx).toContain("Hivemind found a pattern in your past sessions");
-    expect(ctx).toContain("You revisited 4 merged PRs");
-    expect(ctx).toContain("`verify-before-done`");
+    expect(ctx).toContain("7 local skills from past");
     expect(ctx).toContain("hivemind login");
-    expect(ctx).not.toContain("7 local skills from past");
+    // Negative patterns — these are exactly what the user-visible
+    // notifications-rule branch renders. If any of them slip into
+    // additionalContext, the prompt-injection vector is back.
+    expect(ctx).not.toContain("found a pattern");
+    expect(ctx).not.toContain("📌");
+    expect(ctx).not.toContain("✨");
+    expect(ctx).not.toContain("Minted skill");
+    expect(ctx).not.toContain("claude -p '/");
   });
 
   it("does NOT append the mined-skills note when user is logged in (even with manifest present)", async () => {

--- a/tests/claude-code/session-start-hook.test.ts
+++ b/tests/claude-code/session-start-hook.test.ts
@@ -63,9 +63,20 @@ vi.mock("../../src/utils/version-check.js", async (importOriginal) => {
 // N>1 → "N local skills") without depending on the developer's real
 // ~/.claude/hivemind/local-mined.json.
 const countLocalManifestEntriesMock = vi.fn();
+const getLatestInsightEntryMock = vi.fn();
 vi.mock("../../src/skillify/local-manifest.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/skillify/local-manifest.js")>();
-  return { ...actual, countLocalManifestEntries: (...a: unknown[]) => countLocalManifestEntriesMock(...a) };
+  return {
+    ...actual,
+    countLocalManifestEntries: (...a: unknown[]) => countLocalManifestEntriesMock(...a),
+    // Mock the insight accessor too: without this the session-start hook
+    // reads the developer's real ~/.claude/hivemind/local-mined.json at
+    // test time, leaking real-disk insight strings into a test that only
+    // mocked the count. CI runners with a pre-populated manifest would
+    // see the insight branch fire when the test expected the count
+    // fallback, producing a misleading red.
+    getLatestInsightEntry: (...a: unknown[]) => getLatestInsightEntryMock(...a),
+  };
 });
 
 let stdoutLines: string[] = [];
@@ -117,8 +128,12 @@ beforeEach(() => {
   queryMock.mockReset().mockResolvedValue([]); // "no existing summary"
   autoUpdateMock.mockReset().mockResolvedValue(undefined);
   getInstalledVersionMock.mockReset().mockReturnValue("9.9.9");
-  // Default: no manifest → 0 mined skills. Individual tests override.
+  // Default: no manifest → 0 mined skills, no insight entry. Individual
+  // tests override either or both. The insight mock MUST default to null
+  // so existing "legacy count branch" assertions don't accidentally trip
+  // the new concrete-insight rendering.
   countLocalManifestEntriesMock.mockReset().mockReturnValue(0);
+  getLatestInsightEntryMock.mockReset().mockReturnValue(null);
   // Disable auto-pull during this test: autoPullSkills would otherwise issue
   // an extra SQL query (against `skills`) through the same DeeplakeApi mock,
   // breaking the placeholder-branching call-count assertions. The auto-pull
@@ -370,6 +385,38 @@ describe("session-start hook — context shape edge cases", () => {
     const ctx = parsed.hookSpecificOutput.additionalContext;
     expect(ctx).toContain("5 local skills from past");
     expect(ctx).toContain("hivemind login");
+  });
+
+  it("renders the CONCRETE INSIGHT branch when getLatestInsightEntry returns a populated entry", async () => {
+    // Conversion-surface guard for the model-visible additionalContext.
+    // The user-visible side is covered by the notifications-rule tests;
+    // this one ensures the hook itself swaps in the insight rendering
+    // when an entry carries a non-empty `insight` field.
+    loadCredsMock.mockReturnValue(null);
+    countLocalManifestEntriesMock.mockReturnValue(7);
+    getLatestInsightEntryMock.mockReturnValue({
+      skill_name: "verify-before-done",
+      canonical_path: "/x/SKILL.md",
+      symlinks: [],
+      source_session_ids: ["sid"],
+      source_session_paths: ["/x/sid.jsonl"],
+      source_agent: "claude_code",
+      gate_agent: "claude_code",
+      created_at: "2026-05-22T08:58:07.613Z",
+      uploaded: false,
+      insight: "You revisited 4 merged PRs in the last month because tests weren't run before merge.",
+    });
+    const out = await runHook();
+    const parsed = JSON.parse(out!);
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    // Insight branch took over → user sees the concrete pattern, not a
+    // bare count. Negative pattern: the legacy "N local skills" phrasing
+    // MUST NOT appear when insight branch fires (mutually exclusive).
+    expect(ctx).toContain("Hivemind found a pattern in your past sessions");
+    expect(ctx).toContain("You revisited 4 merged PRs");
+    expect(ctx).toContain("`verify-before-done`");
+    expect(ctx).toContain("hivemind login");
+    expect(ctx).not.toContain("7 local skills from past");
   });
 
   it("does NOT append the mined-skills note when user is logged in (even with manifest present)", async () => {


### PR DESCRIPTION
## Summary

- Surface a quantified user-facing **insight** from `mine-local` instead of the generic "N local skills" count at the unauthenticated SessionStart banner. Replaces *"3 local skills from past mining runs live in ~/.claude/skills/"* with *"Hivemind found a pattern in your past sessions: You revisited 4 merged PRs in the last month… Minted skill `verify-before-done` to catch it next time."*
- Driven by the install→signup drop-off problem (Slack thread 2026-05-20): users currently see no concrete value before being asked to authenticate. This is the first user-visible iteration; install-time value-show comes in a follow-up PR.
- Backward-compatible — legacy manifests and entries the gate didn't emit an insight for fall back to the existing count surface.

## Changes

- `LocalManifestEntry` gains optional `insight: string`; new `getLatestInsightEntry` accessor picks the most-recent insight-bearing entry by `created_at`.
- `mine-local` gate prompt now asks for a concrete, quantified, second-person insight per minted skill. `parseMultiVerdict` trims, collapses empty/whitespace to undefined, ignores non-string values (defensive against malformed gate output).
- New pure renderer `renderLocalMinedNote` handles both branches (insight present → new copy; absent → legacy count). The Claude Code SessionStart hook delegates to it so the conditional copy lives in one unit-testable place.
- Tests: schema roundtrip, accessor on mixed manifests, both banner branches with negative patterns, `parseMultiVerdict` insight cases (5 new, all passing).

No new infra; no telemetry; no `process.exit` paths touched. Citation hallucinations are not a concern in this pipeline — mine-local controls the source session paths, the LLM is not asked to cite anything it didn't see.

## Evidence

Ran `mine-local --force --n 5` against real `~/.claude/projects/*.jsonl` (40 sessions on disk, picked 5). Haiku produced **11/11 skills with concrete quantified insights**, zero null. Samples:

> **`verify-before-declaring-ready`** — *"You pushed back on incomplete work 5+ times in this session because the assistant presented plans and code as done without validating them against real systems."*

> **`npm-global-install-corruption-diagnosis`** — *"You hit the same `hivemind: command not found` + partial install twice in one day before tracing it to concurrent npm processes racing on the same deterministic backup-rename path."*

> **`posthog-cohort-staleness-funnel-trap`** — *"You spent 30+ min analyzing a funnel showing 0 new signups because fresh Persons hadn't entered the cohort table yet."*

End-to-end smoke (worktree `session-start.js` against a tmp HOME with the real manifest) renders the new banner verbatim under the un-authed branch.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds (all bundles)
- [x] `npx vitest run tests/claude-code/{local-manifest,local-mined-banner,mine-local-helpers}.test.ts` → 46 pass
- [x] Full `npm test` → 2895 pass (one unrelated flake in `deeplake-fs.test.ts` under bulk-run load; passes cleanly in isolation in 3.44s)
- [x] Smoke 1: tmp HOME + synthetic manifest with `insight` → banner renders new copy
- [x] Smoke 2: tmp HOME + synthetic manifest without `insight` → banner renders legacy count copy (1 vs N pluralization correct)
- [x] Smoke 3: real `mine-local --force --n 5` against ~/.claude → 11/11 insights, banner renders against tmp HOME with the real manifest

## Follow-ups (not in this PR)

- **Install-time value-show**: move the primary surface into `runAuthGate` so users who run `hivemind install` and never open Claude still see the value before the sign-in prompt. The banner change here is the secondary/second-touch surface.
- **Pick by quality, not write order**: when multiple insights are written in the same mine-local batch (~16ms span), `getLatestInsightEntry`'s `created_at` ordering effectively picks at random within the batch. Worth a follow-up that scores by source-session recency or insight quality signals.
- **Telemetry**: wire `hivemind_install_started` + alias chain so we can measure the conversion lift this banner produces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mined skills can include an optional one-line quantified insight (normalized, capped, omitted when empty).
  * Session-start notes and notification banners can surface the latest insight with truncation/dedup rules, falling back to legacy count messaging and preserving the sign-in CTA.
  * Notifications now distinguish user-visible-only content from model-safe additional context; delivery splits model vs user channels.
  * Local manifests persist insight metadata conditionally for backward compatibility.

* **Tests**
  * Added comprehensive tests for insight parsing, manifest read/write, banner rendering, notification routing, and session-start behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->