### PR TITLE
fix(auth): heal token/org drift on switchOrg and session start (all 6 agents)

### DIFF
--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -302,8 +302,12 @@ let authUrl: string | null = null;
 // Heal the legacy `org switch` regression at most once per process: if
 // creds.token's JWT org_id claim differs from creds.orgId, re-mint a
 // token bound to the destination org and rewrite ~/.deeplake/credentials.json.
-// Sentinel prevents re-running on every getApi() invocation.
-let driftHealAttempted = false;
+// Promise sentinel — not a boolean — because the heal awaits I/O and a
+// boolean would let a concurrent getApi() caller see `attempted=true`
+// while the first heal was still in flight, then skip ahead and build/cache
+// the api from still-stale credentials. With a promise, the second caller
+// awaits the first's heal and reads the freshly-healed creds.
+let driftHealPromise: Promise<void> | null = null;
 // Set by the background version check in register() when a newer version is
 // available on ClawHub. Read by before_prompt_build to inject an
 // agent-facing directive nudging it to install via its own exec tool.
@@ -676,13 +680,18 @@ async function getApi(): Promise<DeeplakeApi | null> {
   // Heal token/org drift before loadConfig reads credentials.json. Heal is
   // a no-op when claim matches orgId or when the JWT carries no claim, so
   // the only added cost on the steady-state path is a base64 decode.
-  if (!driftHealAttempted) {
-    driftHealAttempted = true;
-    try {
-      const creds = await loadCredentials();
-      if (creds?.token) await healDriftedOrgToken(creds);
-    } catch { /* heal never throws; this catch is belt + braces */ }
+  // First caller initiates the promise; subsequent concurrent callers
+  // await the same promise so they all see freshly-healed creds before
+  // loadConfig() runs (see comment on driftHealPromise above).
+  if (!driftHealPromise) {
+    driftHealPromise = (async () => {
+      try {
+        const creds = await loadCredentials();
+        if (creds?.token) await healDriftedOrgToken(creds);
+      } catch { /* heal never throws; this catch is belt + braces */ }
+    })();
   }
+  await driftHealPromise;
 
   const config = await loadConfig();
   if (!config) {

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -20,7 +20,7 @@ function loadSetupConfig(): Promise<SetupConfigModule> {
 // Network-only helpers stay as static imports — auth.js no longer touches fs
 // (its credential IO moved to ../../src/commands/auth-creds.js, which we load
 // lazily below so esbuild emits it as a separate chunk).
-import { requestDeviceCode, pollForToken, listOrgs, switchOrg, listWorkspaces, switchWorkspace } from "../../src/commands/auth.js";
+import { requestDeviceCode, pollForToken, listOrgs, switchOrg, listWorkspaces, switchWorkspace, healDriftedOrgToken } from "../../src/commands/auth.js";
 import { DeeplakeApi } from "../../src/deeplake-api.js";
 
 // Lazy-loaders for the fs-touching shared modules. Each becomes its own
@@ -299,6 +299,11 @@ async function checkForUpdate(logger: PluginLogger): Promise<void> {
 // --- Auth state ---
 let authPending = false;
 let authUrl: string | null = null;
+// Heal the legacy `org switch` regression at most once per process: if
+// creds.token's JWT org_id claim differs from creds.orgId, re-mint a
+// token bound to the destination org and rewrite ~/.deeplake/credentials.json.
+// Sentinel prevents re-running on every getApi() invocation.
+let driftHealAttempted = false;
 // Set by the background version check in register() when a newer version is
 // available on ClawHub. Read by before_prompt_build to inject an
 // agent-facing directive nudging it to install via its own exec tool.
@@ -667,6 +672,17 @@ function normalizeVirtualPath(p: string | undefined | null): string {
 
 async function getApi(): Promise<DeeplakeApi | null> {
   if (api) return api;
+
+  // Heal token/org drift before loadConfig reads credentials.json. Heal is
+  // a no-op when claim matches orgId or when the JWT carries no claim, so
+  // the only added cost on the steady-state path is a base64 decode.
+  if (!driftHealAttempted) {
+    driftHealAttempted = true;
+    try {
+      const creds = await loadCredentials();
+      if (creds?.token) await healDriftedOrgToken(creds);
+    } catch { /* heal never throws; this catch is belt + braces */ }
+  }
 
   const config = await loadConfig();
   if (!config) {

--- a/pi/extension-source/hivemind.ts
+++ b/pi/extension-source/hivemind.ts
@@ -93,6 +93,52 @@ function loadCreds(): Creds | null {
   }
 }
 
+// Inline copies of decodeJwtPayload + healDriftedOrgToken (the shared helpers
+// live in src/commands/auth.ts, but pi extensions ship as raw .ts with no
+// shared-module imports — kept in lockstep with that file).
+function decodeJwtPayloadInline(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    let payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    while (payload.length % 4) payload += "=";
+    return JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+  } catch { return null; }
+}
+
+async function healDriftedOrgTokenInline(creds: Creds): Promise<Creds> {
+  if (!creds.token || !creds.orgId) return creds;
+  const payload = decodeJwtPayloadInline(creds.token);
+  const claimOrg = payload && typeof payload.org_id === "string" ? payload.org_id : undefined;
+  if (!claimOrg || claimOrg === creds.orgId) return creds;
+  logHm(`session_start: token org drift detected: jwt.org_id=${claimOrg} creds.orgId=${creds.orgId} — re-minting`);
+  try {
+    const resp = await fetch(`${creds.apiUrl}/users/me/tokens`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${creds.token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: `deeplake-plugin-heal-${Date.now()}`,
+        duration: 365 * 24 * 3600,
+        organization_id: creds.orgId,
+      }),
+    });
+    if (!resp.ok) throw new Error(`API ${resp.status}: ${(await resp.text().catch(() => "")).slice(0, 200)}`);
+    const data = await resp.json() as { token: { token: string } };
+    const newToken = data.token.token;
+    // Read + merge + write the WHOLE creds file so we don't drop fields pi
+    // doesn't model (e.g. savedAt). Atomic via writeFileSync with mode 0o600.
+    const path = join(homedir(), ".deeplake", "credentials.json");
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    raw.token = newToken;
+    writeFileSync(path, JSON.stringify(raw, null, 2), { mode: 0o600 });
+    logHm(`session_start: token re-minted for org=${creds.orgId}`);
+    return { ...creds, token: newToken };
+  } catch (e: any) {
+    logHm(`session_start: token re-mint failed (continuing with stale token): ${e?.message ?? e}`);
+    return creds;
+  }
+}
+
 const MEMORY_TABLE = process.env.HIVEMIND_TABLE ?? "memory";
 const SESSIONS_TABLE = process.env.HIVEMIND_SESSIONS_TABLE ?? "sessions";
 
@@ -1076,11 +1122,12 @@ export default function hivemindExtension(pi: ExtensionAPI): void {
 
   pi.on("session_start", async (_event: any, _ctx: any) => {
     logHm(`session_start: fired (capture=${captureEnabled}, embed=${process.env.HIVEMIND_EMBEDDINGS !== "false"}, table=${SESSIONS_TABLE})`);
-    const creds = loadCreds();
+    let creds = loadCreds();
     if (!creds) {
       logHm(`session_start: no credentials at ~/.deeplake/credentials.json — capture disabled this session`);
     } else {
       logHm(`session_start: creds org=${creds.orgName ?? creds.orgId} ws=${creds.workspaceId}`);
+      creds = await healDriftedOrgTokenInline(creds);
     }
 
     // Centralized autoupdate: shells out to `hivemind update` (npm-based,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -179,8 +179,12 @@ export async function switchOrg(orgId: string, orgName?: string): Promise<void> 
   // /users/me/tokens). Re-mint against the destination org so the claim
   // matches creds.orgId — otherwise anything that trusts the token claim
   // instead of the X-Activeloop-Org-Id header resolves to the old org.
+  // Name suffix uses Date.now() (not the date) because Deeplake's
+  // /users/me/tokens rejects duplicate (user_id, name) with a misleading
+  // 500 — same hazard the heal path documents; two switches the same day
+  // would otherwise fail.
   const apiUrl = creds.apiUrl ?? DEFAULT_API_URL;
-  const tokenName = `deeplake-plugin-${new Date().toISOString().slice(0, 10)}`;
+  const tokenName = `deeplake-plugin-switch-${Date.now()}`;
   const tokenData = await apiPost("/users/me/tokens", {
     name: tokenName,
     duration: 365 * 24 * 3600,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -175,7 +175,55 @@ export async function listOrgs(token: string, apiUrl = DEFAULT_API_URL): Promise
 export async function switchOrg(orgId: string, orgName?: string): Promise<void> {
   const creds = loadCredentials();
   if (!creds) throw new Error("Not logged in. Run deeplake login first.");
-  saveCredentials({ ...creds, orgId, orgName });
+  // Token in creds is org-bound (org_id claim baked in at mint time at
+  // /users/me/tokens). Re-mint against the destination org so the claim
+  // matches creds.orgId — otherwise anything that trusts the token claim
+  // instead of the X-Activeloop-Org-Id header resolves to the old org.
+  const apiUrl = creds.apiUrl ?? DEFAULT_API_URL;
+  const tokenName = `deeplake-plugin-${new Date().toISOString().slice(0, 10)}`;
+  const tokenData = await apiPost("/users/me/tokens", {
+    name: tokenName,
+    duration: 365 * 24 * 3600,
+    organization_id: orgId,
+  }, creds.token, apiUrl) as { token: { token: string } };
+  saveCredentials({ ...creds, orgId, orgName, token: tokenData.token.token });
+}
+
+// Detect and repair the legacy regression where `org switch` only rewrote
+// orgId without re-minting the org-bound API token. Returns updated creds
+// when a heal happens, the input creds when nothing to do, and the input
+// creds (after logging) when the mint fails — never throws, never blocks
+// session start.
+export async function healDriftedOrgToken(
+  creds: Credentials,
+  log: (msg: string) => void = () => {},
+): Promise<Credentials> {
+  if (!creds.token || !creds.orgId) return creds;
+  const payload = decodeJwtPayload(creds.token);
+  const claimOrg = payload && typeof payload.org_id === "string" ? payload.org_id : undefined;
+  if (!claimOrg || claimOrg === creds.orgId) return creds;
+  log(`token org drift detected: jwt.org_id=${claimOrg} creds.orgId=${creds.orgId} — re-minting`);
+  try {
+    const apiUrl = creds.apiUrl ?? DEFAULT_API_URL;
+    // Per-mint unique name. Deeplake rejects duplicate (user_id, name) with
+    // a 500 ("token creation failed"), and the heal runs on EVERY session
+    // start across multiple agents — a date-only suffix would collide as
+    // soon as the second agent heals on the same day. Date.now() suffices:
+    // resolution is ms, only one heal per session, single process per agent.
+    const tokenName = `deeplake-plugin-heal-${Date.now()}`;
+    const tokenData = await apiPost("/users/me/tokens", {
+      name: tokenName,
+      duration: 365 * 24 * 3600,
+      organization_id: creds.orgId,
+    }, creds.token, apiUrl) as { token: { token: string } };
+    const healed = { ...creds, token: tokenData.token.token };
+    saveCredentials(healed);
+    log(`token re-minted for org=${creds.orgId}`);
+    return healed;
+  } catch (err) {
+    log(`token re-mint failed (continuing with stale token): ${(err as Error).message}`);
+    return creds;
+  }
 }
 
 // ── Workspace Commands ───────────────────────────────────────────────────────

--- a/src/hooks/codex/session-start.ts
+++ b/src/hooks/codex/session-start.ts
@@ -13,7 +13,7 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { loadCredentials } from "../../commands/auth.js";
+import { loadCredentials, healDriftedOrgToken } from "../../commands/auth.js";
 import { readStdin } from "../../utils/stdin.js";
 import { countLocalManifestEntries } from "../../skillify/local-manifest.js";
 import { maybeAutoMineLocal } from "../../skillify/spawn-mine-local-worker.js";
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
 
   const input = await readStdin<CodexSessionStartInput>();
 
-  const creds = loadCredentials();
+  let creds = loadCredentials();
 
   if (!creds?.token) {
     log("no credentials found — run auth login to authenticate");
@@ -55,6 +55,7 @@ async function main(): Promise<void> {
     log(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
     log(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    creds = await healDriftedOrgToken(creds, log);
   }
 
   // Spawn async setup (table creation, placeholder, version check) as detached process.

--- a/src/hooks/cursor/session-start.ts
+++ b/src/hooks/cursor/session-start.ts
@@ -20,7 +20,7 @@
 
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { loadCredentials } from "../../commands/auth.js";
+import { loadCredentials, healDriftedOrgToken } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
@@ -137,13 +137,14 @@ async function main(): Promise<void> {
   const sessionId = resolveSessionId(input);
   const cwd = resolveCwd(input);
 
-  const creds = loadCredentials();
+  let creds = loadCredentials();
   if (!creds?.token) {
     log("no credentials found");
     const auto = maybeAutoMineLocal();
     log(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
     log(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    creds = await healDriftedOrgToken(creds, log);
   }
 
   // Centralized autoupdate fires BEFORE the DB ensure-table calls — those

--- a/src/hooks/hermes/session-start.ts
+++ b/src/hooks/hermes/session-start.ts
@@ -11,7 +11,7 @@
 
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { loadCredentials } from "../../commands/auth.js";
+import { loadCredentials, healDriftedOrgToken } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
   const sessionId = input.session_id ?? `hermes-${Date.now()}`;
   const cwd = input.cwd ?? process.cwd();
 
-  const creds = loadCredentials();
+  let creds = loadCredentials();
   const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false";
 
   if (!creds?.token) {
@@ -119,6 +119,8 @@ async function main(): Promise<void> {
     // full set of guards. Next session shows the count via
     // countLocalManifestEntries().
     maybeAutoMineLocal();
+  } else {
+    creds = await healDriftedOrgToken(creds, log);
   }
 
   // Centralized autoupdate fires BEFORE the DB ensure-table calls — those

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -9,7 +9,7 @@
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import { loadCredentials, saveCredentials } from "../commands/auth.js";
+import { loadCredentials, saveCredentials, healDriftedOrgToken } from "../commands/auth.js";
 import { loadConfig } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
 import { sqlStr } from "../utils/sql.js";
@@ -148,6 +148,11 @@ async function main(): Promise<void> {
     log(`auto-mine: ${auto.triggered ? "triggered (background)" : `skipped (${auto.reason})`}`);
   } else {
     log(`credentials loaded: org=${creds.orgName ?? creds.orgId}`);
+    // Self-heal the legacy `org switch` regression: pre-fix versions only
+    // rewrote orgId without re-minting, so creds.token still carries the
+    // old org_id claim. Detect drift here and re-bind; non-fatal on
+    // failure (logged + continue with stale token).
+    creds = await healDriftedOrgToken(creds, log);
     // Backfill userName if missing (for users who logged in before this field was added)
     if (creds.token && !creds.userName) {
       try {

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -255,21 +255,47 @@ describe("listOrgs / listWorkspaces", () => {
 });
 
 describe("switchOrg / switchWorkspace", () => {
-  it("switchOrg writes the new orgId+orgName to credentials", async () => {
-    loadCredentialsMock.mockReturnValue({ token: "tok", orgId: "old", savedAt: "x" });
+  it("switchOrg mints a new token bound to the destination org and persists it", async () => {
+    loadCredentialsMock.mockReturnValue({
+      token: "old-tok", orgId: "old", apiUrl: "https://api.example", savedAt: "x",
+    });
+    fetchMock.mockResolvedValueOnce(ok({ token: { token: "fresh-tok-for-new-org" } }));
     const { switchOrg } = await importAuth();
     await switchOrg("new-org", "Activeloop");
+
+    // Exactly one mint call, no extras.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example/users/me/tokens");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer old-tok");
+    const body = JSON.parse(init.body);
+    expect(body.organization_id).toBe("new-org");
+    expect(body.duration).toBe(365 * 24 * 3600);
+
+    // Exactly one save, with rotated token + new org.
     expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
     const written = saveCredentialsMock.mock.calls[0][0];
     expect(written.orgId).toBe("new-org");
     expect(written.orgName).toBe("Activeloop");
-    expect(written.token).toBe("tok"); // preserved
+    expect(written.token).toBe("fresh-tok-for-new-org"); // rotated, not preserved
   });
 
-  it("switchOrg throws if not logged in", async () => {
+  it("switchOrg does NOT persist credentials when the mint call fails", async () => {
+    loadCredentialsMock.mockReturnValue({
+      token: "old-tok", orgId: "old", apiUrl: "https://api.example", savedAt: "x",
+    });
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+    const { switchOrg } = await importAuth();
+    await expect(switchOrg("new-org", "Activeloop")).rejects.toThrow(/API 403/);
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it("switchOrg throws if not logged in and never hits the network", async () => {
     loadCredentialsMock.mockReturnValue(null);
     const { switchOrg } = await importAuth();
     await expect(switchOrg("new-org", "Activeloop")).rejects.toThrow(/Not logged in/);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(saveCredentialsMock).not.toHaveBeenCalled();
   });
 
@@ -285,6 +311,82 @@ describe("switchOrg / switchWorkspace", () => {
     loadCredentialsMock.mockReturnValue(null);
     const { switchWorkspace } = await importAuth();
     await expect(switchWorkspace("ws2")).rejects.toThrow(/Not logged in/);
+  });
+});
+
+// Tiny helper to forge a 3-part JWT with a given payload (no signature
+// verification on our side — decodeJwtPayload only base64-decodes part 2).
+function fakeJwt(payload: Record<string, unknown>): string {
+  const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64")
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${enc({ alg: "HS256" })}.${enc(payload)}.sig`;
+}
+
+describe("healDriftedOrgToken", () => {
+  it("is a no-op when JWT org_id matches creds.orgId", async () => {
+    const token = fakeJwt({ user_id: "u", org_id: "match", type: "api_token" });
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token, orgId: "match", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
+    expect(out.token).toBe(token);
+  });
+
+  it("is a no-op when the token has no org_id claim", async () => {
+    const token = fakeJwt({ user_id: "u", type: "api_token" });
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token, orgId: "anything", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
+    expect(out.orgId).toBe("anything");
+  });
+
+  it("is a no-op when creds.orgId is missing (legacy creds)", async () => {
+    const token = fakeJwt({ user_id: "u", org_id: "anything", type: "api_token" });
+    const { healDriftedOrgToken } = await importAuth();
+    await healDriftedOrgToken({ token, apiUrl: "https://api.example", savedAt: "x" } as any);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it("re-mints and persists when JWT org_id differs from creds.orgId", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock.mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }));
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example/users/me/tokens");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe(`Bearer ${stale}`);
+    expect(JSON.parse(init.body).organization_id).toBe("target-org");
+
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(saveCredentialsMock.mock.calls[0][0].token).toBe("fresh-tok");
+    expect(out.token).toBe("fresh-tok");
+  });
+
+  it("returns the original creds and does NOT persist when the mint call fails", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+    const logged: string[] = [];
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", apiUrl: "https://api.example", savedAt: "x" } as any,
+      (m) => logged.push(m),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
+    expect(out.token).toBe(stale); // unchanged
+    expect(logged.some(m => /re-mint failed/.test(m))).toBe(true);
   });
 });
 

--- a/tests/claude-code/session-start-graph-worker.test.ts
+++ b/tests/claude-code/session-start-graph-worker.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../src/utils/stdin.js", () => ({ readStdin: (...a: any[]) => stdinMo
 vi.mock("../../src/commands/auth.js", () => ({
   loadCredentials: (...a: any[]) => loadCredsMock(...a),
   saveCredentials: (...a: any[]) => saveCredsMock(...a),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/config.js", () => ({ loadConfig: (...a: any[]) => loadConfigMock(...a) }));
 vi.mock("../../src/utils/debug.js", () => ({

--- a/tests/claude-code/session-start-hook.test.ts
+++ b/tests/claude-code/session-start-hook.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../src/utils/stdin.js", () => ({ readStdin: (...a: any[]) => stdinMo
 vi.mock("../../src/commands/auth.js", () => ({
   loadCredentials: (...a: any[]) => loadCredsMock(...a),
   saveCredentials: (...a: any[]) => saveCredsMock(...a),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/config.js", () => ({ loadConfig: (...a: any[]) => loadConfigMock(...a) }));
 vi.mock("../../src/utils/debug.js", () => ({

--- a/tests/codex/codex-session-start-hook.test.ts
+++ b/tests/codex/codex-session-start-hook.test.ts
@@ -23,6 +23,7 @@ const localManifestMock = vi.fn();
 vi.mock("../../src/utils/stdin.js", () => ({ readStdin: (...a: any[]) => stdinMock(...a) }));
 vi.mock("../../src/commands/auth.js", () => ({
   loadCredentials: (...a: any[]) => loadCredsMock(...a),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/utils/debug.js", () => ({
   log: (_t: string, msg: string) => debugLogMock(msg),

--- a/tests/cursor/cursor-session-start-hook.test.ts
+++ b/tests/cursor/cursor-session-start-hook.test.ts
@@ -14,7 +14,10 @@ const localManifestMock = vi.fn();
 
 vi.mock("../../src/utils/stdin.js", () => ({ readStdin: (...a: unknown[]) => stdinMock(...a) }));
 vi.mock("../../src/config.js", () => ({ loadConfig: (...a: unknown[]) => loadConfigMock(...a) }));
-vi.mock("../../src/commands/auth.js", () => ({ loadCredentials: (...a: unknown[]) => loadCredentialsMock(...a) }));
+vi.mock("../../src/commands/auth.js", () => ({
+  loadCredentials: (...a: unknown[]) => loadCredentialsMock(...a),
+  healDriftedOrgToken: async (creds: unknown) => creds,
+}));
 vi.mock("../../src/utils/debug.js", () => ({ log: (_tag: string, msg: string) => debugLogMock(msg) }));
 vi.mock("../../src/utils/version-check.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/utils/version-check.js")>();

--- a/tests/hermes/hermes-session-start-hook.test.ts
+++ b/tests/hermes/hermes-session-start-hook.test.ts
@@ -12,7 +12,12 @@ const localManifestMock = vi.fn();
 
 vi.mock("../../src/utils/stdin.js", () => ({ readStdin: (...a: unknown[]) => stdinMock(...a) }));
 vi.mock("../../src/config.js", () => ({ loadConfig: (...a: unknown[]) => loadConfigMock(...a) }));
-vi.mock("../../src/commands/auth.js", () => ({ loadCredentials: (...a: unknown[]) => loadCredentialsMock(...a) }));
+vi.mock("../../src/commands/auth.js", () => ({
+  loadCredentials: (...a: unknown[]) => loadCredentialsMock(...a),
+  // Pass-through stub — the heal helper is unit-tested in tests/claude-code/auth.test.ts.
+  // Returning creds unchanged keeps these hook tests focused on the hook's own logic.
+  healDriftedOrgToken: async (creds: unknown) => creds,
+}));
 vi.mock("../../src/utils/debug.js", () => ({ log: (_tag: string, msg: string) => debugLogMock(msg) }));
 vi.mock("../../src/utils/version-check.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/utils/version-check.js")>();

--- a/tests/openclaw/auto-recall.test.ts
+++ b/tests/openclaw/auto-recall.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../src/commands/auth.js", () => ({
   switchOrg: vi.fn(),
   listWorkspaces: vi.fn().mockResolvedValue([]),
   switchWorkspace: vi.fn(),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/deeplake-api.js", () => ({
   DeeplakeApi: class {

--- a/tests/openclaw/hivemind-tools.test.ts
+++ b/tests/openclaw/hivemind-tools.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/commands/auth.js", () => ({
   switchOrg: vi.fn(),
   listWorkspaces: vi.fn().mockResolvedValue([]),
   switchWorkspace: vi.fn(),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/deeplake-api.js", () => ({
   DeeplakeApi: class {

--- a/tests/openclaw/setup-command.test.ts
+++ b/tests/openclaw/setup-command.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../src/commands/auth.js", () => ({
   switchOrg: vi.fn(),
   listWorkspaces: vi.fn().mockResolvedValue([]),
   switchWorkspace: vi.fn(),
+  healDriftedOrgToken: async (creds: unknown) => creds,
 }));
 vi.mock("../../src/deeplake-api.js", () => ({
   DeeplakeApi: class {


### PR DESCRIPTION
## Summary

- **Root cause**: `switchOrg` only rewrote `creds.orgId` while reusing the long-lived API token, but the token has `organization_id` baked into its JWT claim (minted by `POST /users/me/tokens`). After a switch, `creds.orgId` and `payload.org_id` diverged silently. Code that trusts the claim — server-side checks, the `preferredOrgId` fallback in `saveCredentialsFromToken` — kept routing to the original org.
- **Fix**: `switchOrg` now re-mints against the destination org before saving. New `healDriftedOrgToken` helper auto-corrects existing drifted creds on every session start across all 6 hivemind agents (claude-code, codex, cursor, hermes, pi, openclaw).

## Commits

1. **`fix(auth)`** — `switchOrg` mint-before-save + new `healDriftedOrgToken` helper + 5 new tests (46 total).
2. **`feat(hooks)`** — wire heal into the 4 standard hook-based agents' `session-start.ts`.
3. **`feat(pi,openclaw)`** — wire heal into the 2 agents that don't fit the standard hook pattern:
   - **pi**: inline copy (raw-`.ts`, zero-deps contract — cannot import shared helpers).
   - **openclaw**: no `session_start`, so heal runs once per process inside `getApi()` behind a `driftHealAttempted` sentinel.

## Key design choices

- **Token name suffix**: `deeplake-plugin-heal-${Date.now()}` instead of date-only. Deeplake's `/users/me/tokens` rejects duplicate `(user_id, name)` with a misleading **500 INTERNAL_ERROR** (not 409); a date-only suffix would collide as soon as a second agent heals on the same day. This was caught during cross-agent testing — first pass got 500s on codex+hermes after claude-code minted with the same date-only name.
- **Heal never throws**: on mint failure (401/403/500/network), logs and returns the original creds. Session start is never blocked.
- **Mint-before-save**: a failed mint leaves `credentials.json` untouched so re-runs are safe.

## Test plan

- [x] Unit: 46/46 vitest pass, including 5 new tests covering switchOrg success/failure/no-creds + healDriftedOrgToken no-drift / missing-claim / missing-orgId / success / mint-failure.
- [x] E2E fake-token drift × 4 hook agents (claude-code, codex, cursor, hermes): all detect drift, all 401 on mint, all preserve creds.
- [x] E2E real cross-org drift × 4 hook agents (token bound to may25_2, `creds.orgId` flipped to test_plugin): all detect drift, all mint successfully, all rotate the token in credentials.json.
- [x] E2E real cross-org drift via real `claude -p --plugin-dir ./claude-code` CLI: heal log + token rotation confirmed.
- [x] Codex bundle heal verified via direct `node session-start.js` invocation (the real `codex exec --dangerously-bypass-approvals-and-sandbox` flow skips hooks by design — not a regression).
- [ ] pi end-to-end (requires Pi editor runtime).
- [ ] openclaw end-to-end (requires openclaw gateway runtime).
- [ ] CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic credential healing that detects and corrects misaligned authentication tokens when organization IDs drift during startup.

* **Bug Fixes**
  * Fixed legacy organization switch regression by transparently refreshing credentials with organization-bound tokens, ensuring downstream operations use valid credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->