### PR TITLE
feat(hooks): HIVEMIND_CAPTURE_ONLY_CLI gate to skip Agent SDK sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ This plugin captures session activity and stores it in your Deeplake workspace:
 | `HIVEMIND_SESSIONS_TABLE` | `sessions`                | SQL table for per-event session capture    |
 | `HIVEMIND_MEMORY_PATH`    | `~/.deeplake/memory`      | Path that triggers interception            |
 | `HIVEMIND_CAPTURE`        | `true`                    | Set to `false` to disable capture          |
+| `HIVEMIND_CAPTURE_ONLY_CLI` | —                       | Set to `true` to capture only interactive CLI sessions. Sessions spawned by the Claude Agent SDK (Python/TypeScript) are skipped — their `CLAUDE_CODE_ENTRYPOINT` is `sdk-py` / `sdk-ts`, so they fail the substring check for `cli`. |
+| `HIVEMIND_SKILLIFY_EVERY_N_TURNS` | `20`              | Assistant turns between auto skill-mining attempts. Lower = more frequent mining (cheaper sessions, noisier output); higher = fewer attempts on longer histories. |
 | `HIVEMIND_EMBEDDINGS`     | `true`                    | Set to `false` to force lexical-only mode  |
 | `HIVEMIND_DEBUG`          | —                         | Set to `1` for verbose hook debug logs     |
 

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -72,8 +72,16 @@ interface HookInput {
 
 const CAPTURE = process.env.HIVEMIND_CAPTURE !== "false";
 
+// Allowlist gate: when HIVEMIND_CAPTURE_ONLY_CLI=true, only persist sessions
+// whose CLAUDE_CODE_ENTRYPOINT contains "cli". The Claude Agent SDK spawns
+// the CLI with entrypoint "sdk-py" / "sdk-ts", so those subprocesses get
+// filtered out without touching the interactive `cli` entrypoint.
+const ONLY_CLI = process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true";
+const ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT ?? "";
+
 async function main(): Promise<void> {
   if (!CAPTURE) return;
+  if (ONLY_CLI && !ENTRYPOINT.includes("cli")) return;
   const input = await readStdin<HookInput>();
   const config = loadConfig();
   if (!config) { log("no config"); return; }

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -31,6 +31,7 @@ import { dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { getInstalledVersion } from "../utils/version-check.js";
+import { entrypointPassesOnlyCliGate } from "./shared/capture-gate.js";
 const log = (msg: string) => _log("capture", msg);
 
 function resolveEmbedDaemonPath(): string {
@@ -72,16 +73,9 @@ interface HookInput {
 
 const CAPTURE = process.env.HIVEMIND_CAPTURE !== "false";
 
-// Allowlist gate: when HIVEMIND_CAPTURE_ONLY_CLI=true, only persist sessions
-// whose CLAUDE_CODE_ENTRYPOINT contains "cli". The Claude Agent SDK spawns
-// the CLI with entrypoint "sdk-py" / "sdk-ts", so those subprocesses get
-// filtered out without touching the interactive `cli` entrypoint.
-const ONLY_CLI = process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true";
-const ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT ?? "";
-
 async function main(): Promise<void> {
   if (!CAPTURE) return;
-  if (ONLY_CLI && !ENTRYPOINT.includes("cli")) return;
+  if (!entrypointPassesOnlyCliGate()) return;
   const input = await readStdin<HookInput>();
   const config = loadConfig();
   if (!config) { log("no config"); return; }

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -51,6 +51,12 @@ function recordSessionUsage(transcriptPath: string | undefined, sessionId: strin
 async function main(): Promise<void> {
   if (process.env.HIVEMIND_WIKI_WORKER === "1") return;
   if (process.env.HIVEMIND_CAPTURE === "false") return;
+  // Allowlist gate: filter Agent SDK spawns (entrypoint "sdk-py" / "sdk-ts")
+  // when HIVEMIND_CAPTURE_ONLY_CLI=true.
+  if (
+    process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true" &&
+    !(process.env.CLAUDE_CODE_ENTRYPOINT ?? "").includes("cli")
+  ) return;
 
   const input = await readStdin<StopInput>();
   const sessionId = input.session_id;

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -16,6 +16,7 @@ import { tryAcquireLock, releaseLock } from "./summary-state.js";
 import { forceSessionEndTrigger } from "../skillify/triggers.js";
 import { parseTranscript } from "../notifications/transcript-parser.js";
 import { appendUsageRecord } from "../notifications/usage-tracker.js";
+import { entrypointPassesOnlyCliGate } from "./shared/capture-gate.js";
 
 const log = (msg: string) => _log("session-end", msg);
 
@@ -51,12 +52,7 @@ function recordSessionUsage(transcriptPath: string | undefined, sessionId: strin
 async function main(): Promise<void> {
   if (process.env.HIVEMIND_WIKI_WORKER === "1") return;
   if (process.env.HIVEMIND_CAPTURE === "false") return;
-  // Allowlist gate: filter Agent SDK spawns (entrypoint "sdk-py" / "sdk-ts")
-  // when HIVEMIND_CAPTURE_ONLY_CLI=true.
-  if (
-    process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true" &&
-    !(process.env.CLAUDE_CODE_ENTRYPOINT ?? "").includes("cli")
-  ) return;
+  if (!entrypointPassesOnlyCliGate()) return;
 
   const input = await readStdin<StopInput>();
   const sessionId = input.session_id;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -189,7 +189,13 @@ async function main(): Promise<void> {
   // under capture=false. The renderer is read-only and runs
   // regardless; the rules table it queries is lazy-created by the
   // CLI write path (`hivemind rules add`).
-  const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false";
+  // Allowlist gate: when HIVEMIND_CAPTURE_ONLY_CLI=true, capture only sessions
+  // whose CLAUDE_CODE_ENTRYPOINT contains "cli" (filters out Agent SDK spawns
+  // which set entrypoint to "sdk-py" / "sdk-ts").
+  const onlyCli = process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true";
+  const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "";
+  const entrypointAllowed = !onlyCli || entrypoint.includes("cli");
+  const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false" && entrypointAllowed;
   let rulesBlock = "";
   if (input.session_id && creds?.token) {
     try {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -205,7 +205,10 @@ async function main(): Promise<void> {
           await createPlaceholder(api, table, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId, pluginVersion);
           log("placeholder created");
         } else {
-          log("placeholder + schema ensure skipped (HIVEMIND_CAPTURE=false)");
+          const reason = process.env.HIVEMIND_CAPTURE === "false"
+            ? "HIVEMIND_CAPTURE=false"
+            : "HIVEMIND_CAPTURE_ONLY_CLI gate";
+          log(`placeholder + schema ensure skipped (${reason})`);
         }
         // Renderer is read-only and runs regardless of captureEnabled.
         // It absorbs its own errors (missing table, network, etc.)

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -26,6 +26,7 @@ import { renderLocalMinedNote } from "../skillify/local-mined-banner.js";
 import { maybeAutoMineLocal } from "../skillify/spawn-mine-local-worker.js";
 import { graphContextLine } from "../graph/session-context.js";
 import { spawnGraphPullWorker } from "../graph/spawn-pull-worker.js";
+import { entrypointPassesOnlyCliGate } from "./shared/capture-gate.js";
 const log = (msg: string) => _log("session-start", msg);
 
 const __bundleDir = dirname(fileURLToPath(import.meta.url));
@@ -189,13 +190,7 @@ async function main(): Promise<void> {
   // under capture=false. The renderer is read-only and runs
   // regardless; the rules table it queries is lazy-created by the
   // CLI write path (`hivemind rules add`).
-  // Allowlist gate: when HIVEMIND_CAPTURE_ONLY_CLI=true, capture only sessions
-  // whose CLAUDE_CODE_ENTRYPOINT contains "cli" (filters out Agent SDK spawns
-  // which set entrypoint to "sdk-py" / "sdk-ts").
-  const onlyCli = process.env.HIVEMIND_CAPTURE_ONLY_CLI === "true";
-  const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT ?? "";
-  const entrypointAllowed = !onlyCli || entrypoint.includes("cli");
-  const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false" && entrypointAllowed;
+  const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false" && entrypointPassesOnlyCliGate();
   let rulesBlock = "";
   if (input.session_id && creds?.token) {
     try {

--- a/src/hooks/shared/capture-gate.ts
+++ b/src/hooks/shared/capture-gate.ts
@@ -1,0 +1,24 @@
+/**
+ * Allowlist gate for HIVEMIND_CAPTURE_ONLY_CLI.
+ *
+ * When the env var is "true", only capture sessions whose
+ * CLAUDE_CODE_ENTRYPOINT contains the substring "cli". The Claude Agent SDK
+ * (Python / TypeScript) sets the entrypoint to "sdk-py" / "sdk-ts" when it
+ * spawns the CLI subprocess, so those sessions fail the check and the hook
+ * short-circuits. Interactive terminal sessions keep entrypoint="cli".
+ *
+ * Returns true when the gate PASSES (capture should proceed), false when
+ * the caller should skip. With the gate disabled (env var unset or != "true")
+ * this always returns true.
+ *
+ * Accepts an optional env map to keep the function pure and trivially
+ * unit-testable; defaults to process.env.
+ */
+export function entrypointPassesOnlyCliGate(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const onlyCli = env.HIVEMIND_CAPTURE_ONLY_CLI === "true";
+  if (!onlyCli) return true;
+  const entrypoint = env.CLAUDE_CODE_ENTRYPOINT ?? "";
+  return entrypoint.includes("cli");
+}

--- a/tests/shared/capture-gate.test.ts
+++ b/tests/shared/capture-gate.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { entrypointPassesOnlyCliGate } from "../../src/hooks/shared/capture-gate.js";
+
+// The helper takes an explicit env map so each test feeds the exact
+// combination it wants to assert on. process.env is read only when the
+// caller omits the argument; covered separately below.
+
+describe("entrypointPassesOnlyCliGate", () => {
+  it("passes when the gate env var is unset (default behavior)", () => {
+    expect(entrypointPassesOnlyCliGate({})).toBe(true);
+  });
+
+  it("passes when the gate env var is anything other than 'true'", () => {
+    // Defensive: only the exact literal "true" should activate the gate.
+    expect(entrypointPassesOnlyCliGate({ HIVEMIND_CAPTURE_ONLY_CLI: "false" })).toBe(true);
+    expect(entrypointPassesOnlyCliGate({ HIVEMIND_CAPTURE_ONLY_CLI: "1" })).toBe(true);
+    expect(entrypointPassesOnlyCliGate({ HIVEMIND_CAPTURE_ONLY_CLI: "yes" })).toBe(true);
+    expect(entrypointPassesOnlyCliGate({ HIVEMIND_CAPTURE_ONLY_CLI: "" })).toBe(true);
+  });
+
+  it("passes with gate active and entrypoint='cli'", () => {
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "cli",
+    })).toBe(true);
+  });
+
+  it("passes with gate active and entrypoint contains 'cli' as substring", () => {
+    // Substring match (not equality) is intentional — covers future variants
+    // like cli-interactive, claude-cli, etc. without code changes.
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "cli-interactive",
+    })).toBe(true);
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "claude-cli",
+    })).toBe(true);
+  });
+
+  it("blocks with gate active and entrypoint='sdk-py'", () => {
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "sdk-py",
+    })).toBe(false);
+  });
+
+  it("blocks with gate active and entrypoint='sdk-ts'", () => {
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "sdk-ts",
+    })).toBe(false);
+  });
+
+  it("blocks with gate active and entrypoint undefined", () => {
+    // Strict: missing entrypoint is treated as non-cli. An empty string
+    // doesn't contain the "cli" substring so the gate filters it out.
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+    })).toBe(false);
+  });
+
+  it("blocks with gate active and entrypoint=''", () => {
+    expect(entrypointPassesOnlyCliGate({
+      HIVEMIND_CAPTURE_ONLY_CLI: "true",
+      CLAUDE_CODE_ENTRYPOINT: "",
+    })).toBe(false);
+  });
+
+  it("blocks with gate active and any future sdk-* entrypoint", () => {
+    // Forward compat: hypothetical sdk-go, sdk-rust, mcp-host, etc.
+    for (const ep of ["sdk-go", "sdk-rust", "mcp-host", "vscode", "web"]) {
+      expect(entrypointPassesOnlyCliGate({
+        HIVEMIND_CAPTURE_ONLY_CLI: "true",
+        CLAUDE_CODE_ENTRYPOINT: ep,
+      })).toBe(false);
+    }
+  });
+
+  it("defaults to process.env when no argument is passed", () => {
+    // Snapshot + restore to keep the suite hermetic.
+    const prev = {
+      ONLY_CLI: process.env.HIVEMIND_CAPTURE_ONLY_CLI,
+      EP: process.env.CLAUDE_CODE_ENTRYPOINT,
+    };
+    try {
+      process.env.HIVEMIND_CAPTURE_ONLY_CLI = "true";
+      process.env.CLAUDE_CODE_ENTRYPOINT = "sdk-py";
+      expect(entrypointPassesOnlyCliGate()).toBe(false);
+
+      process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+      expect(entrypointPassesOnlyCliGate()).toBe(true);
+
+      delete process.env.HIVEMIND_CAPTURE_ONLY_CLI;
+      process.env.CLAUDE_CODE_ENTRYPOINT = "sdk-py";
+      expect(entrypointPassesOnlyCliGate()).toBe(true);
+    } finally {
+      if (prev.ONLY_CLI === undefined) delete process.env.HIVEMIND_CAPTURE_ONLY_CLI;
+      else process.env.HIVEMIND_CAPTURE_ONLY_CLI = prev.ONLY_CLI;
+      if (prev.EP === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+      else process.env.CLAUDE_CODE_ENTRYPOINT = prev.EP;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **`HIVEMIND_CAPTURE_ONLY_CLI`** opt-in env var. When set to `true`, the three claude-code hooks (`capture`, `session-start`, `session-end`) short-circuit unless `CLAUDE_CODE_ENTRYPOINT` contains the substring `cli`.

The Anthropic Claude Agent SDK (Python / TypeScript) spawns the CLI subprocess with `CLAUDE_CODE_ENTRYPOINT=sdk-py` or `sdk-ts` — those entrypoints fail the substring check and the spawned session writes zero rows to `sessions` / `memory`. Interactive terminal sessions keep `CLAUDE_CODE_ENTRYPOINT=cli` and pass through unchanged.

### Why opt-in (vs default-on)

Shipped as opt-in via env var rather than a default behavior flip so existing users who *deliberately* drive sessions via the Agent SDK and want them captured (CI, scripted automations) aren't silently affected. Adding `HIVEMIND_CAPTURE_ONLY_CLI=true` to `~/.zshrc` or `~/.bashrc` enables it globally per-user; the value propagates to every `claude` subprocess the SDK spawns via standard env inheritance.

### Why substring `.includes("cli")` (not equality)

Future-proofing: covers hypothetical entrypoints like `cli-interactive`, `claude-cli`, etc. without code changes. The Agent SDK's `sdk-py` / `sdk-ts` cannot match this substring; the contract is documented in `claude_agent_sdk/_internal/transport/subprocess_cli.py` ("CLAUDE_CODE_ENTRYPOINT defaults to sdk-py regardless of inherited process env").

## Files

| File | Change |
|---|---|
| `src/hooks/capture.ts` | Early return when gate triggers (before stdin read, config load, DB call) |
| `src/hooks/session-start.ts` | Folded into `captureEnabled` — gates the placeholder INSERT and the `ensureTable`/`ensureSessionsTable` DDL |
| `src/hooks/session-end.ts` | Early return — prevents the wiki worker spawn, usage record, and any downstream `memory` table writes |
| `README.md` | Documents `HIVEMIND_CAPTURE_ONLY_CLI` and also surfaces `HIVEMIND_SKILLIFY_EVERY_N_TURNS` (already honored in `src/skillify/state.ts`) in the Configuration table |

## Verification

**Bundle-level matrix** (against built `claude-code/bundle/capture.js`):

| `ONLY_CLI` | `ENTRYPOINT` | Expected | Result |
|---|---|---|---|
| true | `sdk-py` | gate-out | ✅ GATED OUT |
| true | `sdk-ts` | gate-out | ✅ GATED OUT |
| true | `cli` | pass | ✅ passed gate |
| true | *(unset / empty)* | gate-out | ✅ GATED OUT |
| true | `cli-interactive` | pass (substring) | ✅ passed gate |
| false / unset | `sdk-py` | pass (gate inactive) | ✅ passed gate |
| `HIVEMIND_CAPTURE=false` | any | legacy block | ✅ silent skip |

**End-to-end against prod `sessions` table** (with installed plugin temporarily disabled, `--plugin-dir` pointing at this branch's `claude-code/`):

- Baseline run (gate off): spawned session `bda2a3f8-…` → `SELECT … FROM sessions WHERE path LIKE '%bda2a3f8%'` → **1 row** (capture pipeline works)
- Gated run (gate on): spawned session `c5292417-…` → same query → **`row_count: 0`** (gate effective)

## Test plan

- [x] Bundle-level matrix (7 cases above) on `claude-code/bundle/capture.js`
- [x] E2E against prod `sessions` table with Agent SDK Python 0.2.87
- [x] Verify the gate is also active in `session-start.ts` (placeholder INSERT) and `session-end.ts` (wiki-worker spawn, usage record)
- [x] README config table renders correctly (both new rows)
- [ ] Reviewer: confirm we don't want a default-on flip; current PR ships opt-in only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable to optionally restrict session capture to CLI-only interactions
  * Added environment variable to control the frequency of automatic skill-mining attempts

* **Documentation**
  * Updated configuration reference with two new environment variable options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->