### PR TITLE
codex: tighten hook install and worker diagnostics

### DIFF
--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -25,9 +25,9 @@ function hookCmd(bundleFile: string, timeout: number, matcher?: string): Record<
 function buildHooksJson(): Record<string, unknown> {
   return {
     hooks: {
-      SessionStart: [hookCmd("session-start.js", 120)],
+      SessionStart: [hookCmd("session-start.js", 10, "startup|resume")],
       UserPromptSubmit: [hookCmd("capture.js", 10)],
-      PreToolUse: [hookCmd("pre-tool-use.js", 15, "Bash")],
+      PreToolUse: [hookCmd("pre-tool-use.js", 10, "Bash")],
       PostToolUse: [hookCmd("capture.js", 15)],
       Stop: [hookCmd("stop.js", 30)],
     },

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -104,6 +104,32 @@ function cleanup(): void {
   }
 }
 
+function tailText(text: string, maxChars = 240): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  return compact.length <= maxChars ? compact : `…${compact.slice(-maxChars)}`;
+}
+
+function formatExecFailure(error: any): string {
+  const parts: string[] = [];
+  if (error?.code) parts.push(`code=${error.code}`);
+  if (error?.status !== undefined && error?.status !== null) parts.push(`status=${error.status}`);
+  if (error?.signal) parts.push(`signal=${error.signal}`);
+  if (error?.message) parts.push(`message=${tailText(String(error.message))}`);
+  const stderr = Buffer.isBuffer(error?.stderr)
+    ? error.stderr.toString("utf-8")
+    : typeof error?.stderr === "string"
+      ? error.stderr
+      : "";
+  if (stderr.trim()) parts.push(`stderr=${tailText(stderr)}`);
+  const stdout = Buffer.isBuffer(error?.stdout)
+    ? error.stdout.toString("utf-8")
+    : typeof error?.stdout === "string"
+      ? error.stdout
+      : "";
+  if (stdout.trim()) parts.push(`stdout=${tailText(stdout)}`);
+  return parts.length > 0 ? parts.join(", ") : "unknown failure";
+}
+
 async function main(): Promise<void> {
   try {
     // 1. Fetch session events from sessions table
@@ -161,6 +187,8 @@ async function main(): Promise<void> {
       .replace(/__JSONL_SERVER_PATH__/g, jsonlServerPath);
 
     wlog("running codex exec");
+    let execSucceeded = false;
+    const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
       execFileSync(cfg.codexBin, [
         "exec",
@@ -171,14 +199,21 @@ async function main(): Promise<void> {
         timeout: 120_000,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
+      execSucceeded = true;
       wlog("codex exec exited (code 0)");
     } catch (e: any) {
-      wlog(`codex exec failed: ${e.status ?? e.message}`);
+      const detail = formatExecFailure(e);
+      wlog(`codex exec failed: ${detail}`);
     }
 
     // 4. Upload summary to memory table
     if (existsSync(tmpSummary)) {
       const text = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? text.trim().length > 0 : text !== summaryBeforeExec;
+      if (!execSucceeded && !summaryChanged) {
+        wlog("codex exec failed without producing a new summary; skipping upload");
+        return;
+      }
       if (text.trim()) {
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -93,8 +93,11 @@ describe("installCodex — happy path", () => {
     for (const event of Object.keys(hooks.hooks)) {
       expect(hooks.hooks[event]).toHaveLength(1);
     }
+    expect(hooks.hooks.SessionStart[0].matcher).toBe("startup|resume");
+    expect(hooks.hooks.SessionStart[0].hooks[0].timeout).toBe(10);
     // PreToolUse carries the Bash matcher.
     expect(hooks.hooks.PreToolUse[0].matcher).toBe("Bash");
+    expect(hooks.hooks.PreToolUse[0].hooks[0].timeout).toBe(10);
   });
 
   it("creates the agentskills symlink at ~/.agents/skills/hivemind-memory", async () => {
@@ -248,7 +251,7 @@ describe("installCodex — happy path", () => {
       join(tmpHome, ".codex", "hooks.json"),
       JSON.stringify({
         hooks: {
-          SessionStart: [{ hooks: [{ type: "command", command: foreignCmd, timeout: 120 }] }],
+          SessionStart: [{ matcher: "startup|resume", hooks: [{ type: "command", command: foreignCmd, timeout: 10 }] }],
         },
       }),
     );

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -258,13 +258,17 @@ describe("codex wiki-worker — codex exec failure", () => {
     });
   });
 
-  it("logs status and skips upload when codex exec throws without producing a summary", async () => {
+  it("logs detailed failure and skips upload when codex exec throws without producing a summary", async () => {
     const err: any = new Error("codex crashed");
     err.status = 99;
+    err.signal = "SIGTERM";
+    err.stderr = Buffer.from("backend blew up");
     execFileSyncMock.mockImplementation(() => { throw err; });
     await runWorker();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("codex exec failed: 99");
+    expect(log).toContain("codex exec failed: status=99");
+    expect(log).toContain("signal=SIGTERM");
+    expect(log).toContain("stderr=backend blew up");
     expect(log).toContain("no summary file generated");
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(releaseLockMock).toHaveBeenCalled();
@@ -274,7 +278,19 @@ describe("codex wiki-worker — codex exec failure", () => {
     execFileSyncMock.mockImplementation(() => { throw new Error("no status here"); });
     await runWorker();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("codex exec failed: no status here");
+    expect(log).toContain("codex exec failed: message=no status here");
+  });
+
+  it("does not re-upload a stale existing summary after a failed regeneration", async () => {
+    fetchMock.mockImplementation(async (_url: string, init: any) => {
+      const sql = JSON.parse(init.body).query as string;
+      if (sql.startsWith("SELECT message")) return jsonResp({ columns: ["message", "creation_date"], rows: [["{}", "t"]] });
+      if (sql.startsWith("SELECT DISTINCT path")) return jsonResp({ columns: ["path"], rows: [["/x.jsonl"]] });
+      return jsonResp({ columns: ["summary"], rows: [["# Session X\n- **JSONL offset**: 7\n\n## What Happened\nprior"]] });
+    });
+    execFileSyncMock.mockImplementation(() => { throw new Error("timed out"); });
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary\n- align Codex install hooks with the tested startup/resume matcher and timeout shape\n- improve wiki-worker failure logs so codex exec errors include status/signal/stderr details\n- prevent re-uploading a stale summary after a failed regeneration\n\n## Verification\n- npm test -- tests/codex/codex-wiki-worker.test.ts tests/cli/cli-install-codex-fs.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging with structured fields for improved diagnostics when operations fail.
  * Prevent unnecessary summary uploads when content hasn't changed.
  * Optimized hook configuration with reduced timeouts for faster responsiveness and improved matching behavior.

* **Tests**
  * Updated test suite to validate new hook timeout and matcher configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->