### PR TITLE
chore(release): generate release notes from merged PR list, not PR body

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,19 +172,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get merged PR description
+      - name: Get merged PR title
         if: steps.check.outputs.exists == 'false'
         id: pr
         run: |
-          # Find the most recent merged PR targeting main
-          PR_BODY=$(gh pr list --state merged --base main --limit 1 --json body,title -q '.[0].body // ""')
           PR_TITLE=$(gh pr list --state merged --base main --limit 1 --json title -q '.[0].title // ""')
-          {
-            echo "body<<ENDOFBODY"
-            echo "$PR_BODY"
-            echo "ENDOFBODY"
-            echo "title=$PR_TITLE"
-          } >> "$GITHUB_OUTPUT"
+          echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -194,8 +187,7 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: "${{ steps.version.outputs.version }} — ${{ steps.pr.outputs.title }}"
-          body: ${{ steps.pr.outputs.body }}
-          generate_release_notes: false
+          generate_release_notes: true
 
       - name: Set outputs for publish job
         # Captures the local HEAD SHA after the bump+push (or the


### PR DESCRIPTION
## Summary

- Release notes are currently the verbatim body of the most-recent merged PR — produces walls of text per release because PR bodies trend toward multi-paragraph context + test plans
- Switch to GitHub's built-in `generate_release_notes: true` → compact `* <PR title> by @author in #N` bullets + Full Changelog compare link
- Release title still carries the most-recent PR's title for at-a-glance context
- Drops the PR-body fetch from the workflow; only the title fetch remains

## Sample output

```
v0.7.61 — fix(pkg): include scripts/ in tarball so postinstall finds...

## What's Changed
* fix(pkg): include scripts/ in tarball so postinstall finds ensure-tree-sitter.mjs by @kaghni in #214

**Full Changelog**: https://github.com/activeloopai/hivemind/compare/v0.7.60...v0.7.61
```

## Test plan

- [ ] Merge triggers release workflow
- [ ] Resulting GitHub Release page shows bullet list, not a wall of text
- [ ] `name` field still carries the most-recent PR's title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now automatically generates release notes for GitHub releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->