### PR TITLE
fix(auth): point whoami logged-out hint to hivemind login

### DIFF
--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -47,7 +47,7 @@ export async function runAuthCommand(args: string[]): Promise<void> {
     }
 
     case "whoami": {
-      if (!creds) { console.log("Not logged in. Run: node auth-login.js login"); break; }
+      if (!creds) { console.log("Not logged in. Run: hivemind login"); break; }
       console.log(`User org: ${creds.orgName ?? creds.orgId}`);
       console.log(`Workspace: ${creds.workspaceId ?? "default"}`);
       console.log(`API: ${creds.apiUrl ?? "https://api.deeplake.ai"}`);


### PR DESCRIPTION
## Summary
- After `hivemind logout`, running `hivemind whoami` printed `Not logged in. Run: node auth-login.js login`, which leaks the bundled entry-point filename to end users.
- Replace the hint with the supported CLI command (`hivemind login`) so the suggested follow-up matches how the tool is actually invoked.

## Test plan
- [ ] `hivemind logout && hivemind whoami` prints `Not logged in. Run: hivemind login`
- [ ] `hivemind login` still works and `hivemind whoami` afterwards shows org/workspace/api as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the login prompt message to provide clearer instructions when credentials are missing, directing users to the correct login command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->