### PR TITLE
fix(windows): cross-platform detached worker spawn + backslash-safe hook dedup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          # Don't persist the checkout token into .git/config — it would be
+          # readable by later steps / artifacts. This job only reads + tests.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,40 @@ jobs:
           path: jscpd-report/
           if-no-files-found: ignore
 
+  windows-smoke:
+    # Windows leg for the win32-specific bugs fixed in the Codex/PowerShell
+    # report (2026-05-29):
+    #   1. capture hook crashed with exit 1 because `spawn("nohup", ...)`
+    #      ENOENTs on Windows (no nohup) and the async 'error' event had no
+    #      listener — fixed in src/utils/spawn-detached.ts.
+    #   2. re-install duplicated the PostToolUse hook because hook-dedup
+    #      matched forward-slash paths while Windows writes backslash paths —
+    #      fixed in src/cli/install-codex.ts + install-cursor.ts.
+    #
+    # Scoped to the two suites that cover those fixes rather than the full
+    # vitest run: the bulk of the suite assumes POSIX paths / chmod / symlinks
+    # and would fail on a Windows runner for reasons unrelated to this fix.
+    # Running these two on a REAL windows-latest proves the path-separator and
+    # detached-spawn behavior on win32, on top of the Linux-side
+    # missing-binary + backslash-string reproductions in the same suites.
+    name: Windows smoke (spawn + hook dedup)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        # tree-sitter is an optionalDependency; if its native build fails on
+        # Windows, npm continues — the scoped suites below don't import it.
+        run: npm install
+
+      - name: Run Windows-relevant suites
+        run: npx vitest run tests/shared/spawn-detached.test.ts tests/cli/install-helpers.test.ts
+
   test:
     name: Typecheck and Test
     runs-on: ubuntu-latest

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -70,8 +70,15 @@ export function isHivemindHookEntry(entry: unknown, pluginDir: string = PLUGIN_D
     if (!h || typeof h !== "object") return false;
     const cmd = (h as Record<string, unknown>).command;
     if (typeof cmd !== "string") return false;
-    if (cmd.includes(`${pluginDir}/bundle/`)) return true;
-    return HIVEMIND_BUNDLE_FILES.some(f => cmd.includes(`/bundle/${f}`));
+    // Normalize path separators before matching. On Windows the hook command
+    // is written via join() (backslashes: `...\hivemind\bundle\capture.js`),
+    // but our match patterns use forward slashes. Without this, dedup never
+    // matched the prior install on Windows, so every re-install APPENDED a
+    // duplicate hivemind hook — the user's "PostToolUse runs twice" bug.
+    const nCmd = cmd.replace(/\\/g, "/");
+    const nPluginDir = pluginDir.replace(/\\/g, "/");
+    if (nCmd.includes(`${nPluginDir}/bundle/`)) return true;
+    return HIVEMIND_BUNDLE_FILES.some(f => nCmd.includes(`/bundle/${f}`));
   });
 }
 
@@ -88,7 +95,10 @@ function isForeignHivemindHookEntry(entry: unknown, pluginDir: string = PLUGIN_D
     if (!h || typeof h !== "object") return false;
     const cmd = (h as Record<string, unknown>).command;
     if (typeof cmd !== "string") return false;
-    return !cmd.includes(`${pluginDir}/bundle/`);
+    // Same separator normalization as isHivemindHookEntry — a canonical-path
+    // entry written with backslashes on Windows must NOT be mis-flagged as
+    // "foreign" (which would emit a spurious dev-clone warning on re-install).
+    return !cmd.replace(/\\/g, "/").includes(`${pluginDir.replace(/\\/g, "/")}/bundle/`);
   });
 }
 

--- a/src/cli/install-cursor.ts
+++ b/src/cli/install-cursor.ts
@@ -58,7 +58,12 @@ function buildHookConfig(): Record<string, CursorHookEntry[]> {
 export function isHivemindEntry(entry: unknown): boolean {
   if (!entry || typeof entry !== "object") return false;
   const cmd = (entry as { command?: string }).command;
-  return typeof cmd === "string" && cmd.includes("/.cursor/hivemind/bundle/");
+  if (typeof cmd !== "string") return false;
+  // Normalize separators: on Windows the command is written with backslashes
+  // (`...\.cursor\hivemind\bundle\capture.js`), so a forward-slash-only match
+  // would fail and re-install would duplicate the hooks (same Windows bug as
+  // codex's isHivemindHookEntry).
+  return cmd.replace(/\\/g, "/").includes("/.cursor/hivemind/bundle/");
 }
 
 function mergeHooks(existing: Record<string, unknown> | null): Record<string, unknown> {

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -11,6 +11,7 @@ import { readStdin } from "../utils/stdin.js";
 import { loadConfig, type Config } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
 import { sqlStr } from "../utils/sql.js";
+import { projectNameFromCwd } from "../utils/project-name.js";
 import { log as _log } from "../utils/debug.js";
 import { buildSessionPath } from "../utils/session-path.js";
 import {
@@ -136,7 +137,7 @@ async function main(): Promise<void> {
   log(`writing to ${sessionPath}`);
 
   // Simple INSERT — one row per event, no concat, no race conditions.
-  const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(input.cwd);
   const filename = sessionPath.split("/").pop() ?? "";
 
   // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.

--- a/src/hooks/codex/capture.ts
+++ b/src/hooks/codex/capture.ts
@@ -16,6 +16,7 @@ import { readStdin } from "../../utils/stdin.js";
 import { loadConfig, type Config } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -118,7 +119,7 @@ async function main(): Promise<void> {
   const line = JSON.stringify(entry);
   log(`writing to ${sessionPath}`);
 
-  const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(input.cwd);
   const filename = sessionPath.split("/").pop() ?? "";
   // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.
   // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.

--- a/src/hooks/codex/session-start-setup.ts
+++ b/src/hooks/codex/session-start-setup.ts
@@ -13,6 +13,7 @@ import { loadCredentials, saveCredentials } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { readStdin } from "../../utils/stdin.js";
 import { log as _log } from "../../utils/debug.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
@@ -38,7 +39,7 @@ async function createPlaceholder(api: DeeplakeApi, table: string, sessionId: str
   }
 
   const now = new Date().toISOString();
-  const projectName = cwd.split("/").pop() ?? "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const sessionSource = `/sessions/${userName}/${userName}_${orgName}_${workspaceId}_${sessionId}.jsonl`;
   const content = [
     `# Session ${sessionId}`,

--- a/src/hooks/codex/spawn-wiki-worker.ts
+++ b/src/hooks/codex/spawn-wiki-worker.ts
@@ -12,6 +12,7 @@ import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
 import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".codex", "hooks"));
@@ -87,7 +88,7 @@ export interface SpawnOptions {
 
 export function spawnCodexWikiWorker(opts: SpawnOptions): void {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
 
   const tmpDir = join(tmpdir(), `deeplake-wiki-${sessionId}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });

--- a/src/hooks/codex/spawn-wiki-worker.ts
+++ b/src/hooks/codex/spawn-wiki-worker.ts
@@ -3,7 +3,7 @@
  * Mirrors src/hooks/spawn-wiki-worker.ts but targets ~/.codex/ paths and codexBin.
  */
 
-import { spawn, execSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { writeFileSync, mkdirSync } from "node:fs";
@@ -11,6 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
+import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".codex", "hooks"));
@@ -115,10 +116,7 @@ export function spawnCodexWikiWorker(opts: SpawnOptions): void {
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
 
   const workerPath = join(bundleDir, "wiki-worker.js");
-  spawn("nohup", ["node", workerPath, configFile], {
-    detached: true,
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  spawnDetachedNodeWorker(workerPath, [configFile]);
 
   wikiLog(`${reason}: spawned summary worker for ${sessionId}`);
 }

--- a/src/hooks/codex/stop.ts
+++ b/src/hooks/codex/stop.ts
@@ -18,6 +18,7 @@ import { readStdin } from "../../utils/stdin.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { bundleDirFromImportMeta, spawnCodexWikiWorker, wikiLog } from "./spawn-wiki-worker.js";
 import { forceSessionEndTrigger } from "../../skillify/triggers.js";
@@ -113,7 +114,7 @@ async function main(): Promise<void> {
       };
       const line = JSON.stringify(entry);
       const sessionPath = buildSessionPath(config, sessionId);
-      const projectName = (input.cwd ?? "").split("/").pop() || "unknown";
+      const projectName = projectNameFromCwd(input.cwd);
       const filename = sessionPath.split("/").pop() ?? "";
       // For JSONB: only escape single quotes for the SQL literal, keep JSON structure intact.
       // sqlStr() would also escape backslashes and strip control chars, corrupting the JSON.

--- a/src/hooks/cursor/capture.ts
+++ b/src/hooks/cursor/capture.ts
@@ -17,6 +17,7 @@ import { readStdin } from "../../utils/stdin.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -145,7 +146,7 @@ async function main(): Promise<void> {
   const line = JSON.stringify(entry);
   log(`writing to ${sessionPath}`);
 
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const filename = sessionPath.split("/").pop() ?? "";
   // For JSONB: only escape single quotes, keep JSON structure intact.
   // sqlStr() would also escape backslashes and corrupt the JSON.

--- a/src/hooks/cursor/session-start.ts
+++ b/src/hooks/cursor/session-start.ts
@@ -25,6 +25,7 @@ import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { renderSkillifyCommands } from "../../cli/skillify-spec.js";
 import { countLocalManifestEntries } from "../../skillify/local-manifest.js";
 import { maybeAutoMineLocal } from "../../skillify/spawn-mine-local-worker.js";
@@ -111,7 +112,7 @@ async function createPlaceholder(
   if (existing.length > 0) return;
 
   const now = new Date().toISOString();
-  const projectName = cwd.split("/").pop() ?? "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const sessionSource = `/sessions/${userName}/${userName}_${orgName}_${workspaceId}_${sessionId}.jsonl`;
   const content = [
     `# Session ${sessionId}`,

--- a/src/hooks/cursor/spawn-wiki-worker.ts
+++ b/src/hooks/cursor/spawn-wiki-worker.ts
@@ -12,6 +12,7 @@ import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
 import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".cursor", "hooks"));
@@ -87,7 +88,7 @@ export interface SpawnOptions {
 
 export function spawnCursorWikiWorker(opts: SpawnOptions): void {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
 
   const tmpDir = join(tmpdir(), `deeplake-wiki-${sessionId}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });

--- a/src/hooks/cursor/spawn-wiki-worker.ts
+++ b/src/hooks/cursor/spawn-wiki-worker.ts
@@ -3,7 +3,7 @@
  * Mirrors src/hooks/spawn-wiki-worker.ts but targets ~/.codex/ paths and codexBin.
  */
 
-import { spawn, execSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { writeFileSync, mkdirSync } from "node:fs";
@@ -11,6 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
+import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".cursor", "hooks"));
@@ -116,10 +117,7 @@ export function spawnCursorWikiWorker(opts: SpawnOptions): void {
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
 
   const workerPath = join(bundleDir, "wiki-worker.js");
-  spawn("nohup", ["node", workerPath, configFile], {
-    detached: true,
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  spawnDetachedNodeWorker(workerPath, [configFile]);
 
   wikiLog(`${reason}: spawned summary worker for ${sessionId}`);
 }

--- a/src/hooks/hermes/capture.ts
+++ b/src/hooks/hermes/capture.ts
@@ -18,6 +18,7 @@ import { readStdin } from "../../utils/stdin.js";
 import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -126,7 +127,7 @@ async function main(): Promise<void> {
   const line = JSON.stringify(entry);
   log(`writing to ${sessionPath}`);
 
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const filename = sessionPath.split("/").pop() ?? "";
   // For JSONB: only escape single quotes, keep JSON structure intact.
   const jsonForSql = line.replace(/'/g, "''");

--- a/src/hooks/hermes/session-start.ts
+++ b/src/hooks/hermes/session-start.ts
@@ -16,6 +16,7 @@ import { loadConfig } from "../../config.js";
 import { DeeplakeApi } from "../../deeplake-api.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
 import { sqlStr } from "../../utils/sql.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 import { renderSkillifyCommands } from "../../cli/skillify-spec.js";
 import { countLocalManifestEntries } from "../../skillify/local-manifest.js";
 import { maybeAutoMineLocal } from "../../skillify/spawn-mine-local-worker.js";
@@ -85,7 +86,7 @@ async function createPlaceholder(
   if (existing.length > 0) return;
 
   const now = new Date().toISOString();
-  const projectName = cwd.split("/").pop() ?? "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const sessionSource = `/sessions/${userName}/${userName}_${orgName}_${workspaceId}_${sessionId}.jsonl`;
   const content = [
     `# Session ${sessionId}`,

--- a/src/hooks/hermes/spawn-wiki-worker.ts
+++ b/src/hooks/hermes/spawn-wiki-worker.ts
@@ -13,6 +13,7 @@ import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
 import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
+import { projectNameFromCwd } from "../../utils/project-name.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".hermes", "hooks"));
@@ -88,7 +89,7 @@ export interface SpawnOptions {
 
 export function spawnHermesWikiWorker(opts: SpawnOptions): void {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
 
   const tmpDir = join(tmpdir(), `deeplake-wiki-${sessionId}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });

--- a/src/hooks/hermes/spawn-wiki-worker.ts
+++ b/src/hooks/hermes/spawn-wiki-worker.ts
@@ -4,7 +4,7 @@
  * and shells `hermes -z` (oneshot mode) instead of `codex exec`.
  */
 
-import { spawn, execSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { writeFileSync, mkdirSync } from "node:fs";
@@ -12,6 +12,7 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "../../config.js";
 import { makeWikiLogger } from "../../utils/wiki-log.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
+import { spawnDetachedNodeWorker } from "../../utils/spawn-detached.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".hermes", "hooks"));
@@ -118,10 +119,7 @@ export function spawnHermesWikiWorker(opts: SpawnOptions): void {
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
 
   const workerPath = join(bundleDir, "wiki-worker.js");
-  spawn("nohup", ["node", workerPath, configFile], {
-    detached: true,
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  spawnDetachedNodeWorker(workerPath, [configFile]);
 
   wikiLog(`${reason}: spawned summary worker for ${sessionId}`);
 }

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -13,6 +13,7 @@ import { loadCredentials, saveCredentials, healDriftedOrgToken } from "../comman
 import { loadConfig } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
 import { sqlStr } from "../utils/sql.js";
+import { projectNameFromCwd } from "../utils/project-name.js";
 import { readStdin } from "../utils/stdin.js";
 import { log as _log } from "../utils/debug.js";
 import { getInstalledVersion } from "../utils/version-check.js";
@@ -98,7 +99,7 @@ async function createPlaceholder(api: DeeplakeApi, table: string, sessionId: str
   }
 
   const now = new Date().toISOString();
-  const projectName = cwd.split("/").pop() ?? "unknown";
+  const projectName = projectNameFromCwd(cwd);
   const sessionSource = `/sessions/${userName}/${userName}_${orgName}_${workspaceId}_${sessionId}.jsonl`;
   const content = [
     `# Session ${sessionId}`,

--- a/src/hooks/spawn-wiki-worker.ts
+++ b/src/hooks/spawn-wiki-worker.ts
@@ -12,6 +12,7 @@ import type { Config } from "../config.js";
 import { makeWikiLogger } from "../utils/wiki-log.js";
 import { getInstalledVersion } from "../utils/version-check.js";
 import { spawnDetachedNodeWorker } from "../utils/spawn-detached.js";
+import { projectNameFromCwd } from "../utils/project-name.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".claude", "hooks"));
@@ -90,7 +91,7 @@ export interface SpawnOptions {
 
 export function spawnWikiWorker(opts: SpawnOptions): void {
   const { config, sessionId, cwd, bundleDir, reason } = opts;
-  const projectName = cwd.split("/").pop() || "unknown";
+  const projectName = projectNameFromCwd(cwd);
 
   const tmpDir = join(tmpdir(), `deeplake-wiki-${sessionId}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });

--- a/src/hooks/spawn-wiki-worker.ts
+++ b/src/hooks/spawn-wiki-worker.ts
@@ -3,7 +3,7 @@
  * Called from session-end.ts (always) and capture.ts (periodic trigger).
  */
 
-import { spawn, execSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { writeFileSync, mkdirSync } from "node:fs";
@@ -11,6 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "../config.js";
 import { makeWikiLogger } from "../utils/wiki-log.js";
 import { getInstalledVersion } from "../utils/version-check.js";
+import { spawnDetachedNodeWorker } from "../utils/spawn-detached.js";
 
 const HOME = homedir();
 const wikiLogger = makeWikiLogger(join(HOME, ".claude", "hooks"));
@@ -118,10 +119,7 @@ export function spawnWikiWorker(opts: SpawnOptions): void {
   wikiLog(`${reason}: spawning summary worker for ${sessionId}`);
 
   const workerPath = join(bundleDir, "wiki-worker.js");
-  spawn("nohup", ["node", workerPath, configFile], {
-    detached: true,
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  spawnDetachedNodeWorker(workerPath, [configFile]);
 
   wikiLog(`${reason}: spawned summary worker for ${sessionId}`);
 }

--- a/src/skillify/spawn-skillify-worker.ts
+++ b/src/skillify/spawn-skillify-worker.ts
@@ -7,7 +7,6 @@
  * skill write) happens in the detached child.
  */
 
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { writeFileSync, mkdirSync, appendFileSync, chmodSync } from "node:fs";
@@ -15,6 +14,7 @@ import { homedir, tmpdir } from "node:os";
 import type { Config } from "../config.js";
 import { utcTimestamp } from "../utils/debug.js";
 import { findAgentBin, type Agent } from "./gate-runner.js";
+import { spawnDetachedNodeWorker } from "../utils/spawn-detached.js";
 
 const HOME = homedir();
 export const SKILLIFY_LOG = join(HOME, ".claude", "hooks", "skillify.log");
@@ -93,10 +93,7 @@ export function spawnSkillifyWorker(opts: SkillifySpawnOptions): void {
   skillifyLog(`${reason}: spawning skillify worker for project=${project} key=${projectKey}`);
 
   const workerPath = join(bundleDir, "skillify-worker.js");
-  spawn("nohup", ["node", workerPath, configFile], {
-    detached: true,
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  spawnDetachedNodeWorker(workerPath, [configFile]);
 
   skillifyLog(`${reason}: spawned skillify worker for ${projectKey}`);
 }

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -1,0 +1,16 @@
+import { basename } from "node:path";
+
+/**
+ * Derive a project display name from a working directory.
+ *
+ * Uses path.basename, which is platform-aware: on Windows it splits on BOTH
+ * `\` and `/`, on POSIX on `/`. The previous `cwd.split("/").pop()` form only
+ * split on `/`, so on Windows a cwd like `C:\work\repo` (no forward slashes)
+ * returned the entire path instead of `repo`, polluting the `project` field
+ * threaded into capture rows, session rows, and worker summaries.
+ *
+ * Returns "unknown" for an empty/undefined cwd (basename("") === "").
+ */
+export function projectNameFromCwd(cwd: string | undefined | null): string {
+  return basename(cwd ?? "") || "unknown";
+}

--- a/src/utils/spawn-detached.ts
+++ b/src/utils/spawn-detached.ts
@@ -55,6 +55,9 @@ export function spawnDetachedNodeWorker(
     const child = spawn(execPath, [workerPath, ...args], {
       detached: true,
       stdio: ["ignore", "ignore", "ignore"],
+      // Suppress the transient console window Windows would otherwise pop for
+      // the detached worker. No-op on POSIX.
+      windowsHide: true,
     });
     // ENOENT / EPERM arrive as an ASYNC 'error' event, never a sync throw.
     // Without this listener the event is unhandled and crashes the parent.

--- a/src/utils/spawn-detached.ts
+++ b/src/utils/spawn-detached.ts
@@ -1,0 +1,68 @@
+/**
+ * Cross-platform helper for spawning a detached, fire-and-forget Node worker
+ * that must outlive the parent hook process.
+ *
+ * Why this exists (the Codex/Windows-PowerShell bug, 2026-05-29):
+ *   The wiki-summary and skillify workers were spawned as
+ *     spawn("nohup", ["node", workerPath, configFile], { detached, stdio })
+ *   On Windows `nohup` does not exist, so spawn emits an ASYNC 'error' event
+ *   (ENOENT) — NOT a synchronous throw. With no 'error' listener that event
+ *   is unhandled and crashes the parent hook with exit 1. The summary worker
+ *   fires on a periodic threshold (first at N captured messages, then every
+ *   M), so capture.js exited 1 only "sometimes" — exactly the intermittent
+ *   PostToolUse failure the user reported.
+ *
+ * The fix, and why nohup is dropped entirely:
+ *   `detached: true` + `stdio: ["ignore","ignore","ignore"]` + `.unref()` is
+ *   the canonical Node recipe for a child that survives the parent's exit, on
+ *   BOTH POSIX and Windows. `detached` puts the child in its own session /
+ *   process group (so a terminal SIGHUP never reaches it) and `unref()` lets
+ *   the parent's event loop exit without waiting — `nohup` was always
+ *   redundant alongside those. We invoke the Node binary directly via
+ *   `process.execPath` (the same node that's running this hook), which is
+ *   strictly more robust than relying on a `node` entry on PATH and works
+ *   identically on Windows (`node.exe`). The net effect: the workers now
+ *   actually RUN on Windows instead of crashing the hook.
+ *
+ * Best-effort by contract: any spawn failure (missing binary, EPERM, ...) is
+ * absorbed silently via the 'error' listener. These workers are convenience
+ * side-effects — a failure here must never break the hook that triggered them.
+ */
+
+import { spawn as nodeSpawn } from "node:child_process";
+
+export interface SpawnDetachedDeps {
+  /** Override for tests; defaults to node:child_process spawn. */
+  spawn?: typeof nodeSpawn;
+  /** Override for tests; defaults to process.execPath (the running node). */
+  execPath?: string;
+}
+
+/**
+ * Spawn `node <workerPath> <...args>` detached and fire-and-forget.
+ *
+ * @param workerPath absolute path to the worker .js inside the bundle
+ * @param args       extra argv passed to the worker (e.g. the config path)
+ */
+export function spawnDetachedNodeWorker(
+  workerPath: string,
+  args: readonly string[] = [],
+  deps: SpawnDetachedDeps = {},
+): void {
+  const spawn = deps.spawn ?? nodeSpawn;
+  const execPath = deps.execPath ?? process.execPath;
+  try {
+    const child = spawn(execPath, [workerPath, ...args], {
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    // ENOENT / EPERM arrive as an ASYNC 'error' event, never a sync throw.
+    // Without this listener the event is unhandled and crashes the parent.
+    // Empty body == silent degradation, which is the intended contract.
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Defensive: a rare synchronous throw from spawn (invalid argv types).
+    // The async 'error' listener above covers the common ENOENT path.
+  }
+}

--- a/tests/claude-code/spawn-wiki-worker.test.ts
+++ b/tests/claude-code/spawn-wiki-worker.test.ts
@@ -16,7 +16,11 @@ import type { Config } from "../../src/config.js";
  *   1. Reads the installed plugin version via getInstalledVersion(bundleDir, manifestDir)
  *      — the manifest dir differs per agent (".claude-plugin" / ".codex-plugin").
  *   2. Writes a config.json the detached worker reads at startup.
- *   3. Spawns `nohup node <worker.js> <config.json>`.
+ *   3. Spawns `<node> <worker.js> <config.json>` detached, via the shared
+ *      spawnDetachedNodeWorker helper. Cross-platform: it invokes the node
+ *      binary directly (process.execPath), NOT `nohup node ...` — `nohup` is
+ *      absent on Windows and the old form crashed the hook there with an
+ *      unhandled async ENOENT. See src/utils/spawn-detached.ts.
  *
  * The thing the e2e on test_plugin couldn't directly observe is whether
  * pluginVersion actually lands in config.json for every agent. A regression
@@ -37,9 +41,14 @@ vi.mock("node:child_process", async () => {
     ...actual,
     spawn: vi.fn((cmd: string, args: readonly string[]) => {
       spawnCalls.push({ cmd, args });
-      // Match the surface the production code touches: a child object
-      // with `.unref()`. No stdio, no event emission.
-      return { unref: () => {} } as unknown as ReturnType<typeof actual.spawn>;
+      // Match the surface the production code touches: a child object with
+      // `.on("error", ...)` (the helper installs an async-ENOENT absorber
+      // before unref'ing) and `.unref()`. `.on` returns the child for chaining.
+      const child: { on: () => typeof child; unref: () => void } = {
+        on: () => child,
+        unref: () => {},
+      };
+      return child as unknown as ReturnType<typeof actual.spawn>;
     }),
   };
 });
@@ -105,7 +114,9 @@ function fakeConfig(): Config {
 
 function readSpawnedConfig(): Record<string, unknown> {
   expect(spawnCalls).toHaveLength(1);
-  const [, , configPath] = spawnCalls[0].args;
+  // argv is now [workerPath, configPath] (spawn(node, [worker, config])),
+  // so the config path is index 1 — previously index 2 under `nohup node ...`.
+  const [, configPath] = spawnCalls[0].args;
   return JSON.parse(readFileSync(configPath as string, "utf-8"));
 }
 
@@ -145,7 +156,7 @@ describe("spawnWikiWorker (claude-code) — plugin_version threading", () => {
     expect(cfg.pluginVersion).toBe("");
   });
 
-  it("spawns the worker with nohup + the written config path", () => {
+  it("spawns the node binary directly (NOT nohup) with worker + config path", () => {
     const { bundleDir } = plantBundle(".claude-plugin");
     spawnWikiWorker({
       config: fakeConfig(),
@@ -156,10 +167,12 @@ describe("spawnWikiWorker (claude-code) — plugin_version threading", () => {
     });
     expect(spawnCalls).toHaveLength(1);
     const [{ cmd, args }] = spawnCalls;
-    expect(cmd).toBe("nohup");
-    expect(args[0]).toBe("node");
-    expect(args[1]).toBe(join(bundleDir, "wiki-worker.js"));
-    expect((args[2] as string).endsWith("config.json")).toBe(true);
+    // Cross-platform fix: invoke node via process.execPath, never `nohup`
+    // (which ENOENT-crashes the hook on Windows). argv = [worker, config].
+    expect(cmd).toBe(process.execPath);
+    expect(cmd).not.toBe("nohup");
+    expect(args[0]).toBe(join(bundleDir, "wiki-worker.js"));
+    expect((args[1] as string).endsWith("config.json")).toBe(true);
   });
 });
 

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -96,6 +96,35 @@ describe("isHivemindHookEntry", () => {
     }, PD)).toBe(true);
   });
 
+  // Windows separator bug (2026-05-29): codex on Windows writes the hook
+  // command via join() with BACKSLASHES, but the matcher used forward-slash
+  // literals. Result: isHivemindHookEntry returned false on Windows, so
+  // re-install never stripped the prior entry and APPENDED a duplicate
+  // (PostToolUse capture ran twice — the reported bug). Failure-before-fix.
+  describe("Windows backslash paths (separator normalization)", () => {
+    const WPD = "C:\\Users\\angel\\.codex\\hivemind";
+
+    it("true when a backslash command points into <pluginDir>\\bundle\\ (canonical Windows install)", () => {
+      expect(isHivemindHookEntry({
+        hooks: [{ type: "command", command: `node "${WPD}\\bundle\\capture.js"`, timeout: 15 }],
+      }, WPD)).toBe(true);
+    });
+
+    it("true for each known bundle file written with backslashes", () => {
+      for (const f of ["session-start.js", "capture.js", "stop.js", "wiki-worker.js"]) {
+        expect(isHivemindHookEntry({
+          hooks: [{ type: "command", command: `node "C:\\some\\sibling\\bundle\\${f}"` }],
+        }, WPD)).toBe(true);
+      }
+    });
+
+    it("still false for a user's own backslash hook outside bundle/", () => {
+      expect(isHivemindHookEntry({
+        hooks: [{ type: "command", command: `node "C:\\Users\\angel\\.codex\\my-hook.js"` }],
+      }, WPD)).toBe(false);
+    });
+  });
+
   // Tightens the per-element type guard inside the `.some()` callback so a
   // refactor that drops `!h || typeof h !== "object"` can't start matching
   // arrays full of garbage.
@@ -176,6 +205,24 @@ describe("mergeHooks", () => {
     const hivemindCommands = allCommands.filter(c => c.includes(`${PD}/bundle/`));
     const unique = new Set(hivemindCommands);
     expect(hivemindCommands.length).toBe(unique.size);
+  });
+
+  // The end-to-end repro of the reported Windows bug: re-install on Windows
+  // (backslash commands) must strip the prior hivemind PostToolUse entry, not
+  // accumulate duplicates. Pre-fix this looped to 5 PostToolUse entries.
+  it("Windows backslash re-install: no PostToolUse duplication after N re-runs", () => {
+    const WPD = "C:\\Users\\angel\\.codex\\hivemind";
+    const winOurs = {
+      hooks: {
+        SessionStart: [{ hooks: [{ type: "command", command: `node "${WPD}\\bundle\\session-start.js"`, timeout: 10 }] }],
+        PostToolUse:  [{ hooks: [{ type: "command", command: `node "${WPD}\\bundle\\capture.js"`,        timeout: 15 }] }],
+      },
+    };
+    let cur: Record<string, unknown> = {};
+    for (let i = 0; i < 5; i++) cur = mergeHooks(cur, winOurs, WPD);
+    const h = (cur as { hooks: Record<string, unknown[]> }).hooks;
+    expect(h.SessionStart).toHaveLength(1);
+    expect(h.PostToolUse).toHaveLength(1);
   });
 
   it("re-install with mixed prior (user + stale hivemind) keeps user, replaces stale", () => {
@@ -317,6 +364,12 @@ describe("isHivemindEntry (cursor)", () => {
 
   it("false when command points elsewhere", () => {
     expect(isHivemindEntry({ command: "/usr/local/bin/my-cursor-hook" })).toBe(false);
+  });
+
+  // Same Windows separator bug as codex: a backslash command must still match
+  // so cursor re-install on Windows strips the prior hooks instead of dup'ing.
+  it("true for a Windows backslash command into .cursor\\hivemind\\bundle\\", () => {
+    expect(isHivemindEntry({ command: `node "C:\\Users\\u\\.cursor\\hivemind\\bundle\\capture.js"` })).toBe(true);
   });
 
   it.each([

--- a/tests/shared/project-name.test.ts
+++ b/tests/shared/project-name.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { basename, win32, posix } from "node:path";
+import { projectNameFromCwd } from "../../src/utils/project-name.js";
+
+/**
+ * Guard for the cwd → project-name derivation. The bug this replaces
+ * (`cwd.split("/").pop()`) only split on `/`, so a Windows cwd like
+ * `C:\work\repo` returned the whole path instead of `repo`.
+ *
+ * path.basename is platform-aware, so on a POSIX test host it won't split a
+ * backslash string — to prove the Windows behavior deterministically we also
+ * assert against path.win32.basename directly (which is what runs on Windows).
+ */
+describe("projectNameFromCwd", () => {
+  it("POSIX path → basename", () => {
+    expect(projectNameFromCwd("/home/me/work/repo")).toBe("repo");
+  });
+
+  it("empty / undefined / null → 'unknown'", () => {
+    expect(projectNameFromCwd("")).toBe("unknown");
+    expect(projectNameFromCwd(undefined)).toBe("unknown");
+    expect(projectNameFromCwd(null)).toBe("unknown");
+  });
+
+  it("matches the host platform's path.basename for a native path", () => {
+    const cwd = "/a/b/c/myproj";
+    expect(projectNameFromCwd(cwd)).toBe(basename(cwd) || "unknown");
+  });
+
+  // The actual Windows fix, asserted against win32 semantics directly so it's
+  // deterministic regardless of the test host OS. The OLD split("/") code
+  // returns the WHOLE backslash path here — the negative-pattern guard.
+  it("Windows backslash path resolves to the basename under win32 semantics", () => {
+    const winCwd = "C:\\Users\\angel\\work\\my-repo";
+    expect(win32.basename(winCwd)).toBe("my-repo");
+    // Negative guard: the replaced implementation would NOT have produced this.
+    expect(winCwd.split("/").pop()).toBe(winCwd); // old code: whole path, wrong
+    // posix.basename (what a Linux host's basename uses) also can't split it —
+    // confirms the bug is genuinely platform-dependent, not test-host luck.
+    expect(posix.basename(winCwd)).toBe(winCwd);
+  });
+});

--- a/tests/shared/spawn-detached.test.ts
+++ b/tests/shared/spawn-detached.test.ts
@@ -57,6 +57,8 @@ describe("spawnDetachedNodeWorker", () => {
     expect(opts).toMatchObject({
       detached: true,
       stdio: ["ignore", "ignore", "ignore"],
+      // windowsHide suppresses the console-window flash on Windows (no-op on POSIX).
+      windowsHide: true,
     });
   });
 

--- a/tests/shared/spawn-detached.test.ts
+++ b/tests/shared/spawn-detached.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest";
+import type { spawn as nodeSpawn, ChildProcess } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnDetachedNodeWorker } from "../../src/utils/spawn-detached.js";
+
+/**
+ * Unit guard for the cross-platform detached-worker spawn helper.
+ *
+ * This helper exists to fix the Codex/Windows-PowerShell crash (2026-05-29):
+ * the old `spawn("nohup", ["node", ...])` form ENOENT-crashed the hook on
+ * Windows (no `nohup`) because the async 'error' event had no listener. The
+ * tests below are the failure cases that form:
+ *   - did NOT use `nohup` (regression guard — the literal bug),
+ *   - did NOT install an 'error' listener (the crash mechanism).
+ *
+ * Test seam: spawn + execPath are injected, so no real child process runs and
+ * the assertions are stable across CI environments regardless of PATH.
+ */
+function fakeSpawn(): {
+  calls: { cmd: string; args: string[]; opts: unknown }[];
+  onCalls: { event: string; cb: (...a: unknown[]) => void }[];
+  unref: ReturnType<typeof vi.fn>;
+  spy: typeof nodeSpawn;
+} {
+  const calls: { cmd: string; args: string[]; opts: unknown }[] = [];
+  const onCalls: { event: string; cb: (...a: unknown[]) => void }[] = [];
+  const unref = vi.fn();
+  const impl = (cmd: string, args: readonly string[], opts: unknown) => {
+    calls.push({ cmd, args: [...args], opts });
+    const child: { on: (e: string, cb: (...a: unknown[]) => void) => unknown; unref: typeof unref } = {
+      on: (event, cb) => { onCalls.push({ event, cb }); return child; },
+      unref,
+    };
+    return child as unknown as ChildProcess;
+  };
+  return { calls, onCalls, unref, spy: impl as unknown as typeof nodeSpawn };
+}
+
+describe("spawnDetachedNodeWorker", () => {
+  it("invokes the node binary (execPath) directly with [workerPath, ...args] — NOT nohup", () => {
+    const { calls, spy } = fakeSpawn();
+    spawnDetachedNodeWorker("/bundle/wiki-worker.js", ["/tmp/config.json"], {
+      spawn: spy,
+      execPath: "/usr/bin/node",
+    });
+    expect(calls).toHaveLength(1);
+    const { cmd, args, opts } = calls[0]!;
+    // The literal Windows bug was spawn("nohup", ...). Guard against its return.
+    expect(cmd).not.toBe("nohup");
+    expect(cmd).toBe("/usr/bin/node");
+    expect(args).toEqual(["/bundle/wiki-worker.js", "/tmp/config.json"]);
+    // detached + fully-ignored stdio are what let the worker outlive the hook
+    // on BOTH POSIX and Windows (nohup was redundant with these).
+    expect(opts).toMatchObject({
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+  });
+
+  it("registers an 'error' listener BEFORE unref (Windows ENOENT is async; no listener = crash)", () => {
+    const { onCalls, unref, spy } = fakeSpawn();
+    spawnDetachedNodeWorker("/bundle/w.js", ["/cfg"], { spawn: spy, execPath: "node" });
+
+    const errorListeners = onCalls.filter(c => c.event === "error");
+    expect(errorListeners).toHaveLength(1);
+    // Triggering the listener (what Node does when nohup/node is missing) must
+    // be silent — this is the degradation that replaces the hook crash.
+    expect(() => errorListeners[0]!.cb(new Error("spawn ENOENT"))).not.toThrow();
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to process.execPath when execPath is not injected", () => {
+    const { calls, spy } = fakeSpawn();
+    spawnDetachedNodeWorker("/bundle/w.js", [], { spawn: spy });
+    expect(calls[0]!.cmd).toBe(process.execPath);
+  });
+
+  it("a synchronous throw from spawn does NOT propagate (best-effort: must never crash the hook)", () => {
+    const impl = (() => { throw new Error("spawn ENOENT nohup"); }) as unknown as typeof nodeSpawn;
+    expect(() => spawnDetachedNodeWorker("/bundle/w.js", ["/cfg"], { spawn: impl })).not.toThrow();
+  });
+
+  it("composes args after the worker path (worker is always argv[0] to node)", () => {
+    const { calls, spy } = fakeSpawn();
+    spawnDetachedNodeWorker("/b/skillify-worker.js", ["a", "b"], { spawn: spy, execPath: "node" });
+    expect(calls[0]!.args).toEqual(["/b/skillify-worker.js", "a", "b"]);
+  });
+});
+
+/**
+ * REAL-PROCESS tests (no spawn mock). These are the failure-before-fix /
+ * success-path guards that the mocked unit tests above CANNOT provide — the
+ * mock proves we don't *call* nohup; these prove the hook doesn't *die* and
+ * that the worker actually *runs*.
+ *
+ * Cross-platform without needing Windows: the Windows crash was "spawn a
+ * binary that isn't on PATH → async ENOENT → no listener → process exits 1."
+ * On Linux a missing `nohup` is indistinguishable from any other missing
+ * binary, so spawning a deliberately-absent binary reproduces the EXACT
+ * mechanism here. (A windows-latest CI leg exercises the real win32 path
+ * separators + detach semantics on top of this — see .github/workflows/ci.yaml.)
+ */
+describe("spawnDetachedNodeWorker — real process (no mock)", () => {
+  const MISSING = "hivemind-definitely-not-a-real-binary-xyz";
+
+  // The literal bug: the OLD code shape, run in a child node process, must
+  // crash with a non-zero exit. If this ever starts exiting 0, the runtime no
+  // longer surfaces unhandled spawn errors and the rest of this fix is moot.
+  it("OLD shape (spawn missing binary, NO error listener) crashes a child node proc", () => {
+    const script =
+      `const {spawn}=require('child_process');` +
+      `spawn(${JSON.stringify(MISSING)},['node','x'],{detached:true,stdio:['ignore','ignore','ignore']}).unref();`;
+    const res = spawnSync(process.execPath, ["-e", script], { encoding: "utf-8" });
+    expect(res.status).not.toBe(0); // unhandled 'error' event → exit 1
+    expect(res.stderr).toContain("ENOENT");
+  });
+
+  // The fix, in a child node proc: same missing binary, WITH the error
+  // listener → clean exit 0. Mirrors spawnDetachedNodeWorker's exact shape.
+  it("NEW shape (same spawn + error listener + unref) exits cleanly", () => {
+    const script =
+      `const {spawn}=require('child_process');` +
+      `const c=spawn(${JSON.stringify(MISSING)},['node','x'],{detached:true,stdio:['ignore','ignore','ignore']});` +
+      `c.on('error',()=>{});c.unref();`;
+    const res = spawnSync(process.execPath, ["-e", script], { encoding: "utf-8" });
+    expect(res.status).toBe(0);
+  });
+
+  // Ties the above to the REAL helper (not a hand-copied shape): calling it
+  // in-process with a missing execPath and the REAL node spawn must not crash
+  // this test process — the async ENOENT is absorbed. Reaching the assertion
+  // after two macrotasks (long enough for the 'error' event to fire) IS the
+  // proof of survival.
+  it("real helper absorbs a missing-binary ENOENT in-process (parent survives)", async () => {
+    spawnDetachedNodeWorker("/bundle/whatever.js", ["/cfg"], { execPath: MISSING });
+    await new Promise(r => setTimeout(r, 50));
+    await new Promise(r => setTimeout(r, 50));
+    expect(true).toBe(true); // we got here → no unhandled crash
+  });
+
+  // Success path with a REAL detached worker: point the helper at the real
+  // node (process.execPath) and a tiny worker that writes its argv to a
+  // sentinel file. Proves detached + execPath actually launches a working
+  // child on the host OS, and that the helper returns immediately (the call
+  // does not block on the child).
+  it("launches a real detached node worker that runs and receives its config arg", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hm-spawn-real-"));
+    try {
+      const sentinel = join(dir, "ran.json");
+      const worker = join(dir, "worker.js");
+      // Worker writes [its own argv tail] so we can assert it got the config.
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(
+        worker,
+        `require('fs').writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(process.argv.slice(2)));`,
+      );
+
+      const t0 = process.hrtime.bigint();
+      spawnDetachedNodeWorker(worker, [join(dir, "config.json")], { execPath: process.execPath });
+      const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
+      // The call must return ~immediately (fire-and-forget), not await the child.
+      expect(elapsedMs).toBeLessThan(1000);
+
+      // Poll for the sentinel — the detached child runs on its own schedule.
+      let ran = false;
+      for (let i = 0; i < 60 && !ran; i++) {
+        if (existsSync(sentinel)) { ran = true; break; }
+        await new Promise(r => setTimeout(r, 50));
+      }
+      expect(ran).toBe(true);
+      const argv = JSON.parse(readFileSync(sentinel, "utf-8")) as string[];
+      expect(argv).toEqual([join(dir, "config.json")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Reported by a Windows/PowerShell Codex user: the Hivemind PostToolUse capture hook (`capture.js`) **intermittently exited 1**, and `hooks.json` had a **duplicated** PostToolUse entry (capture ran twice). Two distinct Windows bugs:

### Bug 1 — the crash (exit 1)
The wiki-summary and skillify workers were spawned as:
```js
spawn("nohup", ["node", workerPath, configFile], { detached, stdio })
```
`nohup` doesn't exist on Windows → `spawn` emits an **async `ENOENT` 'error' event**, not a sync throw. With **no `error` listener**, that event is unhandled and crashes the parent hook with exit 1. The summary worker only fires past a periodic message threshold (first at N captured, then every M), which is why it failed *sometimes*, not every tool call. The pattern existed in **5 helpers** — codex/claude/cursor/hermes wiki workers + skillify — only `spawn-pull-worker.ts` had previously been fixed.

### Bug 2 — the duplicate PostToolUse hook
`isHivemindHookEntry` (codex) / `isHivemindEntry` (cursor) matched with forward-slash literals (`/bundle/`), but on Windows the hook command is written via `join()` with **backslashes** (`node "C:\Users\...\hivemind\bundle\capture.js"`). So dedup never matched the prior install → **every re-install appended a duplicate**.

## Fix

- **New `src/utils/spawn-detached.ts`** — invokes the node binary directly via `process.execPath` (drops `nohup`), installs an `error` listener before `unref()`, and relies on `detached` + ignored stdio to outlive the parent on **both POSIX and Windows**. Net effect: the workers now actually *run* on Windows instead of crashing the hook. All 5 spawn sites routed through it.
- **Separator normalization** in `install-codex.ts` (`isHivemindHookEntry` + `isForeignHivemindHookEntry`) and `install-cursor.ts` (`isHivemindEntry`) so backslash commands match. Pi uses marker blocks — unaffected.

## Testing — 3 layers

Neither bug actually requires Windows to test; both are mechanisms Linux reproduces on demand:

1. **Live crash mechanism (Linux, in suite):** spawn a *real* missing binary in a child node proc — old shape **exits 1** (unhandled ENOENT), fixed shape **exits 0**. "`nohup` missing on Windows" ≡ "any missing binary on Linux."
2. **Real detached-worker E2E (Linux, in suite):** real helper + `process.execPath` + a tiny worker that writes a sentinel; asserts it ran with the right arg and the call returned <1s (fire-and-forget). Plus an in-process test that calls the real helper with a bogus execPath and survives.
3. **Windows CI leg:** new `windows-smoke` job (`windows-latest`) runs the spawn + install-dedup suites on real win32 — scoped, since the rest of the suite assumes POSIX paths/chmod/symlinks.

Bug 2 is pure string logic, so tests feed the **exact backslash command** `join()` produces, including a "5 re-installs → still 1 PostToolUse entry" repro of the reported symptom.

**133/133 passing** across all touched suites (9 in the new spawn-detached suite, 4 of them real-process).

## Not covered
- The actual `windows-latest` run (executes when this PR's CI runs).
- The built `capture.js` bundle — blocked locally by the missing native `tree-sitter` optional dep (unmodified `main` fails `tsc` identically; environmental, not this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate hook installs and incorrect hook classification on Windows by normalizing path handling.

* **Improvements**
  * Consolidated worker startup into a cross-platform detached spawn helper with safer error handling.
  * Made project name derivation consistent across platforms.

* **Tests**
  * Added Windows smoke CI job and extensive tests covering detached workers and Windows path scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/activeloopai/hivemind/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->