### PR TITLE
ci: cross-Node-major install canary + strict postinstall opt-in

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,3 +275,67 @@ jobs:
         # broken `files` array trips on the PR — never on a release run
         # where tokens are reachable.
         run: npm run pack:check
+
+  cross-node-install:
+    # Cross-Node-major install + build canary. Catches the class of bug
+    # where a native dep's prebuild ABI no longer matches a newer Node
+    # major and the fall-back compile fails — silently, because the
+    # offending package is now an optionalDependency. That exact pattern
+    # broke the post-merge Release run on PR #206 (tree-sitter@0.21 vs
+    # Node 24): the main `test` job above runs only on Node 22 where
+    # the prebuild matches, so the failure was invisible at PR time and
+    # only surfaced on `main` when release.yaml booted Node 24.12.
+    #
+    # This job runs the same install + build on every Node major the
+    # `engines` field admits, with HIVEMIND_STRICT_POSTINSTALL=1 so the
+    # ensure-tree-sitter.mjs heal turns "WARNING: bindings still
+    # unavailable" into a hard `exit 1` instead of swallowing it. The
+    # result: a Node-24-only install regression now fails this canary
+    # job at PR time with a clear error, not on the post-merge Release.
+    #
+    # `continue-on-error: true` keeps PRs unblocked while a known
+    # upstream Node-major break (e.g. the current tree-sitter@0.21 +
+    # Node 24 incompatibility) is being resolved. The signal is visible
+    # in the PR checks table as a yellow/red row. Once the underlying
+    # incompatibility is fixed (or matrix entries adjusted), flip this
+    # to `continue-on-error: false` to make the canary blocking.
+    name: Cross-Node install canary (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      # fail-fast: false so a failure on one Node major doesn't cancel
+      # the other — both signals are useful in the PR checks table.
+      fail-fast: false
+      matrix:
+        # Each major the `engines` field (">=22.0.0") admits. Bump this
+        # list when a new LTS lands (28, 30, …) or when 22 falls out of
+        # the support window. setup-node picks the latest available
+        # minor/patch for each major.
+        node-version: [22, 24]
+    env:
+      # Opt the heal into strict mode for our own CI runs only.
+      # Downstream consumers of @deeplake/hivemind never see this flag,
+      # so their install stays non-fatal.
+      HIVEMIND_STRICT_POSTINSTALL: "1"
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        # If the postinstall heal cannot make tree-sitter loadable under
+        # this Node major, HIVEMIND_STRICT_POSTINSTALL=1 makes ensure-
+        # tree-sitter.mjs exit 1 here, failing the job at the earliest
+        # possible step (instead of swallowing the warning and failing
+        # later in tsc with a confusing "Cannot find module" error).
+        run: npm install
+
+      - name: Build (typecheck + emit bundle artefacts)
+        # Second backstop: if the strict-postinstall path somehow doesn't
+        # catch a broken native dep, the tsc step downstream of it will,
+        # because `import Parser from 'tree-sitter'` (src/graph/extract/
+        # typescript.ts) needs the package resolvable at type-check time.
+        run: npm run build

--- a/scripts/ensure-tree-sitter.mjs
+++ b/scripts/ensure-tree-sitter.mjs
@@ -75,8 +75,17 @@ if (bindingsLoad()) {
   console.error('[ensure-tree-sitter] OK — bindings compiled from source and loadable.');
   process.exit(0);
 }
+
+// Strict mode: turn the warning into a hard failure. Opt-in via
+// HIVEMIND_STRICT_POSTINSTALL=1 — set by this repo's own CI workflows so a
+// heal failure surfaces as a red check on the PR instead of getting swallowed
+// and re-emerging downstream as `tsc: Cannot find module 'tree-sitter'`.
+// Default stays non-fatal so end-user consumers of @deeplake/hivemind never
+// get a hard install break — the runtime check at use-time is enough for them.
+const strict = process.env.HIVEMIND_STRICT_POSTINSTALL === '1';
 console.error(
   '[ensure-tree-sitter] WARNING: tree-sitter bindings still unavailable. ' +
-    'Install a C/C++ toolchain and re-run `npm run rebuild:native`. (non-fatal)',
+    'Install a C/C++ toolchain and re-run `npm run rebuild:native`.' +
+    (strict ? ' (strict mode — failing this install)' : ' (non-fatal)'),
 );
-process.exit(0);
+process.exit(strict ? 1 : 0);


### PR DESCRIPTION
## Why

PR #206 (`fix(deps): build tree-sitter from source on linux-arm64 / Node >=22`) introduced a postinstall heal that turned a hard install failure on Node 24 into a silent `WARNING: tree-sitter bindings still unavailable` + `exit 0`. Because `ci.yaml` runs only on Node 22 — where the linux-x64 prebuild ABI matches and the heal short-circuits cleanly — the regression was **invisible at PR time** and only surfaced post-merge in the `Release` workflow ([run 26430516153](https://github.com/activeloopai/hivemind/actions/runs/26430516153)), which was pinned to Node 24.12. That broke v0.7.55 mid-release.

The unblock is in #207 (pin release.yaml to Node 22). This PR closes the **detection gap** so the next regression of this class fails on the PR instead of on `main`.

## What

Two pieces:

### 1. New `cross-node-install` job in `ci.yaml`

- Matrix `[22, 24]` — every Node major the `engines` field (`>=22.0.0`) admits
- Runs `npm install && npm run build` only — the bug class is install/build-time, not runtime, so running the full test suite on every matrix slot doubles CI cost for no extra signal
- `continue-on-error: true` — keeps PRs unblocked while the known upstream tree-sitter@0.21 + Node 24 incompatibility is being resolved. Signal is still visible in the PR checks table as yellow/red. Flip to `false` once Node 24 install is healthy.

### 2. Opt-in strict mode for `scripts/ensure-tree-sitter.mjs`

- `HIVEMIND_STRICT_POSTINSTALL=1` (set by this repo's own CI workflows) turns `WARNING: bindings still unavailable` into `exit 1` instead of `exit 0`
- Downstream consumers of `@deeplake/hivemind` never see this flag, so their install stays non-fatal as before
- Strict path turns a buried `tsc: Cannot find module 'tree-sitter'` 30 seconds later into an immediate, labeled install-time failure

## How this would have caught #206 → #207

PR #206 in the new canary's Node 24 slot:
1. `npm install` runs the postinstall heal
2. Heal fails to make bindings loadable → `WARNING` + `HIVEMIND_STRICT_POSTINSTALL=1` → `exit 1`
3. Job fails at the install step with a clear `[ensure-tree-sitter] WARNING: ... (strict mode — failing this install)`
4. PR check shows red Node 24 row; reviewer / author sees the regression **before** merging

Even with strict mode off, the next step (`npm run build`) would have failed tsc with `Cannot find module 'tree-sitter'` — same failure as the Release run, but on the PR.

## Test plan

- [ ] Node 22 canary slot passes (existing prebuild ABI match, heal no-op)
- [ ] Node 24 canary slot fails RED but doesn't block PR merge (continue-on-error)
- [ ] Existing `test` (Node 22) and `duplication` jobs unaffected
- [ ] Locally verified: strict-mode logic in `ensure-tree-sitter.mjs` exits 1 only when both `HIVEMIND_STRICT_POSTINSTALL=1` AND `bindingsLoad() === false`; healthy bindings still exit 0

## Follow-up (not in this PR)

- Align `release.yaml` and `publish-smoke-test.yaml` env to also set `HIVEMIND_STRICT_POSTINSTALL=1` once #207 lands
- Add Node 26 to matrix when it ships
- Once tree-sitter@0.21 vs Node 24 is resolved upstream (or we upgrade tree-sitter), flip `continue-on-error` to `false` to make Node 24 install a hard gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline to test builds across multiple Node.js versions (22, 24) with stricter validation rules, ensuring improved build reliability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->