### PR TITLE
fix(codex): migrate install to renamed `hooks` feature flag, strip legacy key

### DIFF
--- a/codex/INSTALL.md
+++ b/codex/INSTALL.md
@@ -14,7 +14,7 @@ npx @deeplake/hivemind@latest codex install
 
 The installer:
 
-- Enables the `codex_hooks` feature flag
+- Enables the `hooks` feature flag (and strips the legacy `codex_hooks` key, if a previous install added it)
 - Writes `~/.codex/hooks.json` with hivemind entries
 - Copies the plugin bundle to `~/.codex/hivemind/`
 - Symlinks the skill into `~/.agents/skills/hivemind-memory`

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { HOME, pkgRoot, ensureDir, copyDir, writeJson, symlinkForce, writeVersionStamp, log, warn } from "./util.js";
@@ -166,10 +166,31 @@ function reportForeignHivemindHooks(existing: Record<string, unknown>): void {
 }
 
 function tryEnableCodexHooks(): void {
+  // codex 0.130.0 renamed the `codex_hooks` feature flag to `hooks`. The legacy
+  // key still works but prints a deprecation warning on every startup, so we
+  // enable the new name and strip the legacy key if it lingers from an older
+  // install of this plugin.
   try {
-    execFileSync("codex", ["features", "enable", "codex_hooks"], { stdio: "ignore" });
+    execFileSync("codex", ["features", "enable", "hooks"], { stdio: "ignore" });
   } catch {
     // codex CLI may not be on PATH (e.g., running under a separate user); not fatal.
+  }
+  stripLegacyCodexHooksKey();
+}
+
+function stripLegacyCodexHooksKey(): void {
+  const cfgPath = join(CODEX_HOME, "config.toml");
+  if (!existsSync(cfgPath)) return;
+  try {
+    const original = readFileSync(cfgPath, "utf-8");
+    // Match a top-level `codex_hooks = ...` line in the `[features]` table.
+    // The regex requires the key at line start (after optional whitespace) and
+    // immediately followed by `=` or whitespace+`=`, so it won't touch keys
+    // like `codex_hooks_other` or `[features.codex_hooks]` table headers.
+    const cleaned = original.replace(/^[ \t]*codex_hooks[ \t]*=[^\n]*\r?\n?/gm, "");
+    if (cleaned !== original) writeFileSync(cfgPath, cleaned);
+  } catch {
+    // best-effort cleanup; never fail the install over it.
   }
 }
 

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -170,12 +170,20 @@ function tryEnableCodexHooks(): void {
   // key still works but prints a deprecation warning on every startup, so we
   // enable the new name and strip the legacy key if it lingers from an older
   // install of this plugin.
+  //
+  // The strip is gated on a successful enable: on pre-0.130 codex (or if the
+  // codex CLI isn't on PATH) the `hooks` feature is unknown and the call
+  // throws — in that case we must leave any existing `codex_hooks = true`
+  // entry alone, otherwise we'd silently disable hooks on the user's box.
+  let enabled = false;
   try {
     execFileSync("codex", ["features", "enable", "hooks"], { stdio: "ignore" });
+    enabled = true;
   } catch {
-    // codex CLI may not be on PATH (e.g., running under a separate user); not fatal.
+    // codex CLI may not be on PATH (e.g., running under a separate user) or
+    // the codex version pre-dates the rename; not fatal.
   }
-  stripLegacyCodexHooksKey();
+  if (enabled) stripLegacyCodexHooksKey();
 }
 
 function stripLegacyCodexHooksKey(): void {

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -107,16 +107,79 @@ describe("installCodex — happy path", () => {
     expect(existsSync(join(link, "SKILL.md"))).toBe(true);
   });
 
-  it("attempts to enable codex hooks via the codex CLI (best-effort, no throw on failure)", async () => {
+  it("attempts to enable the renamed `hooks` codex feature (best-effort, no throw on failure)", async () => {
     execFileSyncMock.mockImplementation(() => { throw new Error("codex not installed"); });
     const { installCodex } = await importInstaller();
     expect(() => installCodex()).not.toThrow();
-    // We did try.
     expect(execFileSyncMock).toHaveBeenCalledWith(
+      "codex",
+      ["features", "enable", "hooks"],
+      expect.any(Object),
+    );
+    // Defends against accidentally regressing to the deprecated flag name.
+    expect(execFileSyncMock).not.toHaveBeenCalledWith(
       "codex",
       ["features", "enable", "codex_hooks"],
       expect.any(Object),
     );
+  });
+
+  it("strips a legacy `codex_hooks = ...` line from ~/.codex/config.toml on install", async () => {
+    const cfgPath = join(tmpHome, ".codex", "config.toml");
+    writeFileSync(
+      cfgPath,
+      [
+        "model = \"gpt-5\"",
+        "",
+        "[features]",
+        "codex_hooks = true",
+        "hooks = true",
+        "some_other = true",
+        "",
+      ].join("\n"),
+    );
+    const { installCodex } = await importInstaller();
+    installCodex();
+    const cleaned = readFileSync(cfgPath, "utf-8");
+    expect(cleaned).not.toMatch(/^[ \t]*codex_hooks[ \t]*=/m);
+    // Everything else is preserved.
+    expect(cleaned).toMatch(/^hooks = true$/m);
+    expect(cleaned).toMatch(/^some_other = true$/m);
+    expect(cleaned).toMatch(/^\[features\]$/m);
+    expect(cleaned).toMatch(/^model = "gpt-5"$/m);
+  });
+
+  it("leaves config.toml untouched when no legacy `codex_hooks` line is present", async () => {
+    const cfgPath = join(tmpHome, ".codex", "config.toml");
+    const body = ["[features]", "hooks = true", ""].join("\n");
+    writeFileSync(cfgPath, body);
+    const { installCodex } = await importInstaller();
+    installCodex();
+    expect(readFileSync(cfgPath, "utf-8")).toBe(body);
+  });
+
+  it("does not match keys that merely share a `codex_hooks` prefix or appear in table headers", async () => {
+    const cfgPath = join(tmpHome, ".codex", "config.toml");
+    const body = [
+      "[features]",
+      "codex_hooks_other = true",
+      "",
+      "[features.codex_hooks]",
+      "nested = 1",
+      "",
+    ].join("\n");
+    writeFileSync(cfgPath, body);
+    const { installCodex } = await importInstaller();
+    installCodex();
+    // Whole body should survive — neither line is the deprecated top-level key.
+    expect(readFileSync(cfgPath, "utf-8")).toBe(body);
+  });
+
+  it("does not crash when config.toml does not exist", async () => {
+    // tmpHome/.codex exists but config.toml does not (default test setup).
+    const { installCodex } = await importInstaller();
+    expect(() => installCodex()).not.toThrow();
+    expect(existsSync(join(tmpHome, ".codex", "config.toml"))).toBe(false);
   });
 
   it("preserves a user-defined hook on a non-hivemind event when re-installing over an existing config", async () => {

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -124,6 +124,20 @@ describe("installCodex — happy path", () => {
     );
   });
 
+  it("does NOT strip the legacy `codex_hooks` key when `codex features enable hooks` fails", async () => {
+    // Regression guard: on pre-0.130 codex (or when the codex CLI isn't on
+    // PATH at all) the enable call throws. Stripping the legacy key in that
+    // case would silently disable hooks for users whose only working entry is
+    // `codex_hooks = true`.
+    execFileSyncMock.mockImplementation(() => { throw new Error("codex not installed"); });
+    const cfgPath = join(tmpHome, ".codex", "config.toml");
+    const body = ["[features]", "codex_hooks = true", ""].join("\n");
+    writeFileSync(cfgPath, body);
+    const { installCodex } = await importInstaller();
+    installCodex();
+    expect(readFileSync(cfgPath, "utf-8")).toBe(body);
+  });
+
   it("strips a legacy `codex_hooks = ...` line from ~/.codex/config.toml on install", async () => {
     const cfgPath = join(tmpHome, ".codex", "config.toml");
     writeFileSync(

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -237,6 +237,102 @@ describe("installCodex — happy path", () => {
     const { installCodex } = await importInstaller();
     expect(() => installCodex()).toThrow(/Codex bundle missing/);
   });
+
+  it("strips a non-canonical hivemind hook entry (sibling dev-clone leftover) and warns about it", async () => {
+    // Realistic dual-install fixture: a previous `npm link` of a hivemind dev
+    // clone left a SessionStart hook pointing at /tmp/old-clone instead of
+    // the canonical ~/.codex/hivemind. installCodex must recognise that as
+    // ours-but-foreign, strip it, and surface what it stripped to stderr.
+    const foreignCmd = `node "/tmp/old-clone/codex/bundle/session-start.js"`;
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [{ hooks: [{ type: "command", command: foreignCmd, timeout: 120 }] }],
+        },
+      }),
+    );
+
+    const stderrCalls: string[] = [];
+    // Re-spy so we can read what reportForeignHivemindHooks wrote.
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrCalls.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+
+    const { installCodex } = await importInstaller();
+    installCodex();
+
+    const hooks = JSON.parse(readFileSync(join(tmpHome, ".codex", "hooks.json"), "utf-8"));
+    // SessionStart has exactly one entry — the canonical one — and the
+    // foreign /tmp/old-clone path is gone.
+    expect(hooks.hooks.SessionStart).toHaveLength(1);
+    const cmd = hooks.hooks.SessionStart[0].hooks[0].command;
+    expect(cmd).toContain(`${tmpHome}/.codex/hivemind/bundle/session-start.js`);
+    expect(cmd).not.toContain("/tmp/old-clone");
+
+    const warns = stderrCalls.join("");
+    expect(warns).toContain("non-canonical path");
+    expect(warns).toContain(foreignCmd);
+  });
+
+  it("does NOT classify an entry as foreign when its hooks[] contains a malformed sibling element", async () => {
+    // Edge case: an entry whose hooks[] mixes one canonical hivemind hook
+    // with garbage (a null entry, a hook with a non-string command). The
+    // canonical hook is recognised — so the entry is hivemind and gets
+    // stripped — but the malformed siblings short-circuit the "is foreign"
+    // check, so we must NOT report this entry as a non-canonical dev clone.
+    const canonicalForeignCmd = `node "/opt/other-install/codex/bundle/capture.js"`;
+    const otherForeignCmd     = `node "/opt/other-install/codex/bundle/pre-tool-use.js"`;
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          // Order matters: `.every()` short-circuits on the first false, so
+          // we need two events to reach BOTH malformed branches —
+          // PostToolUse exercises the null guard (h is null), PreToolUse
+          // exercises the non-string command guard (typeof cmd !== "string").
+          PostToolUse: [{
+            hooks: [
+              { type: "command", command: canonicalForeignCmd, timeout: 15 },
+              null,
+            ],
+          }],
+          PreToolUse: [{
+            hooks: [
+              { type: "command", command: otherForeignCmd, timeout: 15 },
+              { type: "command", command: 12345 },
+            ],
+          }],
+        },
+      }),
+    );
+
+    const stderrCalls: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrCalls.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+
+    const { installCodex } = await importInstaller();
+    installCodex();
+
+    const hooks = JSON.parse(readFileSync(join(tmpHome, ".codex", "hooks.json"), "utf-8"));
+    // Stripped from both events — only our canonical entries remain.
+    expect(hooks.hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.hooks.PreToolUse).toHaveLength(1);
+    expect(hooks.hooks.PostToolUse[0].hooks[0].command)
+      .toContain(`${tmpHome}/.codex/hivemind/bundle/capture.js`);
+    expect(hooks.hooks.PreToolUse[0].hooks[0].command)
+      .toContain(`${tmpHome}/.codex/hivemind/bundle/pre-tool-use.js`);
+
+    // And: no foreign warning, because neither entry passed isForeign (the
+    // malformed siblings made `.every()` return false in both).
+    const warns = stderrCalls.join("");
+    expect(warns).not.toContain("non-canonical path");
+    expect(warns).not.toContain(canonicalForeignCmd);
+    expect(warns).not.toContain(otherForeignCmd);
+  });
 });
 
 describe("uninstallCodex", () => {
@@ -257,6 +353,32 @@ describe("uninstallCodex", () => {
   it("is a no-op when there's nothing to remove (cold uninstall)", async () => {
     const { uninstallCodex } = await importInstaller();
     expect(() => uninstallCodex()).not.toThrow();
+  });
+
+  it("preserves a non-hivemind hook during uninstall: rewrites hooks.json instead of deleting it", async () => {
+    // Install hivemind, then mix in a user-owned hook that shares an event
+    // with us. Uninstall must strip our entries but keep the user's, which
+    // exercises the writeJson branch (hooks.json survives) rather than the
+    // unlinkSync branch (hooks.json deleted because nothing else is left).
+    const { installCodex, uninstallCodex } = await importInstaller();
+    installCodex();
+    const hooksPath = join(tmpHome, ".codex", "hooks.json");
+    const cfg = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    const userHook = { hooks: [{ type: "command", command: "/usr/local/bin/audit.sh", timeout: 5 }] };
+    cfg.hooks.PostToolUse.push(userHook);
+    cfg.version = 9;
+    writeFileSync(hooksPath, JSON.stringify(cfg));
+
+    uninstallCodex();
+
+    expect(existsSync(hooksPath)).toBe(true);
+    const after = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    expect(after.hooks.PostToolUse).toHaveLength(1);
+    expect(after.hooks.PostToolUse[0]).toEqual(userHook);
+    // Top-level metadata is preserved through the rewrite.
+    expect(after.version).toBe(9);
+    // Hivemind-only events lose their entries entirely.
+    expect(after.hooks.SessionStart ?? []).toHaveLength(0);
   });
 
   it("uninstall on a malformed hooks.json deletes the file rather than crashing", async () => {

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -95,6 +95,18 @@ describe("isHivemindHookEntry", () => {
       ],
     }, PD)).toBe(true);
   });
+
+  // Tightens the per-element type guard inside the `.some()` callback so a
+  // refactor that drops `!h || typeof h !== "object"` can't start matching
+  // arrays full of garbage.
+  it.each([
+    ["hooks[] contains null",      { hooks: [null] }],
+    ["hooks[] contains undefined", { hooks: [undefined] }],
+    ["hooks[] contains a string",  { hooks: ["not-an-object"] }],
+    ["hooks[] contains a number",  { hooks: [42] }],
+  ])("false when %s", (_label, entry) => {
+    expect(isHivemindHookEntry(entry, PD)).toBe(false);
+  });
 });
 
 // ─── codex: mergeHooks (the data-loss-fix surface) ────────────────────────


### PR DESCRIPTION
## Summary

codex 0.130.0 renamed the `codex_hooks` feature flag to `hooks`. The legacy
key still works but prints a deprecation warning on every codex startup:

```
`[features].codex_hooks` is deprecated. Use `[features].hooks` instead.
Enable it with `--enable hooks` or `[features].hooks` in config.toml.
```

Users who installed an earlier revision of this plugin have `codex_hooks = true`
written into `~/.codex/config.toml`, so the warning keeps firing on every
codex launch even after they upgrade hivemind. `codex features disable codex_hooks`
does not help — codex just flips it to `false`, and the deprecation check
fires on the **key being present at all**, regardless of value.

## What changed

- `src/cli/install-codex.ts`
  - `tryEnableCodexHooks()` now calls `codex features enable hooks` (the new
    feature name). The existing best-effort try/catch is preserved so the
    install doesn't fail when codex CLI isn't on `$PATH`.
  - New `stripLegacyCodexHooksKey()` runs after the enable on every install
    and removes any top-level `codex_hooks = ...` line from `~/.codex/config.toml`.
    Regex matches the key only at line start, immediately followed by `=`, so
    it never touches `codex_hooks_other` or `[features.codex_hooks]` table
    headers. Gracefully no-ops if the file does not exist.
- `codex/INSTALL.md` — updated to mention the renamed flag and the legacy-key cleanup.
- `tests/cli/cli-install-codex-fs.test.ts`
  - Updated the existing "best-effort enable" test to assert the new `hooks`
    argument and to defend against regressing to `codex_hooks`.
  - Added coverage for:
    - legacy `codex_hooks` line is stripped on install
    - config file is byte-identical when no legacy key is present
    - prefix matches (`codex_hooks_other`) and `[features.codex_hooks]` table
      headers are not falsely matched
    - install does not crash when `config.toml` is missing

## Why not just enable `hooks` and leave the legacy line?

Because the deprecation warning fires on key presence. Users who upgrade
without cleanup would still see the warning every time they launch codex.
The strip is a one-shot side effect of running install (or reinstall), so
the upgrade path is "run the new install once → warning gone forever".

## Tests

- Unit tests for `installCodex`: 15/15 passing (includes 4 new tests for the
  strip logic).
- Full suite: **2917/2917 passing**.
- End-to-end smoke test against an isolated `HOME`:
  - Pre-state: `~/.codex/config.toml` contains `codex_hooks = true` plus
    unrelated `some_other = true` and a `model = "..."` outside `[features]`.
  - After `hivemind codex install`:
    - `codex_hooks` line removed
    - `hooks = true` added by `codex features enable hooks`
    - `some_other = true` and the top-level `model = ...` untouched
  - `codex exec` no longer prints the deprecation warning.

## Test plan

- [x] Unit tests green (`npx vitest run`)
- [x] End-to-end isolated-HOME smoke test (legacy line removed, no warning on codex launch)
- [x] False-positive defense (table header / suffixed key not matched)
- [x] Missing `config.toml` does not throw

## Out of scope

The `bubblewrap not on PATH` and `MCP swarm failed to start` warnings observed
on the same codex launch are unrelated to this plugin (system package /
external MCP server) and are not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation to reflect current setup procedures.

* **Refactor**
  * Enhanced the installer to use modern feature flag configuration.
  * Added automatic cleanup of legacy configuration entries during installation for smoother upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->