### PR TITLE
fix(deps): build tree-sitter from source on linux-arm64 / Node ≥22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@deeplake/hivemind",
       "version": "0.7.54",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.97.1",
         "@huggingface/transformers": "^3.0.0",
@@ -14,8 +15,6 @@
         "deeplake": "^0.3.30",
         "js-yaml": "^4.1.1",
         "just-bash": "^2.14.0",
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-typescript": "^0.23.2",
         "yargs-parser": "^22.0.0",
         "zod": "^4.3.6"
       },
@@ -37,6 +36,10 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-typescript": "^0.23.2"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "dup": "jscpd src",
     "audit:openclaw": "node scripts/audit-openclaw-bundle.mjs",
     "pack:check": "node scripts/pack-check.mjs",
+    "rebuild:native": "node scripts/ensure-tree-sitter.mjs",
     "ci": "npm run typecheck && npm run dup && npm test",
+    "postinstall": "node scripts/ensure-tree-sitter.mjs",
     "prepare": "husky && npm run build",
     "prepack": "npm run build"
   },
@@ -58,10 +60,12 @@
     "deeplake": "^0.3.30",
     "js-yaml": "^4.1.1",
     "just-bash": "^2.14.0",
-    "tree-sitter": "^0.21.1",
-    "tree-sitter-typescript": "^0.23.2",
     "yargs-parser": "^22.0.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/scripts/ensure-tree-sitter.mjs
+++ b/scripts/ensure-tree-sitter.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Ensures the native tree-sitter bindings are loadable on this platform / Node ABI.
+//
+// Why this exists: tree-sitter@0.21.x ships no linux-arm64 prebuild, and
+// tree-sitter-typescript@0.23.x ships a mislabeled (x86-64) one. On linux-arm64
+// both must be compiled from source, and under Node >=22 that compile requires C++20
+// (tree-sitter@0.21's binding.gyp does not request it). tree-sitter is declared as an
+// optionalDependency so this expected arm64 build failure does not abort `npm install`;
+// this script then heals it afterwards.
+//
+// On platforms where the shipped prebuilds work (x64 / darwin / CI) this is a fast
+// no-op and never touches anything. It is intentionally non-fatal: if no toolchain is
+// available it warns and exits 0 rather than breaking the install.
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const ROOT = process.cwd();
+const require = createRequire(`${ROOT}/`);
+const PKGS = ['tree-sitter', 'tree-sitter-typescript'];
+
+function bindingsLoad() {
+  try {
+    const Parser = require('tree-sitter');
+    const TS = require('tree-sitter-typescript').typescript;
+    const parser = new Parser();
+    parser.setLanguage(TS);
+    parser.parse('const x = 1;');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (process.env.ENSURE_TS_RUNNING) process.exit(0); // recursion guard for the nested npm calls below
+if (bindingsLoad()) process.exit(0); // healthy prebuild / prior build → nothing to do
+
+console.error('[ensure-tree-sitter] native bindings not loadable on this platform — building from source...');
+
+const pkg = JSON.parse(readFileSync(`${ROOT}/package.json`, 'utf8'));
+const declared = { ...pkg.dependencies, ...pkg.optionalDependencies };
+
+const env = { ...process.env, ENSURE_TS_RUNNING: '1' };
+if (process.platform !== 'win32') {
+  // Node >=22 V8 headers require C++20; tree-sitter@0.21's binding.gyp doesn't request it.
+  env.CXXFLAGS = `${process.env.CXXFLAGS ?? ''} -std=c++20`.trim();
+}
+const run = (cmd) => execSync(cmd, { stdio: 'inherit', env, cwd: ROOT });
+
+try {
+  // 1. Re-fetch any package npm dropped — an optional dependency whose build failed is
+  //    removed from node_modules. --ignore-scripts: fetch only, so the compile below is
+  //    the single source of truth and the project build isn't triggered prematurely.
+  const missing = PKGS.filter((n) => !existsSync(`${ROOT}/node_modules/${n}/package.json`));
+  if (missing.length) {
+    const specs = missing.map((n) => `${n}@${declared[n] ?? 'latest'}`);
+    run(`npm install ${specs.join(' ')} --no-save --ignore-scripts`);
+  }
+
+  // 2. Force a from-source compile. These packages install via node-gyp-build, which uses
+  //    a local prebuild when present and otherwise compiles from source — no network. By
+  //    removing the (absent or wrong-arch) prebuilds plus any stale build, the rebuild is
+  //    guaranteed to compile locally, and node-gyp-build loads build/Release ahead of
+  //    prebuilds, so the correct binary always wins.
+  for (const n of PKGS) {
+    rmSync(`${ROOT}/node_modules/${n}/prebuilds`, { recursive: true, force: true });
+    rmSync(`${ROOT}/node_modules/${n}/build`, { recursive: true, force: true });
+  }
+  run(`npm rebuild ${PKGS.join(' ')}`);
+} catch (err) {
+  console.error('[ensure-tree-sitter] rebuild command failed:', err.message);
+}
+
+if (bindingsLoad()) {
+  console.error('[ensure-tree-sitter] OK — bindings compiled from source and loadable.');
+  process.exit(0);
+}
+console.error(
+  '[ensure-tree-sitter] WARNING: tree-sitter bindings still unavailable. ' +
+    'Install a C/C++ toolchain and re-run `npm run rebuild:native`. (non-fatal)',
+);
+process.exit(0);


### PR DESCRIPTION
## Problem

A bare `npm install` **hard-fails on linux-arm64 under Node ≥22**:

```
.../include/node/v8config.h:13:2: error: #error "C++20 or later required."
```

Root cause (verified on this repo's pinned versions):

- `tree-sitter@0.21.x` ships **no `linux-arm64` prebuild** → it always compiles from source on arm64.
- `tree-sitter-typescript@0.23.x` ships a `linux-arm64` prebuild that is actually a **mislabeled x86-64 binary** (`file` reports `x86-64`), so it can't be `dlopen`'d on arm64 → also needs a source build.
- Node ≥22's V8 headers **require C++20**, but `tree-sitter@0.21`'s `binding.gyp` doesn't request it → the source compile fails.

Bumping out of this isn't possible: the latest `tree-sitter-typescript` (0.23.2) peer-pins `tree-sitter: ^0.21.0`, so core can't move to 0.22+ without orphaning the grammar.

## Fix

1. **Move `tree-sitter` + `tree-sitter-typescript` to `optionalDependencies`** — the expected arm64 build failure is then tolerated instead of aborting the whole install, so a `postinstall` step can heal it.
2. **`scripts/ensure-tree-sitter.mjs`** (wired as `postinstall`): if the bindings fail to load, it re-fetches any dropped package, removes the absent/wrong-arch prebuilds, and recompiles from source with `CXXFLAGS=-std=c++20`. `node-gyp-build` loads `build/Release` ahead of `prebuilds/`, so the freshly compiled aarch64 binary always wins.
   - **No-op** where prebuilds work (x64 / darwin / CI) — sub-second, touches nothing.
   - **Non-fatal**: warns and exits 0 if no C/C++ toolchain is present, so it never breaks an install.
   - **No deprecated config / no network**: forces the source build purely by removing prebuilds (node-gyp-build builds locally when none match).
3. **`npm run rebuild:native`** — manual escape hatch.

## Testing (linux-arm64, Node 24)

- `rm -rf node_modules && npm install` → completes (no longer aborts); heal logs `OK — bindings compiled from source and loadable`.
- Both `.node` files verified **ARM aarch64**; `node-gyp-build` resolves to `build/Release`, not the bad prebuild; real TS parse works.
- Re-running on a healthy tree is a **0.04s no-op**.
- No `Unknown env config "build-from-source"` warning.

## Note (out of scope)

The committed `package-lock.json` already has **pre-existing drift** unrelated to this change — `npm ci` fails on `main` today with `Missing: @emnapi/runtime` / `Missing: pg` under both npm 10 and npm 11 (the lockfile was written by an older npm). This PR keeps the lockfile delta minimal (only the `tree-sitter` reclassification) and does **not** attempt to fix that drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved installation reliability with enhanced native dependency handling and automated verification.
  * Optimized package dependency structure for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->