### PR TITLE
fix(codex): idempotent hooks.json install (stop repeated trust prompts) + README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ git clone https://github.com/activeloopai/hivemind.git ~/.codex/hivemind
 ```
 
 Restart Codex to activate.
+
+**First launch — trust the hooks.** Codex shows a **"Hooks need review"** prompt before it will run hivemind's hooks:
+
+```
+Hooks need review
+2 hooks are new or changed.
+Hooks can run outside the sandbox after you trust them.
+
+   1. Review hooks
+ › 2. Trust all and continue
+   3. Continue without trusting (hooks won't run)
+```
+
+Choose **`2. Trust all and continue`** — otherwise the hooks won't run and hivemind stays inactive.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Restart Codex to activate.
 
 **First launch — trust the hooks.** Codex shows a **"Hooks need review"** prompt before it will run hivemind's hooks:
 
-```
+```text
 Hooks need review
 2 hooks are new or changed.
 Hooks can run outside the sandbox after you trust them.

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { HOME, pkgRoot, ensureDir, copyDir, writeJson, symlinkForce, writeVersionStamp, log, warn } from "./util.js";
+import { HOME, pkgRoot, ensureDir, copyDir, writeJson, writeJsonIfChanged, symlinkForce, writeVersionStamp, log, warn } from "./util.js";
 import { getVersion } from "./version.js";
 
 const CODEX_HOME = join(HOME, ".codex");
@@ -225,7 +225,14 @@ export function installCodex(): void {
   if (existsSync(srcSkills)) copyDir(srcSkills, join(PLUGIN_DIR, "skills"));
 
   tryEnableCodexHooks();
-  writeJson(HOOKS_PATH, mergeHooksJson(buildHooksJson()));
+  // Idempotent: only rewrite hooks.json when the merged result actually
+  // changed. An unconditional rewrite (even byte-identical) changes the file
+  // Codex fingerprints and re-triggers its "Hooks need review" trust prompt on
+  // every install/update. Skipping the no-op write keeps the user from being
+  // re-prompted each time.
+  if (!writeJsonIfChanged(HOOKS_PATH, mergeHooksJson(buildHooksJson()))) {
+    log(`  Codex          hooks.json unchanged — skipped rewrite (no re-trust prompt)`);
+  }
 
   ensureDir(AGENTS_SKILLS_DIR);
   const skillTarget = join(PLUGIN_DIR, "skills", "deeplake-memory");

--- a/src/cli/install-cursor.ts
+++ b/src/cli/install-cursor.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { HOME, pkgRoot, ensureDir, copyDir, readJson, writeJson, writeVersionStamp, log } from "./util.js";
+import { HOME, pkgRoot, ensureDir, copyDir, readJson, writeJson, writeJsonIfChanged, writeVersionStamp, log } from "./util.js";
 import { getVersion } from "./version.js";
 
 // Cursor 1.7+ hooks API: https://cursor.com/docs/agent/hooks
@@ -105,7 +105,9 @@ export function installCursor(): void {
 
   const existing = readJson<Record<string, unknown>>(HOOKS_PATH);
   const merged = mergeHooks(existing);
-  writeJson(HOOKS_PATH, merged);
+  // Idempotent (same rationale as codex): skip the rewrite when unchanged so
+  // we don't perturb the hooks.json Cursor/Codex-style trust fingerprints.
+  writeJsonIfChanged(HOOKS_PATH, merged);
 
   writeVersionStamp(PLUGIN_DIR, getVersion());
   log(`  Cursor         installed -> ${PLUGIN_DIR}`);

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -59,6 +59,29 @@ export function writeJson(path: string, obj: unknown): void {
   writeFileSync(path, JSON.stringify(obj, null, 2) + "\n");
 }
 
+/**
+ * Write JSON only if the serialized result differs from what's already on
+ * disk. Returns true if it wrote, false if the file already matched.
+ *
+ * Why: Codex fingerprints each hook *definition* and re-prompts the user to
+ * "review & trust" whenever a hook it sees has changed. Our installer used to
+ * rewrite hooks.json unconditionally on every install/update — even when the
+ * merged result was byte-identical — which re-triggered that trust prompt for
+ * no reason. Skipping the write when nothing changed keeps the file (and its
+ * fingerprint) stable, so Codex stops re-asking after the first trust.
+ */
+export function writeJsonIfChanged(path: string, obj: unknown): boolean {
+  const next = JSON.stringify(obj, null, 2) + "\n";
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf-8") === next) return false; // unchanged → no write
+    } catch { /* unreadable → fall through and rewrite */ }
+  }
+  ensureDir(dirname(path));
+  writeFileSync(path, next);
+  return true;
+}
+
 export function writeVersionStamp(dir: string, version: string): void {
   ensureDir(dir);
   writeFileSync(join(dir, ".hivemind_version"), version);

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -98,6 +98,44 @@ describe("installCodex — happy path", () => {
     // PreToolUse carries the Bash matcher.
     expect(hooks.hooks.PreToolUse[0].matcher).toBe("Bash");
     expect(hooks.hooks.PreToolUse[0].hooks[0].timeout).toBe(10);
+  });
+
+  it("is idempotent: a second install does NOT rewrite hooks.json (avoids Codex re-trust prompt)", async () => {
+    const { installCodex } = await importInstaller();
+    installCodex();
+    const hooksPath = join(tmpHome, ".codex", "hooks.json");
+    const content1 = readFileSync(hooksPath, "utf-8");
+
+    // Pin mtime to the past — a real rewrite would bump it to ~now. This is
+    // the regression guard: pre-fix, install() always rewrote the file, which
+    // re-triggered Codex's "Hooks need review" prompt on every install/update.
+    const past = new Date("2020-01-01T00:00:00Z");
+    utimesSync(hooksPath, past, past);
+
+    installCodex(); // re-install, same version/bundle → merged result identical
+
+    expect(readFileSync(hooksPath, "utf-8")).toBe(content1); // content stable
+    expect(statSync(hooksPath).mtimeMs).toBe(past.getTime()); // file NOT rewritten
+  });
+
+  it("DOES rewrite hooks.json when a stale/foreign entry must be merged out (write path still works)", async () => {
+    const { installCodex } = await importInstaller();
+    const hooksPath = join(tmpHome, ".codex", "hooks.json");
+    // Pre-seed a hooks.json that differs from the canonical install result
+    // (a user's own hook on an event we don't claim) so the merge changes it.
+    writeFileSync(hooksPath, JSON.stringify({
+      hooks: { Notification: [{ hooks: [{ type: "command", command: "/usr/local/bin/notify.sh" }] }] },
+    }, null, 2) + "\n");
+    const past = new Date("2020-01-01T00:00:00Z");
+    utimesSync(hooksPath, past, past);
+
+    installCodex();
+
+    // It rewrote (mtime moved) and the user's hook survived alongside ours.
+    expect(statSync(hooksPath).mtimeMs).not.toBe(past.getTime());
+    const merged = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    expect(merged.hooks.Notification).toHaveLength(1);
+    expect(merged.hooks.PostToolUse).toHaveLength(1);
   });
 
   it("creates the agentskills symlink at ~/.agents/skills/hivemind-memory", async () => {

--- a/tests/cli/write-json-if-changed.test.ts
+++ b/tests/cli/write-json-if-changed.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeJsonIfChanged } from "../../src/cli/util.js";
+
+/**
+ * writeJsonIfChanged underpins the "don't re-trigger Codex's hook-trust
+ * prompt" fix: it must NOT touch the file when the serialized JSON already
+ * matches on disk (a no-op write changes the file Codex fingerprints).
+ *
+ * Failure-before-fix framing (CLAUDE.md rule 12): the old code called
+ * writeJson unconditionally, so the file was always rewritten. These assert
+ * the file is left untouched when unchanged.
+ */
+describe("writeJsonIfChanged", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wjic-"));
+    path = join(dir, "hooks.json");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("writes (returns true) when the file does not exist", () => {
+    expect(writeJsonIfChanged(path, { a: 1 })).toBe(true);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(JSON.stringify({ a: 1 }, null, 2) + "\n");
+  });
+
+  it("does NOT write (returns false) when the serialized result already matches", () => {
+    writeJsonIfChanged(path, { a: 1, b: [2, 3] });
+    // Pin mtime to the past; a real rewrite would bump it to ~now.
+    const past = new Date("2020-01-01T00:00:00Z");
+    utimesSync(path, past, past);
+
+    expect(writeJsonIfChanged(path, { a: 1, b: [2, 3] })).toBe(false);
+    expect(statSync(path).mtimeMs).toBe(past.getTime()); // file untouched
+  });
+
+  it("writes (returns true) when the content differs", () => {
+    writeJsonIfChanged(path, { a: 1 });
+    const past = new Date("2020-01-01T00:00:00Z");
+    utimesSync(path, past, past);
+
+    expect(writeJsonIfChanged(path, { a: 2 })).toBe(true);
+    expect(statSync(path).mtimeMs).not.toBe(past.getTime());
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({ a: 2 });
+  });
+
+  it("uses the same 2-space + trailing-newline format as writeJson (so a writeJson'd file is seen as unchanged)", () => {
+    // Simulate a file written by the legacy writeJson, then confirm
+    // writeJsonIfChanged treats identical content as a no-op.
+    const obj = { hooks: { PostToolUse: [{ command: "x" }] } };
+    writeFileSync(path, JSON.stringify(obj, null, 2) + "\n");
+    expect(writeJsonIfChanged(path, obj)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Recent Codex versions gate hooks behind a **"Hooks need review / Trust"** prompt, and they fingerprint each hook *definition*. Our installer rewrote `hooks.json` **unconditionally on every install/update** — even when the merged result was byte-identical — which changed the file Codex fingerprints and **re-triggered the trust prompt every time**. Users had to "Trust all and continue" after every update.

(Evidence it's a *definition* fingerprint, not script-content: in the field only the 2 hooks whose definitions changed were flagged for review; the 3 with stable definitions stayed trusted across the update.)

## Fix

- New `writeJsonIfChanged(path, obj)` — skips the write when the serialized JSON already matches on disk (returns whether it wrote).
- Codex + Cursor install-time `hooks.json` writes now use it. Re-installing the same version leaves the file (and its fingerprint) untouched → Codex stops re-asking after the first trust.

**Real-world E2E** (built `bundle/cli.js`, sandboxed HOME): install twice → second install leaves `hooks.json` byte-identical, mtime unchanged, and logs `hooks.json unchanged — skipped rewrite (no re-trust prompt)`.

## Docs

Adds a short note to the README Codex section: on first launch, choose **"Trust all and continue"** or the hooks won't run. (Deliberately does *not* mention the per-update re-prompt — this PR removes that.)

## Tests

- `writeJsonIfChanged` unit coverage (write / skip / rewrite branches, via mtime pinning).
- Codex-install idempotency guard: a second install does **not** rewrite `hooks.json`; plus a guard that the write path still fires when a merge actually changes the file.

## Notes

Builds on the merged Windows fix (#221). The first install of a version that genuinely changes a hook *definition* will still (correctly) prompt once; this only removes the spurious re-prompts from no-op rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Codex manual install first-launch behavior: explains the "Hooks need review" prompt and advises selecting "Trust all and continue" to enable Hivemind hooks.

* **Bug Fixes**
  * Hook installation is now idempotent and will skip rewriting unchanged hook configuration to avoid repeated trust prompts.

* **Tests**
  * Added coverage verifying install idempotency and the write-if-changed behavior for hook files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->