### PR TITLE
Hivemind: surface low-balance warning banner via X-Activeloop-Balance-Cents

### DIFF
--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -131,7 +131,10 @@ function maybeSignalLowBalance(resp: Response): void {
   // standard `headers` getter, so guard the access rather than assume it.
   const raw = resp.headers?.get?.(BALANCE_HEADER);
   if (!raw) return;
-  const balance = Number.parseInt(raw, 10);
+  // Strict integer parse — Number.parseInt would accept "150abc" as 150 and
+  // fire a spurious warning. Reject anything that isn't a clean integer.
+  if (!/^-?\d+$/.test(raw.trim())) return;
+  const balance = Number(raw.trim());
   if (!Number.isFinite(balance)) return;
   if (balance >= LOW_BALANCE_THRESHOLD_CENTS) return;
   // Suppress the soft warning when the user is already at hard zero — the
@@ -147,6 +150,9 @@ function maybeSignalLowBalance(resp: Response): void {
     body: `Only $${(balance / 100).toFixed(2)} of prepaid balance remains. Top up at ${billingUrl()} to avoid interruption when requests start failing.`,
     dedupKey: { reason: "low-balance" },
   }).catch((e: unknown) => {
+    // Reset the dedup flag so a transient queue-write failure doesn't
+    // permanently suppress low-balance warnings for the rest of the process.
+    _signalledLowBalance = false;
     log(`enqueue low-balance failed: ${e instanceof Error ? e.message : String(e)}`);
   });
 }

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -54,6 +54,20 @@ function traceSql(msg: string): void {
 // queue.ts's sameDedupKey check.
 let _signalledBalanceExhausted = false;
 
+// Process-local once-only flag for the "approaching empty" warning.
+// Symmetrical with _signalledBalanceExhausted — see maybeSignalLowBalance.
+let _signalledLowBalance = false;
+
+// Mirror of the backend's billing.LowBalanceThresholdCents. Hardcoded
+// rather than fetched because (a) the threshold rarely changes, (b)
+// fetching it would mean a round-trip just to render a banner, and (c)
+// the backend ALSO sets the header value only when balance < threshold —
+// so the client never actually decides; it just renders what the header
+// hints at. Keep this value in sync with internal/billing/low_balance.go
+// if the backend constant ever moves.
+const LOW_BALANCE_THRESHOLD_CENTS = 200;
+const BALANCE_HEADER = "X-Activeloop-Balance-Cents";
+
 /**
  * If the response is the server's "out of credits" 402
  * (`{"balance_cents":0,"error":"insufficient balance, please top up"}`),
@@ -89,6 +103,48 @@ function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
     dedupKey: { reason: "balance-zero" },
   }).catch((e: unknown) => {
     log(`enqueue balance-exhausted failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
+}
+
+/**
+ * Read the backend's `X-Activeloop-Balance-Cents` response header and, if
+ * the balance is below the warning threshold, enqueue a one-shot
+ * mid-session banner pointing the user at the billing page. Mirrors the
+ * 402-driven `maybeSignalBalanceExhausted` path but fires while requests
+ * still SUCCEED — the goal is to give the user a chance to top up before
+ * the hard 402 wall kicks in.
+ *
+ * Once-only semantics:
+ *  - Process-local `_signalledLowBalance` collapses repeated calls within
+ *    one hivemind process to a single enqueue.
+ *  - `transient: true` means the drain doesn't persist to `state.shown`,
+ *    so the next session that still sees a low-balance header re-fires
+ *    the banner — natural client-side rearm without explicit signalling.
+ *  - When the backend's `MaybeRearm` path dismisses the notification row
+ *    after a top-up, subsequent requests stop carrying the low-balance
+ *    header (because balance is now ≥ threshold), so this function no-ops.
+ */
+function maybeSignalLowBalance(resp: Response): void {
+  if (_signalledLowBalance) return;
+  const raw = resp.headers.get(BALANCE_HEADER);
+  if (!raw) return;
+  const balance = Number.parseInt(raw, 10);
+  if (!Number.isFinite(balance)) return;
+  if (balance >= LOW_BALANCE_THRESHOLD_CENTS) return;
+  // Suppress the soft warning when the user is already at hard zero — the
+  // 402-driven exhausted banner is louder and more accurate.
+  if (balance <= 0) return;
+  _signalledLowBalance = true;
+  log(`balance below threshold (${balance}¢) — enqueuing low-balance banner`);
+  enqueueNotification({
+    id: "low-balance-warning",
+    severity: "warn",
+    transient: true,
+    title: "Hivemind balance is running low — top up before it runs out",
+    body: `Only $${(balance / 100).toFixed(2)} of prepaid balance remains. Top up at ${billingUrl()} to avoid interruption when requests start failing.`,
+    dedupKey: { reason: "low-balance" },
+  }).catch((e: unknown) => {
+    log(`enqueue low-balance failed: ${e instanceof Error ? e.message : String(e)}`);
   });
 }
 
@@ -257,6 +313,11 @@ export class DeeplakeApi {
         }
         throw lastError;
       }
+      // Mid-session low-balance signal: fire on both success and 402
+      // paths so users get warned BEFORE their balance hits zero. The
+      // function is process-local-deduped, so it's cheap to call on every
+      // response.
+      maybeSignalLowBalance(resp);
       if (resp.ok) {
         const raw = await resp.json() as { columns?: string[]; rows?: unknown[][]; row_count?: number } | null;
         if (!raw?.rows || !raw?.columns) return [];
@@ -439,6 +500,7 @@ export class DeeplakeApi {
             ...deeplakeClientHeader(),
           },
         });
+        maybeSignalLowBalance(resp);
         if (resp.ok) {
           const data = await resp.json() as { tables?: { table_name: string }[] };
           return {
@@ -671,5 +733,6 @@ export class DeeplakeApi {
 /** Reset module-local flags so tests start clean. Not for production use. */
 export function _resetSdkStateForTesting(): void {
   _signalledBalanceExhausted = false;
+  _signalledLowBalance = false;
 }
 

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -146,8 +146,8 @@ function signalLowBalanceFromHeader(resp: Response): void {
     id: "low-balance-warning",
     severity: "warn",
     transient: true,
-    title: "Hivemind balance is running low. Top up before it runs out",
-    body: `Only $${(balance / 100).toFixed(2)} of prepaid balance remains. Top up at ${billingUrl()} to avoid interruption when requests start failing.`,
+    title: "Your org's Hivemind balance is running low",
+    body: `Only $${(balance / 100).toFixed(2)} of prepaid balance remains. Admins can top up at ${billingUrl()}; otherwise ask an org admin to top up before requests start failing.`,
     dedupKey: { reason: "low-balance" },
   }).catch((e: unknown) => {
     // Reset the dedup flag so a transient queue-write failure doesn't

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -146,7 +146,7 @@ function maybeSignalLowBalance(resp: Response): void {
     id: "low-balance-warning",
     severity: "warn",
     transient: true,
-    title: "Hivemind balance is running low — top up before it runs out",
+    title: "Hivemind balance is running low. Top up before it runs out",
     body: `Only $${(balance / 100).toFixed(2)} of prepaid balance remains. Top up at ${billingUrl()} to avoid interruption when requests start failing.`,
     dedupKey: { reason: "low-balance" },
   }).catch((e: unknown) => {

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -55,7 +55,7 @@ function traceSql(msg: string): void {
 let _signalledBalanceExhausted = false;
 
 // Process-local once-only flag for the "approaching empty" warning.
-// Symmetrical with _signalledBalanceExhausted — see maybeSignalLowBalance.
+// Symmetrical with _signalledBalanceExhausted — see signalLowBalanceFromHeader.
 let _signalledLowBalance = false;
 
 // Mirror of the backend's billing.LowBalanceThresholdCents. Hardcoded
@@ -124,7 +124,7 @@ function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
  *    after a top-up, subsequent requests stop carrying the low-balance
  *    header (because balance is now ≥ threshold), so this function no-ops.
  */
-function maybeSignalLowBalance(resp: Response): void {
+function signalLowBalanceFromHeader(resp: Response): void {
   if (_signalledLowBalance) return;
   // Best-effort side-effect: never throw into the query path. Some callers
   // (and test fakes) hand back a minimal Response-like object without a
@@ -326,7 +326,7 @@ export class DeeplakeApi {
       // paths so users get warned BEFORE their balance hits zero. The
       // function is process-local-deduped, so it's cheap to call on every
       // response.
-      maybeSignalLowBalance(resp);
+      signalLowBalanceFromHeader(resp);
       if (resp.ok) {
         const raw = await resp.json() as { columns?: string[]; rows?: unknown[][]; row_count?: number } | null;
         if (!raw?.rows || !raw?.columns) return [];
@@ -509,7 +509,7 @@ export class DeeplakeApi {
             ...deeplakeClientHeader(),
           },
         });
-        maybeSignalLowBalance(resp);
+        signalLowBalanceFromHeader(resp);
         if (resp.ok) {
           const data = await resp.json() as { tables?: { table_name: string }[] };
           return {

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -126,7 +126,10 @@ function maybeSignalBalanceExhausted(status: number, bodyText: string): void {
  */
 function maybeSignalLowBalance(resp: Response): void {
   if (_signalledLowBalance) return;
-  const raw = resp.headers.get(BALANCE_HEADER);
+  // Best-effort side-effect: never throw into the query path. Some callers
+  // (and test fakes) hand back a minimal Response-like object without a
+  // standard `headers` getter, so guard the access rather than assume it.
+  const raw = resp.headers?.get?.(BALANCE_HEADER);
   if (!raw) return;
   const balance = Number.parseInt(raw, 10);
   if (!Number.isFinite(balance)) return;

--- a/tests/shared/deeplake-api-low-balance.test.ts
+++ b/tests/shared/deeplake-api-low-balance.test.ts
@@ -145,6 +145,36 @@ describe("DeeplakeApi — X-Activeloop-Balance-Cents low-balance warning", () =>
     expect(enqueueNotificationMock).not.toHaveBeenCalled();
   });
 
+  it("rejects partially-numeric header values (strict parse, no spurious warning)", async () => {
+    // Number.parseInt("150abc") would yield 150 and fire a false warning;
+    // strict /^-?\d+$/ parsing must reject it.
+    const resp = new Response(JSON.stringify({ columns: ["x"], rows: [[1]] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", "X-Activeloop-Balance-Cents": "150abc" },
+    });
+    fetchMock.mockResolvedValueOnce(resp);
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("resets the dedup flag when enqueue fails, so a later request can retry the warning", async () => {
+    // First low-balance response: enqueue rejects. The flag must reset so a
+    // subsequent low-balance response re-attempts the enqueue rather than
+    // silently suppressing warnings for the rest of the process.
+    enqueueNotificationMock.mockRejectedValueOnce(new Error("queue write failed"));
+    enqueueNotificationMock.mockResolvedValueOnce(undefined);
+    fetchMock.mockImplementation(() => Promise.resolve(okResp(150)));
+    const api = await makeApi();
+
+    await api.query("SELECT 1");
+    // Let the rejected enqueue's .catch run (resets the flag).
+    await new Promise(resolve => setImmediate(resolve));
+    await api.query("SELECT 2");
+
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
   it("swallows enqueueNotification rejection — successful query still returns rows", async () => {
     enqueueNotificationMock.mockRejectedValueOnce(new Error("queue write failed"));
     fetchMock.mockResolvedValueOnce(okResp(150));

--- a/tests/shared/deeplake-api-low-balance.test.ts
+++ b/tests/shared/deeplake-api-low-balance.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Tests for the low-balance warning path in DeeplakeApi.
+ *
+ * The backend sets the `X-Activeloop-Balance-Cents` response header on
+ * every billable response (success and 402 alike). When the value is
+ * below the threshold, hivemind enqueues a one-shot mid-session banner
+ * pointing the user at the billing page — symmetrical with the
+ * 402-driven balance-exhausted path, but the request itself still
+ * succeeds.
+ *
+ * Pins:
+ *  - Header below threshold on a SUCCESSFUL response → enqueues banner
+ *  - Header above threshold → does NOT enqueue
+ *  - Header absent → does NOT enqueue (compat with backends that don't yet emit it)
+ *  - Process-local dedup: multiple requests with low balance enqueue once
+ *  - Balance exactly at threshold → does NOT enqueue (boundary contract)
+ *  - Zero balance suppressed → the 402 exhausted banner is louder and takes over
+ */
+
+const enqueueNotificationMock = vi.fn();
+vi.mock("../../src/notifications/queue.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/notifications/queue.js")>(
+    "../../src/notifications/queue.js",
+  );
+  return { ...actual, enqueueNotification: (...a: unknown[]) => enqueueNotificationMock(...a) };
+});
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function okResp(balanceCents: number | null): Response {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (balanceCents !== null) headers["X-Activeloop-Balance-Cents"] = String(balanceCents);
+  return new Response(JSON.stringify({ columns: ["x"], rows: [[1]] }), { status: 200, headers });
+}
+
+let TEMP_HOME = "";
+let ORIGINAL_HOME: string | undefined;
+
+beforeEach(async () => {
+  fetchMock.mockReset();
+  enqueueNotificationMock.mockReset();
+  enqueueNotificationMock.mockResolvedValue(undefined);
+  const { _resetSdkStateForTesting } = await import("../../src/deeplake-api.js");
+  _resetSdkStateForTesting();
+  TEMP_HOME = mkdtempSync(join(tmpdir(), "hivemind-low-bal-test-"));
+  ORIGINAL_HOME = process.env.HOME;
+  process.env.HOME = TEMP_HOME;
+  mkdirSync(join(TEMP_HOME, ".deeplake"), { recursive: true });
+  writeFileSync(
+    join(TEMP_HOME, ".deeplake", "credentials.json"),
+    JSON.stringify({
+      token: "tok",
+      orgId: "org-uuid",
+      orgName: "acme",
+      userName: "ada",
+      workspaceId: "default",
+      apiUrl: "https://api.example",
+      savedAt: "2026-05-19T00:00:00Z",
+    }),
+    { mode: 0o600 },
+  );
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) process.env.HOME = ORIGINAL_HOME;
+  else delete process.env.HOME;
+  rmSync(TEMP_HOME, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function makeApi() {
+  const { DeeplakeApi } = await import("../../src/deeplake-api.js");
+  return new DeeplakeApi("tok", "https://api.example", "org", "ws", "memory");
+}
+
+describe("DeeplakeApi — X-Activeloop-Balance-Cents low-balance warning", () => {
+  it("enqueues a mid-session banner when a successful response carries balance below threshold", async () => {
+    fetchMock.mockResolvedValueOnce(okResp(150));
+    const api = await makeApi();
+    const rows = await api.query("SELECT 1");
+    expect(rows).toEqual([{ x: 1 }]);
+
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+    const arg = enqueueNotificationMock.mock.calls[0][0];
+    expect(arg.id).toBe("low-balance-warning");
+    expect(arg.severity).toBe("warn");
+    expect(arg.title).toMatch(/running low/i);
+    expect(arg.body).toMatch(/\$1\.50/);
+    expect(arg.body).toContain("https://deeplake.ai/acme/workspace/default/billing");
+    expect(arg.dedupKey.reason).toBe("low-balance");
+    expect(arg.transient).toBe(true);
+  });
+
+  it("does NOT enqueue when balance is at or above the threshold (boundary contract)", async () => {
+    fetchMock.mockResolvedValueOnce(okResp(200)); // exactly threshold
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT enqueue when the X-Activeloop-Balance-Cents header is absent (older backend)", async () => {
+    fetchMock.mockResolvedValueOnce(okResp(null));
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("process-local dedup: low-balance header on successive requests enqueues once", async () => {
+    // A fresh Response per call — Body streams are single-use, so reusing
+    // the same instance across three queries would error on the second
+    // `resp.json()`.
+    fetchMock.mockImplementation(() => Promise.resolve(okResp(120)));
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    await api.query("SELECT 2");
+    await api.query("SELECT 3");
+    expect(enqueueNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses the low-balance banner when balance is zero — the 402 exhausted banner takes over", async () => {
+    // Zero-balance + 200 OK is a backend bug (the middleware would have
+    // returned 402), but we explicitly suppress at the SDK level so the
+    // soft-warning copy never claims '$0.00 remaining' alongside the
+    // hard-block banner.
+    fetchMock.mockResolvedValueOnce(okResp(0));
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed balance header without throwing", async () => {
+    const resp = new Response(JSON.stringify({ columns: ["x"], rows: [[1]] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", "X-Activeloop-Balance-Cents": "not-a-number" },
+    });
+    fetchMock.mockResolvedValueOnce(resp);
+    const api = await makeApi();
+    await api.query("SELECT 1");
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows enqueueNotification rejection — successful query still returns rows", async () => {
+    enqueueNotificationMock.mockRejectedValueOnce(new Error("queue write failed"));
+    fetchMock.mockResolvedValueOnce(okResp(150));
+    const api = await makeApi();
+    const rows = await api.query("SELECT 1");
+    expect(rows).toEqual([{ x: 1 }]);
+    await new Promise(resolve => setImmediate(resolve));
+  });
+});

--- a/tests/shared/deeplake-api-low-balance.test.ts
+++ b/tests/shared/deeplake-api-low-balance.test.ts
@@ -153,4 +153,23 @@ describe("DeeplakeApi — X-Activeloop-Balance-Cents low-balance warning", () =>
     expect(rows).toEqual([{ x: 1 }]);
     await new Promise(resolve => setImmediate(resolve));
   });
+
+  it("does NOT throw when the response has no headers object (minimal Response-like fake)", async () => {
+    // Other suites (deeplake-api.test.ts) mock fetch with a bare
+    // { ok, status, json, text } object — no `headers` getter. The
+    // low-balance probe must treat that as 'no header present' and return,
+    // never crash the query path. Regression guard for the optional-chain
+    // on resp.headers?.get — removing it reintroduces a TypeError that
+    // fails 69 unrelated tests.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ columns: ["x"], rows: [[1]] }),
+      text: async () => "",
+    });
+    const api = await makeApi();
+    const rows = await api.query("SELECT 1");
+    expect(rows).toEqual([{ x: 1 }]);
+    expect(enqueueNotificationMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- New `maybeSignalLowBalance(resp)` reads the `X-Activeloop-Balance-Cents` response header on every fetch — when below $2, enqueues a one-shot mid-session warning banner pointing the user at the billing page
- Mirrors the existing `maybeSignalBalanceExhausted` (402 path) but fires on the **success** path so users get warned before the hard wall
- Suppresses on balance ≤ 0 so the louder 402 banner takes over without overlapping copy

## Dedup semantics
- **Process-local** flag collapses repeats within a hivemind process to one enqueue
- **`transient: true`** so the banner doesn't persist in `state.shown` — when the backend's rearm path dismisses the warning row after a top-up, the header stops appearing below threshold and the banner silences naturally; a future dip refires
- Matches user's spec: "showing once is enough"

## Backend dependency
Reads a header that doesn't exist on `main` yet — paired with [activeloopai/deeplake-api#245](https://github.com/activeloopai/deeplake-api/pull/245). The new code no-ops gracefully when the header is absent (older backend), so this PR is safe to ship ahead of the backend deploy.

## Test plan
- [x] 7 vitest cases in `tests/shared/deeplake-api-low-balance.test.ts` covering:
  - enqueue when header < threshold on a successful response
  - no enqueue when header ≥ threshold (boundary contract)
  - no enqueue when header absent (older-backend compat)
  - process-local dedup across multiple requests
  - zero-balance suppression (402 banner takes over)
  - malformed header value tolerated
  - `enqueueNotification` rejection swallowed cleanly
- [x] Existing `deeplake-api-balance-exhausted.test.ts` and `deeplake-api-retry.test.ts` still pass — no regression in the 402 path
- [x] `tsc --noEmit --skipLibCheck` clean

## Untested
- Real session-start drain rendering the banner (only the enqueue contract is verified)
- End-to-end with the backend PR landed (next: smoke against beta)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Low-balance warnings now appear during API operations when a reported balance is below the threshold; each warning is shown once per session and tolerates malformed or missing server headers.

* **Tests**
  * Expanded coverage for low-balance behavior, deduplication, error-tolerance, and non-throwing behavior when notification delivery fails or responses are minimal.  
  * Test helper updated to reset the session low-balance signal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->