### PR TITLE
ci(release): pin release + publish jobs to Node 22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: "24.12"
+          # Pinned to 22 to match ci.yaml. Under Node 24+ the tree-sitter
+          # 0.21 prebuild ABI no longer matches and the install falls back
+          # to a from-source compile that fails (binding.gyp does not
+          # request the C++20 standard Node 24's V8 headers now require).
+          # The ensure-tree-sitter.mjs postinstall heal cannot fully
+          # recover once npm drops the optional dep, so tsc later fails
+          # with "Cannot find module 'tree-sitter'". Aligning with CI's
+          # Node version makes the prebuild match and avoids the issue
+          # entirely. Engines field allows >=22; bundles produced by
+          # Node 22 stay forward-compatible.
+          node-version: 22
 
       - name: Check if version was already bumped in this push
         id: check_bump
@@ -228,7 +238,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: "24.12"
+          # Same rationale as the release job above — keep both jobs on
+          # Node 22 so the publish-time install/build matches what
+          # actually went through CI and what the release-job rebuild
+          # produced. Drifting between jobs would re-introduce the
+          # tree-sitter ABI/build mismatch.
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
           scope: "@deeplake"
           cache: "npm"


### PR DESCRIPTION
## Why

The `Release` workflow failed on the merge commit of #206 ([run 26430516153](https://github.com/activeloopai/hivemind/actions/runs/26430516153)). Main is intact (the failure was before the 2-commit release pair landed) but v0.7.55 was never tagged or published.

## Root cause

| | Node | Outcome |
|---|---|---|
| `ci.yaml` (passed) | 22 | prebuild ABI match → install clean → ensure-tree-sitter no-op |
| `release.yaml` (failed) | 24.12 | prebuild ABI mismatch → fall-back compile → fail (binding.gyp does not request C++20 Node 24 requires) → `tree-sitter` (optional dep) dropped from `node_modules` → tsc later fails with `Cannot find module 'tree-sitter'` |

The `ensure-tree-sitter.mjs` postinstall heal added by #206 prints `WARNING: tree-sitter bindings still unavailable` and exits 0 (non-fatal by design), so the failure surfaces downstream in `tsc` instead of at install time.

## Fix

Pin `release.yaml`'s `release` job and its `publish` job to `node-version: 22`, matching `ci.yaml`. `package.json` engines is `>=22.0.0` so this is within the supported range; bundles produced by Node 22 stay forward-compatible with end-user Node 24 runtimes.

## Follow-up (not in this PR)

- `publish-smoke-test.yaml` is also pinned to `24.12` but is `workflow_dispatch` only, so it does not affect the automatic release pipeline. Will align as part of the next follow-up.
- `ci.yaml` should grow a Node version matrix (e.g. `[22, 24]`) so this class of cross-Node-major install regression fails on the PR rather than on the post-merge Release run. Separate PR.
- `ensure-tree-sitter.mjs` should exit non-zero when its heal fails AND `CI=true`, turning the silent warning into a red light. Same follow-up PR.

## Test plan

- [ ] Merge → `Release` workflow runs on Node 22 → no `tree-sitter` ABI / build failure
- [ ] v0.7.55 (or next patch) gets tagged + published to npm + ClawHub
- [ ] `publish-smoke-test` dry-run can still be invoked manually (no auto-run change in this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration for release and publish processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->