### PR TITLE
Resume: pickup-from-Next-Steps fix + capture tasks with context

### DIFF
--- a/claude-code/skills/hivemind-goals/SKILL.md
+++ b/claude-code/skills/hivemind-goals/SKILL.md
@@ -73,6 +73,36 @@ When the user expresses a new goal:
 
 **Do NOT auto-generate KPIs.** A goal is created with zero KPI files by default. Generate KPIs ONLY when the user explicitly asks you to ("aggiungi KPI per …", "add metrics for this goal", "track these metrics: …"). When the user asks, write each KPI as a separate file at `~/.deeplake/memory/kpi/<goal_id>/<kpi-slug>.md` with the body format documented above.
 
+### 1a. Capture a task for later (with resumable context)
+
+Use this when the user **parks a tangential task** mid-session — "save this for later", "remind me to …", "don't let me forget …", "let's do X later", "capture this in Hivemind". The value is NOT the one-liner — it's storing enough **context to resume cold** in a future session without the user re-explaining anything.
+
+Write it via the **CLI** (not the VFS heredoc) so the row is tagged `agent: capture`, which separates parked side-tasks from hand-made goals:
+
+```bash
+hivemind goal add --agent capture "Add rate-limiting to the webhook handler
+
+Start here: add a per-IP token bucket on the handler entry path
+Files: src/webhook/handler.ts:120-160, src/webhook/limits.ts
+Branch: feat/webhook-hardening
+Run: pnpm test webhook
+Why: bursty clients hammer the endpoint; agreed to defer until the retry-backoff work lands"
+```
+
+- **Line 1 is the label** — keep it short; it's what `goal list` and the SessionStart banner show.
+- Fill `Start here / Files / Branch / Run / Why` from the live conversation — you already know the files you just touched and the branch. Include only the lines you can fill; omit the rest. **`Start here:` is the most important** — the concrete first action.
+- Pass the whole package as **one double-quoted argument** (the newlines are preserved into the stored body).
+- Confirm to the user: the label + that it'll resume cleanly next session.
+
+### 1b. Resume a parked task (automatic context transfer)
+
+When the user says "let's work on that task / that goal", "let's start the `<X>` task", or "pick up the parked `<X>`", pull its stored context back into the session and continue — the user should NOT have to re-explain anything.
+
+1. **Find it:** `hivemind goal list --mine` and match the user's reference to a `goal_id` (by label / topic). If ambiguous, show the candidates and ask which one.
+2. **Transfer the context:** `hivemind goal get <goal_id>` prints the full package (`Start here / Files / Branch / Run / Why`). Read it as your working context — `goal list` only shows the first line, so always use `goal get` for the full body.
+3. **Flip to in_progress:** `mv ~/.deeplake/memory/goal/<owner>/opened/<uuid>.md ~/.deeplake/memory/goal/<owner>/in_progress/<uuid>.md`
+4. **Act on it:** open the `Files:`, switch to the `Branch:` if given, and begin from `Start here:`. You are now resumed — continue as if the context was never lost. Close it (section 5) when the work is done.
+
 ### 2. List goals
 
 ```bash

--- a/codex/skills/hivemind-goals/SKILL.md
+++ b/codex/skills/hivemind-goals/SKILL.md
@@ -67,6 +67,36 @@ When the user expresses a new goal:
 
 **Do NOT auto-generate KPIs.** A goal is created with zero KPI files by default. Generate KPIs ONLY when the user explicitly asks you to ("aggiungi KPI per …", "add metrics for this goal", "track these metrics: …"). When the user asks, write each KPI as a separate file at `~/.deeplake/memory/kpi/<goal_id>/<kpi-slug>.md` with the body format documented above.
 
+### 1a. Capture a task for later (with resumable context)
+
+Use this when the user **parks a tangential task** mid-session — "save this for later", "remind me to …", "don't let me forget …", "let's do X later". The value is NOT the one-liner — it's storing enough **context to resume cold** in a future session without the user re-explaining anything.
+
+Write it via the **CLI** so the row is tagged `agent: capture`, which separates parked side-tasks from hand-made goals:
+
+```bash
+hivemind goal add --agent capture "Add rate-limiting to the webhook handler
+
+Start here: add a per-IP token bucket on the handler entry path
+Files: src/webhook/handler.ts:120-160, src/webhook/limits.ts
+Branch: feat/webhook-hardening
+Run: pnpm test webhook
+Why: bursty clients hammer the endpoint; agreed to defer until the retry-backoff work lands"
+```
+
+- **Line 1 is the label** — short; it's what `goal list` and the SessionStart banner show.
+- Fill `Start here / Files / Branch / Run / Why` from the live conversation. Include only the lines you can fill; `Start here:` (the concrete first action) matters most.
+- Pass the whole package as **one double-quoted argument** (newlines are preserved into the stored body).
+- Confirm to the user: the label + that it'll resume cleanly next session.
+
+### 1b. Resume a parked task (automatic context transfer)
+
+When the user says "let's work on that task / that goal", "let's start the `<X>` task", or "pick up the parked `<X>`", pull its stored context back into the session and continue — the user should NOT have to re-explain anything.
+
+1. **Find it:** `hivemind goal list --mine` and match the user's reference to a `goal_id`. If ambiguous, show the candidates and ask.
+2. **Transfer the context:** `hivemind goal get <goal_id>` prints the full package (`Start here / Files / Branch / Run / Why`). Read it as your working context — `goal list` only shows the first line, so always use `goal get` for the full body.
+3. **Flip to in_progress:** `mv ~/.deeplake/memory/goal/<owner>/opened/<uuid>.md ~/.deeplake/memory/goal/<owner>/in_progress/<uuid>.md`
+4. **Act on it:** open the `Files:`, switch to the `Branch:` if given, and begin from `Start here:`. You are resumed — continue as if the context was never lost.
+
 ### 2. List goals
 
 ```bash

--- a/docs/CAPTURE_TASKS.md
+++ b/docs/CAPTURE_TASKS.md
@@ -1,0 +1,107 @@
+# Capture Tasks — turning conversation tangents into Hivemind goals
+
+**Status:** v1 implemented · **Owner:** Sasun · **Companion to:** "pick up where you left off" (resume-brief)
+
+> **Decision (v1).** We did **not** build the auto-detection pipeline below (Stop-hook → LLM gate → dedup → confirm). Instead, capture is **explicit, user-initiated, and in-session**: the user says *"save this for later"* and the agent — which already holds the live context — writes the task as a goal then and there. Its sibling is the resume half: when the user says *"let's work on that task,"* the agent transfers the stored context back into the session and continues with no re-explaining.
+>
+> The whole feature is a **Save↔Resume context-transfer pair**, designed together: what Save stores is exactly what Resume hands back. Implemented as two operations in the `hivemind-goals` skill (all agent copies) plus two small CLI additions — `hivemind goal add --agent capture` (provenance) and `hivemind goal get <goal_id>` (full-body read for the transfer). No Stop-hook, gate, worker, confirm-flow, or new table. The auto-detection design below is preserved as **Later** (see Scope).
+
+## Problem
+
+Mid-session, a user often states a *new, unrelated* action — "oh, we should also fix the retry backoff", "remind me to email johg", "later we need to migrate the index". It's a real commitment, but it's a tangent from whatever the agent is doing right now, so it evaporates: the agent stays on the main thread, the session ends, the task is lost.
+
+This is a stickiness lever, not an acquisition one. Hivemind's value is "nothing gets lost across sessions"; today that holds for the *main* thread (resume-brief) but not for the *side* threads a user throws out in passing. Capturing them:
+
+- makes the memory measurably more useful (more reasons to keep it installed → W1→W2 stickiness, the leak the data points at);
+- feeds the existing **goals** system, which already drives the SessionStart "📌 N goals open" banner and the context-block goals injection.
+
+Non-goal: this is not a general TODO manager. It captures *agent-observed* commitments the user would otherwise drop.
+
+## What "a task" means here
+
+Reuse the existing **goals** primitive — there is no separate "tasks" concept (the legacy `hivemind tasks` CLI was folded into goals). A captured task is a goal row:
+
+- table: `GOALS_COLUMNS` — `goal_id / owner / status / content / version / created_at / agent`
+- VFS: `memory/goal/<owner>/<status>/<goal_id>.md`, `content` = markdown (first line = label)
+- `agent` field distinguishes provenance — captured tasks should write `agent: "capture"` (vs `manual` / a CLI), so they're auditable and separable from hand-created goals.
+
+## User flow (recommended: confirm-first)
+
+```
+[mid-session] user: "…and we should also add rate-limiting to the webhook handler, but not now."
+                    ↓  (Stop hook, end of turn/session)
+agent surfaces (user channel only):
+  📝 Noticed a side task: "Add rate-limiting to the webhook handler"
+     Save to Hivemind goals?  (reply: yes / no / edit)
+                    ↓ user: "yes"
+goal written → shows in next session's "📌 N goals open" banner + goals context block.
+```
+
+The capture is **proposed, not silent.** The user confirms (or edits/declines). This is the v1 stance — see the decision below.
+
+## Mechanism
+
+Reuse the **skillify mine pipeline** shape (`src/skillify/`), which already does exactly this class of work: read a session → run an LLM gate → dedup → write rows. The goal-capture pipeline mirrors it:
+
+1. **Trigger** — a `Stop` hook (end of session/turn). Stop, not UserPromptSubmit: we want the full exchange, and we don't want to add latency to every prompt.
+2. **Extract (LLM gate)** — feed the session (or the recent window) to a gated `claude -p` call, same as `gate-runner.ts`. Prompt: *extract explicit, actionable commitments the user stated that are **tangential** to the session's main thread; ignore the main task, ignore rhetorical/hypothetical statements.* Output: strict JSON `[{title, detail, confidence}]`.
+3. **Dedup** — against open goals via the canonical `listOpenGoals` reader (same owner-matching used by the banner, so we never double-capture or collide on a `%user%` substring). Drop near-duplicates of existing goals.
+4. **Confirm** — surface survivors `userVisibleOnly` (see safety) for yes / edit / no.
+5. **Write** — on confirm, write a goal row (`agent: "capture"`) via the existing `commands/goal.ts` add path + VFS convention.
+
+## The one real decision: auto vs confirm vs command
+
+| Mode | Value | Risk | 
+|---|---|---|
+| **Command** (`/hivemind:capture-tasks`) | zero noise, zero risk | user must remember → most tasks still lost |
+| **Auto** (Stop hook writes silently) | highest capture | pollutes goals with mis-detected / rhetorical items; hard to trust |
+| **Confirm** (Stop hook proposes, user approves) | captures the value | one extra interaction; depends on detection quality |
+
+**Recommendation: Confirm for v1.** It captures the value without polluting the goals table with false positives, and it's the cheapest way to *learn whether the detection is any good* before trusting it silently. If confirm-acceptance is consistently high, graduate to auto (with an undo) later.
+
+## Detection: what counts as a "new/unrelated task"
+
+The hard part, and the main source of noise. The gate must keep:
+- explicit, actionable, **deferred** commitments ("we should also…", "remind me to…", "later we need to…", "TODO: …", "don't let me forget…");
+
+and reject:
+- the session's **main** work (already being done / will be resumed by resume-brief);
+- hypotheticals, questions, opinions ("maybe we could…", "I wonder if…");
+- things already tracked (dedup step).
+
+"Tangential to the main thread" is the key filter — a task the agent is *about to do anyway* is not a capture; a task the user parks *for later* is. Bias toward **precision over recall**: a missed capture is invisible; a wrong capture erodes trust in the whole goals list.
+
+## Safety (channel)
+
+The proposal and the captured `content` are derived from conversation — same untrusted-content class as summaries. So:
+- the confirm prompt is **user-facing only** (terminal), never the model's `additionalContext`, consistent with the resume-brief / banner channel rules;
+- captured goal content is data, not instructions — when later surfaced (banner / context block) it's already treated as user-facing.
+
+No new injection surface: capture writes to the goals table; goals already render `userVisibleOnly`.
+
+## Failure modes / noise control
+
+- **Over-capture** → the goals list becomes noise and people stop trusting it. Mitigate: confirm-first, precision-biased gate, per-session cap (e.g. ≤3 proposed).
+- **Duplicate capture** across sessions → dedup via `listOpenGoals` (canonical owner match), and skip if a near-identical open goal exists.
+- **Latency** → Stop hook runs the gate out of band (spawned worker, like skillify's `spawn-mine-local-worker`), never blocking the session.
+- **Wrong owner / workspace** → goals are owner- and workspace-scoped; reuse the same scoping as the goals banner so captures land where the user will see them.
+
+## Scope
+
+**v1 (shipped) — explicit Save↔Resume context-transfer**
+- **Save:** on "save this for later", the agent writes a goal whose body is a resumable *context package* (`<label>` + `Start here / Files / Branch / Run / Why`) via `hivemind goal add --agent capture "<package>"`. `agent:"capture"` keeps parked side-tasks separable from hand-made goals.
+- **Resume:** on "let's work on that task", the agent finds the goal, pulls the full body with `hivemind goal get <goal_id>`, flips it to `in_progress`, and continues from `Start here:` — automatic context transfer, no re-explaining.
+- Implemented in the `hivemind-goals` skill (claude-code / codex / hermes / openclaw copies) + `src/commands/goal.ts` (`--agent` flag, `goal get`). Reuses the existing goals primitive — no separate task store, no new table.
+
+**Later (the auto-detection design above)**
+- Stop-hook → LLM gate → dedup → confirm → write, to catch tangents the user *forgets* to park. Gated behind proving demand for explicit capture first.
+- Auto-capture with undo, once confirm-acceptance proves detection quality.
+- Mid-session capture (UserPromptSubmit) for "remind me" said in the moment.
+- Link a captured task back to the session summary that spawned it (provenance for resume).
+
+## Open questions
+
+1. **Trigger granularity** — Stop (per session) is the v1 call. Is per-turn ever worth it for explicit "remind me right now"? (Probably a later UserPromptSubmit path.)
+2. **Acceptance metric** — track confirm yes/no rate to decide if/when to graduate to auto. Where does that get logged?
+3. **Edit flow** — "edit" before save: free-text re-prompt, or just let the user restate? v1 could keep it to yes/no and let the user create manually if they want to tweak.
+4. **Cross-project tasks** — a task stated in repo A that's really about repo B. v1: attribute to current project; revisit if it matters.

--- a/hermes/skills/hivemind-goals/SKILL.md
+++ b/hermes/skills/hivemind-goals/SKILL.md
@@ -29,6 +29,31 @@ hivemind kpi bump <goal_id> <kpi_id> <delta>                # increment current 
 2. If the user explicitly asks for KPIs: `hivemind kpi add <goal_id> <slug> <target> <unit>` per KPI.
 3. Tell the user the goal_id and that it is now team-visible in Deeplake.
 
+## Capture a task for later (with resumable context)
+
+When the user **parks a tangential task** mid-session — "save this for later", "remind me to …", "don't let me forget …", "let's do X later" — store enough **context to resume cold** later, not just a one-liner. Tag it `--agent capture` so parked side-tasks are separable from hand-made goals:
+
+```
+hivemind goal add --agent capture "Add rate-limiting to the webhook handler
+
+Start here: add a per-IP token bucket on the handler entry path
+Files: src/webhook/handler.ts:120-160, src/webhook/limits.ts
+Branch: feat/webhook-hardening
+Run: pnpm test webhook
+Why: bursty clients hammer the endpoint; defer until retry-backoff lands"
+```
+
+Line 1 is the label (what `goal list` shows). Fill `Start here / Files / Branch / Run / Why` from the conversation; `Start here:` matters most. Pass the whole package as **one double-quoted argument** so the newlines are preserved.
+
+## Resume a parked task (automatic context transfer)
+
+When the user says "let's work on that task / goal" or "pick up the `<X>` task":
+
+1. `hivemind goal list --mine` — match the user's reference to a `goal_id`.
+2. `hivemind goal get <goal_id>` — prints the **full** package (`goal list` shows only the first line, so always use `goal get`). Read it as your working context.
+3. `hivemind goal progress <goal_id> in_progress` — mark it started.
+4. Begin from `Start here:` using the `Files` / `Branch` / `Run` lines. Continue as if the context was never lost.
+
 ## What NOT to do
 
 - Do NOT call `write_file` on any path under `~/.deeplake/memory/goal/` or `~/.deeplake/memory/kpi/`.

--- a/openclaw/skills/hivemind-goals/SKILL.md
+++ b/openclaw/skills/hivemind-goals/SKILL.md
@@ -23,6 +23,31 @@ OpenClaw exposes purpose-built tools for goals + KPIs. Use them directly — do 
 3. ONLY if the user asks for KPIs: `hivemind_kpi_add` once per KPI with `goal_id` + `kpi_id` (short slug like `k-prs`) + `target` (positive int) + `unit`.
 4. Confirm to the user with the goal_id and that the goal is team-visible.
 
+## Capture a task for later (with resumable context)
+
+When the user **parks a tangential task** mid-session — "save this for later", "remind me to …", "don't let me forget …", "let's do X later" — store enough **context to resume cold** later, not just a one-liner. Put the full package in the `text` of `hivemind_goal_add`:
+
+```
+hivemind_goal_add({ text:
+  "Add rate-limiting to the webhook handler\n\n" +
+  "Start here: add a per-IP token bucket on the handler entry path\n" +
+  "Files: src/webhook/handler.ts:120-160, src/webhook/limits.ts\n" +
+  "Branch: feat/webhook-hardening\n" +
+  "Run: pnpm test webhook\n" +
+  "Why: bursty clients hammer the endpoint; defer until retry-backoff lands" })
+```
+
+Line 1 is the label. Fill `Start here / Files / Branch / Run / Why` from the conversation; `Start here:` (the concrete first action) matters most. (OpenClaw's `hivemind_goal_add` has no provenance flag, so the row is tagged `manual` — that's fine; the context is what matters.)
+
+## Resume a parked task (automatic context transfer)
+
+When the user says "let's work on that task / goal" or "pick up the `<X>` task":
+
+1. `hivemind_search({ query: "<topic>" })` or `hivemind_index({})` to locate the parked goal, then `hivemind_read({ path: "memory/goal/<owner>/opened/<goal_id>.md" })` to pull the **full** context package back.
+2. Read it as your working context and begin from `Start here:` using the `Files` / `Branch` / `Run` lines — continue as if the context was never lost.
+
+(Status-move tools aren't exposed on OpenClaw, so leave the goal where it is and just resume the work.)
+
 ## What NOT to do
 
 - Do NOT write files anywhere under `~/.deeplake/memory/`. OpenClaw's runtime does not route filesystem writes to the Deeplake tables — only the `hivemind_*` tools above do.

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -43,6 +43,40 @@ type QueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
 
 const VALID_STATUS = new Set(["opened", "in_progress", "closed"]);
 
+// Provenance values allowed in the `agent` column when adding a goal.
+// `capture` marks a task the user parked mid-session ("save this for
+// later") so it can be told apart from hand-created goals. Allowlisted
+// because the value is interpolated into the INSERT literal.
+const VALID_AGENT = new Set(["manual", "capture"]);
+
+/**
+ * Pull an optional `--agent <name>` out of the `goal add` args, leaving
+ * the rest as the goal text. The flag may appear anywhere; the value is
+ * validated against VALID_AGENT. Defaults to "manual".
+ */
+function parseAgentFlag(args: string[]): { agent: string; rest: string[] } {
+  const rest: string[] = [];
+  let agent = "manual";
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--agent") {
+      const val = args[i + 1];
+      if (!val) {
+        process.stderr.write("usage: --agent requires a value (manual|capture)\n");
+        process.exit(1);
+      }
+      agent = val;
+      i++; // consume the value
+      continue;
+    }
+    rest.push(args[i]);
+  }
+  if (!VALID_AGENT.has(agent)) {
+    process.stderr.write(`invalid --agent: ${agent} (expected manual|capture)\n`);
+    process.exit(1);
+  }
+  return { agent, rest };
+}
+
 function loadApiOrDie(table: string): { api: DeeplakeApi; query: QueryFn; userName: string } {
   const cfg = loadConfig();
   if (!cfg) {
@@ -62,7 +96,7 @@ function loadApiOrDie(table: string): { api: DeeplakeApi; query: QueryFn; userNa
 
 // ── goal subcommands ────────────────────────────────────────────────────────
 
-async function goalAdd(text: string): Promise<void> {
+async function goalAdd(text: string, agent: string = "manual"): Promise<void> {
   const cfg = loadConfig();
   if (!cfg) {
     process.stderr.write("hivemind: not logged in.\n");
@@ -83,7 +117,7 @@ async function goalAdd(text: string): Promise<void> {
     `E'${sqlStr(text)}', ` +
     `1, ` +
     `'${sqlStr(ts)}', ` +
-    `'manual', ` +
+    `'${sqlStr(agent)}', ` +
     `''` +
     `)`
   );
@@ -111,6 +145,30 @@ async function goalList(filter: "all" | "mine"): Promise<void> {
     }
   } catch (e: unknown) {
     process.stderr.write(`hivemind goal list: ${(e as Error).message}\n`);
+    process.exit(1);
+  }
+}
+
+async function goalGet(goalId: string): Promise<void> {
+  if (!goalId) { process.stderr.write("usage: hivemind goal get <goal_id>\n"); process.exit(1); }
+  const cfg = loadConfig();
+  if (!cfg) { process.stderr.write("not logged in\n"); process.exit(1); }
+  const { query } = loadApiOrDie(cfg.goalsTableName);
+  const safe = sqlIdent(cfg.goalsTableName);
+  try {
+    // Latest version wins (the VFS write path appends a fresh row per
+    // overwrite; the CLI updates in place). Print the FULL content — this
+    // is the resumable context package a future session reads back.
+    const rows = await query(
+      `SELECT content FROM "${safe}" WHERE goal_id = '${sqlStr(goalId)}' ORDER BY version DESC, created_at DESC LIMIT 1`
+    );
+    if (rows.length === 0) {
+      process.stderr.write(`goal not found: ${goalId}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${String(rows[0].content ?? "")}\n`);
+  } catch (e: unknown) {
+    process.stderr.write(`hivemind goal get: ${(e as Error).message}\n`);
     process.exit(1);
   }
 }
@@ -237,8 +295,10 @@ const USAGE_GOAL = `
 hivemind goal — manage team goals
 
 Usage:
-  hivemind goal add "<text>"            create a goal (status=opened)
+  hivemind goal add "<text>" [--agent manual|capture]
+                                        create a goal (status=opened)
   hivemind goal list [--all|--mine]     list goals (default: --mine)
+  hivemind goal get <goal_id>           print a goal's full body (resume context)
   hivemind goal done <goal_id>          mark goal closed
   hivemind goal progress <goal_id> <opened|in_progress|closed>
 `.trim();
@@ -247,14 +307,21 @@ export async function runGoalCommand(args: string[]): Promise<void> {
   const sub = args[0];
   if (!sub || sub === "--help" || sub === "-h") { process.stdout.write(USAGE_GOAL + "\n"); return; }
   if (sub === "add") {
-    const text = args.slice(1).join(" ").trim();
+    const { agent, rest } = parseAgentFlag(args.slice(1));
+    const text = rest.join(" ").trim();
     if (!text) { process.stderr.write("usage: hivemind goal add \"<text>\"\n"); process.exit(1); }
-    await goalAdd(text);
+    await goalAdd(text, agent);
     return;
   }
   if (sub === "list") {
     const filter = args.includes("--all") ? "all" : "mine";
     await goalList(filter);
+    return;
+  }
+  if (sub === "get") {
+    const id = args[1];
+    if (!id) { process.stderr.write("usage: hivemind goal get <goal_id>\n"); process.exit(1); }
+    await goalGet(id);
     return;
   }
   if (sub === "done") {

--- a/src/hooks/codex/spawn-wiki-worker.ts
+++ b/src/hooks/codex/spawn-wiki-worker.ts
@@ -64,6 +64,9 @@ Format: **entity** (type) — what was done with it, its current state>
 ## Open Questions / TODO
 <Anything unresolved, blocked, or explicitly deferred>
 
+## Next Steps
+<The single concrete next action to resume with, as one imperative line (e.g. "Wire the resume-brief Next Steps fallback and run the tests"). If the session reached a clean stopping point with nothing pending, write exactly: none>
+
 IMPORTANT: Be exhaustive. Extract EVERY entity, decision, and fact.
 PRIVACY: Never include absolute filesystem paths in the summary.
 LENGTH LIMIT: Keep the total summary under 4000 characters.`;

--- a/src/hooks/cursor/spawn-wiki-worker.ts
+++ b/src/hooks/cursor/spawn-wiki-worker.ts
@@ -64,6 +64,9 @@ Format: **entity** (type) — what was done with it, its current state>
 ## Open Questions / TODO
 <Anything unresolved, blocked, or explicitly deferred>
 
+## Next Steps
+<The single concrete next action to resume with, as one imperative line (e.g. "Wire the resume-brief Next Steps fallback and run the tests"). If the session reached a clean stopping point with nothing pending, write exactly: none>
+
 IMPORTANT: Be exhaustive. Extract EVERY entity, decision, and fact.
 PRIVACY: Never include absolute filesystem paths in the summary.
 LENGTH LIMIT: Keep the total summary under 4000 characters.`;

--- a/src/hooks/hermes/spawn-wiki-worker.ts
+++ b/src/hooks/hermes/spawn-wiki-worker.ts
@@ -65,6 +65,9 @@ Format: **entity** (type) — what was done with it, its current state>
 ## Open Questions / TODO
 <Anything unresolved, blocked, or explicitly deferred>
 
+## Next Steps
+<The single concrete next action to resume with, as one imperative line (e.g. "Wire the resume-brief Next Steps fallback and run the tests"). If the session reached a clean stopping point with nothing pending, write exactly: none>
+
 IMPORTANT: Be exhaustive. Extract EVERY entity, decision, and fact.
 PRIVACY: Never include absolute filesystem paths in the summary.
 LENGTH LIMIT: Keep the total summary under 4000 characters.`;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -56,6 +56,13 @@ Tool choice on this mount:
   ❌ Built-in Grep tool — not supported on this path; use Bash grep instead.
   ❌ \`grep\` without a \`summaries/\` or \`sessions/\` suffix — too noisy, drowns the answer.
 
+Resuming work (user says "pick up where I left off" / "load that from hivemind" / "continue where we stopped"):
+  The resume target is the most recent session summary for the CURRENT project. Find and load it from the VFS — do not wait for or expect it to be pre-loaded:
+  1. \`cat ~/.deeplake/memory/index.md\` and take the newest rows whose \`Project\` matches this repo (or \`ls -t ~/.deeplake/memory/summaries/<your-username>/\` for the latest files).
+  2. \`cat\` the newest matching summary. If its \`## Next Steps\` (or older \`## Open Questions / TODO\`) is empty or says "none", move to the next-newest until you find one with real open work.
+  3. Load THAT summary as context, then RECONCILE with the current git state (branch, uncommitted changes) before acting — the summary can be stale. Tell the user where they left off and confirm before continuing; don't silently execute the next step.
+  4. Don't bulk-read \`sessions/\` — drill into the raw jsonl only for a specific detail the summary is missing.
+
 Organization management — each argument is SEPARATE (do NOT quote subcommands together):
 - hivemind login                              — SSO login
 - hivemind whoami                             — show current user/org

--- a/src/hooks/spawn-wiki-worker.ts
+++ b/src/hooks/spawn-wiki-worker.ts
@@ -65,6 +65,9 @@ Example: "- The memory table uses DELETE+INSERT, not UPDATE (WASM doesn't suppor
 ## Open Questions / TODO
 <Anything unresolved, blocked, or explicitly deferred>
 
+## Next Steps
+<The single concrete next action to resume with, as one imperative line (e.g. "Wire the resume-brief Next Steps fallback and run the tests"). If the session reached a clean stopping point with nothing pending, write exactly: none>
+
 IMPORTANT: Be exhaustive. Extract EVERY entity, decision, and fact. Future you will search this wiki to answer questions like "who worked on X", "why did we choose Y", "what's the status of Z". If a detail exists in the session, it should be in the wiki.
 
 PRIVACY: Never include absolute filesystem paths (e.g. /home/user/..., /Users/..., C:\\\\...) in the summary. Use only project-relative paths or the project name. The Source and Project fields above are already correct — do not change them.

--- a/src/notifications/sources/resume-brief.ts
+++ b/src/notifications/sources/resume-brief.ts
@@ -43,10 +43,18 @@ const log = (m: string) => _log("notifications-resume-brief", m);
 /** Max length of the surfaced "next step" line — one terminal row. */
 const MAX_LINE_CHARS = 120;
 
-/** How many recent summaries to walk, newest-first, looking for the most
+/** How many real summaries to walk, newest-first, looking for the most
  *  recent session that left open work. A project untouched for a while
  *  resuming on an older-but-real TODO is fine. */
 const LOOKBACK = 5;
+
+/** How many raw rows to pull before filtering. The memory table carries a
+ *  SessionStart *placeholder* row per session (a skeleton with no `##`
+ *  content section until the wiki worker fills it at SessionEnd) and can
+ *  hold duplicate rows per session. Both would otherwise consume the
+ *  LOOKBACK window and shadow the real summaries underneath, so we
+ *  over-fetch, dedup by path, drop placeholders, then keep LOOKBACK reals. */
+const SCAN_LIMIT = 40;
 
 /** Hard cap on the lookup. DeeplakeApi.query retries ~3.5s on an unreachable
  *  endpoint; the SessionStart hook budget is 5s and fetchOrgStats already
@@ -110,6 +118,48 @@ export function extractNextSteps(summary: string): string {
   return "";
 }
 
+/**
+ * A SessionStart placeholder is a metadata skeleton (`# Session …` title +
+ * bullet lines, `Status: in-progress`) with no `## ` content section yet —
+ * the wiki worker hasn't summarized the session. A real summary always has
+ * at least one `## ` section (`## What Happened`, `## Open Questions / TODO`,
+ * `## Next Steps`, …). Treat anything without a `## ` heading as a placeholder
+ * so it never counts as "wrapped clean" or shadows a real summary.
+ */
+export function isPlaceholderSummary(summary: string): boolean {
+  return !/^##\s+/m.test(summary);
+}
+
+export interface SummaryRow {
+  summary?: unknown;
+  path?: unknown;
+  last_update_date?: unknown;
+}
+
+/**
+ * From raw newest-first rows, keep the most recent REAL summary per session
+ * (dedup by path), drop placeholders, and cap at `lookback`. Pure so the
+ * windowing — the part that was silently broken — is unit-testable without
+ * the network.
+ */
+export function selectRealSummaries(
+  rows: SummaryRow[],
+  lookback = LOOKBACK,
+): { summary: string; date: string | undefined }[] {
+  const seenPath = new Set<string>();
+  const out: { summary: string; date: string | undefined }[] = [];
+  for (const row of rows) {
+    const path = typeof row.path === "string" ? row.path : "";
+    if (path && seenPath.has(path)) continue; // duplicate row for a session we already took
+    if (path) seenPath.add(path);
+    const summary = typeof row.summary === "string" ? row.summary : "";
+    if (isPlaceholderSummary(summary)) continue; // SessionStart skeleton — skip
+    out.push({ summary, date: typeof row.last_update_date === "string" ? row.last_update_date : undefined });
+    if (out.length >= lookback) break;
+  }
+  return out;
+}
+
 function truncate(s: string, max = MAX_LINE_CHARS): string {
   const clean = s.replace(/\s+/g, " ").trim();
   if (clean.length <= max) return clean;
@@ -167,27 +217,36 @@ export async function pickResumeBrief(
       table,
     );
 
-    // Last LOOKBACK summaries for THIS project by THIS user, newest first.
-    const rows = await withTimeout(
+    // Over-fetch recent rows for THIS project by THIS user, newest first.
+    // SessionStart placeholders + duplicate rows live here too, so we filter
+    // them out below rather than trusting a raw LIMIT.
+    const rawRows = await withTimeout(
       api.query(
-        `SELECT summary, last_update_date FROM "${table}" ` +
+        `SELECT summary, path, last_update_date FROM "${table}" ` +
           `WHERE project = '${sqlStr(project)}' AND author = '${sqlStr(creds.userName)}' ` +
-          `AND summary <> '' ORDER BY last_update_date DESC LIMIT ${LOOKBACK}`,
+          `AND summary <> '' ORDER BY last_update_date DESC LIMIT ${SCAN_LIMIT}`,
       ),
       QUERY_TIMEOUT_MS,
       null,
     );
-    if (!rows || rows.length === 0) {
+    if (!rawRows || rawRows.length === 0) {
       log(`silent (no prior summary for project=${project})`);
       return null; // outcome 3 — plain welcome
     }
 
+    // Dedup by session + drop placeholders so the walk-back lands on real
+    // summaries instead of in-progress skeletons.
+    const reals = selectRealSummaries(rawRows as SummaryRow[]);
+    if (reals.length === 0) {
+      log(`silent (only placeholders for project=${project})`);
+      return null; // no real summary yet — don't claim "wrapped clean"
+    }
+
     // Walk newest-first for the most recent session with real open work.
-    for (const row of rows) {
-      const summary = typeof row.summary === "string" ? row.summary : "";
-      const next = extractNextSteps(summary);
+    for (const r of reals) {
+      const next = extractNextSteps(r.summary);
       if (next.length >= 4) {
-        const age = relativeAge(row.last_update_date as string | undefined);
+        const age = relativeAge(r.date);
         const when = age ? ` (${age})` : "";
         log(`fired (project=${project}, open work)`);
         return {
@@ -199,8 +258,8 @@ export async function pickResumeBrief(
       }
     }
 
-    // outcome 2 — summaries exist, but every recent session wrapped clean.
-    const age = relativeAge(rows[0].last_update_date as string | undefined);
+    // outcome 2 — real summaries exist, but every recent session wrapped clean.
+    const age = relativeAge(reals[0].date);
     const when = age ? ` ${age}` : "";
     log(`fired (project=${project}, no open work)`);
     return { brief: `Picking up on ${project} — last session${when} wrapped up clean, nothing pending.` };

--- a/src/notifications/sources/resume-brief.ts
+++ b/src/notifications/sources/resume-brief.ts
@@ -5,22 +5,30 @@
  * "where did I leave off?" from their captured Hivemind summaries.
  *
  * It is the gated half of the pair: it only ever runs when creds are
- * present (the caller passes null-or-creds), so the "sign in and future
- * sessions start with what you've learned" promise is literally what this
- * delivers. No creds → this never runs → no payoff. That IS the gate.
+ * present (the caller passes null-or-creds). No creds → never runs → no
+ * payoff. That IS the gate.
  *
- * Source: the `memory` table (one row per session summary, written by the
- * wiki worker). We take the most recent summary for the CURRENT project
- * authored by the current user, and surface its first meaningful line as
- * the resume pointer.
+ * Source: the `memory` table (one row per session summary). We pull the last
+ * few summaries for the CURRENT project by THIS user and surface the most
+ * recent unfinished work as a "pick up where you left off" pointer.
  *
- * High-precision-or-silent: returns null when there's no prior summary for
- * this project (e.g. the user's genuine first signed-in session, or they're
- * in a fresh repo). The caller falls back to the plain welcome — never a
- * broken "where you left off" with nothing behind it.
+ * Resolution (newest-first over the last LOOKBACK summaries):
+ *   1. First session with real open work → "you left off here: <next step>"
+ *      + a pick-it-up call to action.
+ *   2. Summaries exist but every recent session wrapped clean → a brief with
+ *      NO call to action ("wrapped up clean, nothing pending") — we don't
+ *      invent an action that isn't there.
+ *   3. No summaries for this project at all → null; the caller renders the
+ *      plain welcome (no whiff).
  *
- * Failure mode: any error (network/auth/missing table) returns null. The
- * banner renders as a normal welcome; the SessionStart hook is unaffected.
+ * "Open work" comes from the summary's `## Next Steps` section (preferred)
+ * or the older `## Open Questions / TODO`. An empty / "none" section counts
+ * as wrapped-clean.
+ *
+ * userVisibleOnly: the caller renders this in the user's terminal only,
+ * never the model's additionalContext.
+ *
+ * Failure mode: any error (network/auth/missing table) returns null.
  */
 
 import type { Credentials } from "../../commands/auth-creds.js";
@@ -32,18 +40,20 @@ import { log as _log } from "../../utils/debug.js";
 
 const log = (m: string) => _log("notifications-resume-brief", m);
 
-/** Max length of the surfaced "left off" line — one terminal row at typical
- *  widths. Long summary headers get cut at a word boundary with an ellipsis. */
+/** Max length of the surfaced "next step" line — one terminal row. */
 const MAX_LINE_CHARS = 120;
 
-/** Hard cap on the summary lookup. DeeplakeApi.query retries ~3.5s on an
- *  unreachable endpoint; the SessionStart hook budget is 5s and fetchOrgStats
- *  already spends up to 1.5s before us. Race the query against this so a slow
- *  or down backend degrades to a plain welcome instead of stalling the hook. */
+/** How many recent summaries to walk, newest-first, looking for the most
+ *  recent session that left open work. A project untouched for a while
+ *  resuming on an older-but-real TODO is fine. */
+const LOOKBACK = 5;
+
+/** Hard cap on the lookup. DeeplakeApi.query retries ~3.5s on an unreachable
+ *  endpoint; the SessionStart hook budget is 5s and fetchOrgStats already
+ *  spends up to 1.5s before us. Race it so a slow backend degrades to a
+ *  plain welcome instead of stalling the hook. */
 const QUERY_TIMEOUT_MS = 1_500;
 
-/** Resolve to `fallback` if `p` hasn't settled within `ms`. The timer is
- *  unref'd so a pending query can't keep the process alive past the hook. */
 function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
   return new Promise<T>((resolve) => {
     const t = setTimeout(() => resolve(fallback), ms);
@@ -59,28 +69,43 @@ export interface ResumeBrief {
   brief: string;
 }
 
-/** The first substantive prose sentence of a summary.
- *
- * Wiki summaries open with boilerplate that is useless as a resume pointer:
- * a `# Session <uuid>` title, a `- **Started/Ended/Project**:` metadata
- * block, and `## Section` headers — and the template varies across plugin
- * versions (only ~20% use a `## What Happened` header), so we can't key on
- * one section name. Instead we skip every non-prose line — headings,
- * bullets, and `**Label**` lines (the People/Entities sections) — and return
- * the first real sentence of the first prose paragraph (the "what happened"
- * narrative). Returns "" when nothing qualifies.
- *
- * Sentence cut requires whitespace/end after the `.!?` so mid-token dots
- * (`module.json`, `v0.6.25`) don't truncate the sentence early. */
-export function firstProseSentence(summary: string): string {
+/** Parse a wiki summary into a header→body map keyed by lowercased
+ *  `## Header`. Body is everything up to the next `##` heading. */
+function sections(summary: string): Map<string, string> {
+  const map = new Map<string, string>();
+  let cur: string | null = null;
+  let buf: string[] = [];
   for (const raw of summary.split(/\r?\n/)) {
-    const line = raw.trim();
+    const h = raw.match(/^##\s+(.*?)\s*$/);
+    if (h) {
+      if (cur) map.set(cur.toLowerCase(), buf.join("\n").trim());
+      cur = h[1]; buf = [];
+    } else if (cur !== null) {
+      buf.push(raw);
+    }
+  }
+  if (cur) map.set(cur.toLowerCase(), buf.join("\n").trim());
+  return map;
+}
+
+/** Treat these as "nothing left" even when the section is present. */
+const EMPTY_SECTION = /^(none|n\/?a|n\.a\.|nothing|nothing pending|tbd|—|-)\.?$/i;
+
+/**
+ * The "what to resume" pointer for one summary, or "" when the session
+ * wrapped clean. Prefers `## Next Steps`; falls back to the older
+ * `## Open Questions / TODO`. Returns the first real line of that section
+ * (bullet markers stripped), truncated to one row.
+ */
+export function extractNextSteps(summary: string): string {
+  const s = sections(summary);
+  const body = s.get("next steps") || s.get("open questions / todo") || s.get("open questions") || "";
+  if (!body) return "";
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.replace(/^[\s>]*[-*]?\s*/, "").replace(/^#+\s*/, "").replace(/[`*_]/g, "").trim();
     if (!line) continue;
-    if (line.startsWith("#")) continue;                  // # title / ## section
-    if (line.startsWith("-") || line.startsWith("*")) continue; // bullets / metadata
-    if (line.startsWith("**")) continue;                 // **Label** — value rows
-    const m = line.match(/^.*?[.!?](\s|$)/);
-    return (m ? m[0] : line).trim();
+    if (EMPTY_SECTION.test(line)) return "";
+    return truncate(line);
   }
   return "";
 }
@@ -94,9 +119,8 @@ function truncate(s: string, max = MAX_LINE_CHARS): string {
   return cut.trimEnd() + "…";
 }
 
-/** "3 days ago" / "yesterday" / "earlier today" from an ISO-ish timestamp.
- *  Returns "" when the timestamp is missing/unparseable so the caller can
- *  drop the clause rather than render "(Invalid Date)". */
+/** "3 days ago" / "yesterday" / "earlier today" from an ISO-ish timestamp,
+ *  or "" when missing/unparseable so the caller can drop the clause. */
 function relativeAge(iso: string | undefined): string {
   if (!iso) return "";
   const then = new Date(iso);
@@ -110,10 +134,9 @@ function relativeAge(iso: string | undefined): string {
 }
 
 /**
- * Build the resume brief for a signed-in user, or null when there's
- * nothing to resume. Only called with non-null creds — the creds gate
- * lives in the caller (primary-banner), which routes anonymous users to
- * the signup brief instead.
+ * Build the resume brief for a signed-in user, or null. Only called with
+ * non-null creds — the gate lives in the caller (primary-banner), which
+ * routes anonymous users to the signup brief instead.
  */
 export async function pickResumeBrief(
   creds: Credentials | null | undefined,
@@ -126,11 +149,9 @@ export async function pickResumeBrief(
   try {
     const cfg = loadConfig();
     // sqlIdent throws on anything outside [A-Za-z_][A-Za-z0-9_]*. The table
-    // name comes from HIVEMIND_TABLE (loadConfig) and is interpolated into
-    // FROM "${table}" below — sqlStr only escapes string LITERALS, not
-    // identifiers, so a name containing a double-quote could break out of
-    // the quoted identifier. Validate it; on a bad value, log and bail to a
-    // plain welcome rather than run an attacker-shaped query.
+    // name comes from HIVEMIND_TABLE — interpolated into FROM "${table}"
+    // below, and sqlStr only escapes literals, not identifiers. Validate it;
+    // on a bad value, bail to a plain welcome.
     let table: string;
     try {
       table = sqlIdent(cfg?.tableName ?? "memory");
@@ -146,37 +167,43 @@ export async function pickResumeBrief(
       table,
     );
 
-    // Most recent summary for THIS project by THIS user. summary != ''
-    // skips placeholder rows; ORDER BY last_update_date DESC takes the
-    // latest. LIMIT 1 — we only need the one resume pointer.
+    // Last LOOKBACK summaries for THIS project by THIS user, newest first.
     const rows = await withTimeout(
       api.query(
-        `SELECT summary, project, last_update_date FROM "${table}" ` +
+        `SELECT summary, last_update_date FROM "${table}" ` +
           `WHERE project = '${sqlStr(project)}' AND author = '${sqlStr(creds.userName)}' ` +
-          `AND summary <> '' ORDER BY last_update_date DESC LIMIT 1`,
+          `AND summary <> '' ORDER BY last_update_date DESC LIMIT ${LOOKBACK}`,
       ),
       QUERY_TIMEOUT_MS,
       null,
     );
     if (!rows || rows.length === 0) {
       log(`silent (no prior summary for project=${project})`);
-      return null;
+      return null; // outcome 3 — plain welcome
     }
 
-    const summary = typeof rows[0].summary === "string" ? rows[0].summary : "";
-    const line = truncate(firstProseSentence(summary));
-    if (line.length < 8) return null; // no usable prose (boilerplate-only summary)
+    // Walk newest-first for the most recent session with real open work.
+    for (const row of rows) {
+      const summary = typeof row.summary === "string" ? row.summary : "";
+      const next = extractNextSteps(summary);
+      if (next.length >= 4) {
+        const age = relativeAge(row.last_update_date as string | undefined);
+        const when = age ? ` (${age})` : "";
+        log(`fired (project=${project}, open work)`);
+        return {
+          brief:
+            `Picking up on ${project}${when} — you left off here:\n` +
+            `   📌 ${next}\n` +
+            `   Ask me for the full thread whenever you're ready.`,
+        }; // outcome 1 — with CTA
+      }
+    }
 
+    // outcome 2 — summaries exist, but every recent session wrapped clean.
     const age = relativeAge(rows[0].last_update_date as string | undefined);
-    const when = age ? ` (${age})` : "";
-
-    const brief =
-      `Picking up on ${project}${when} — last time you left off here:\n` +
-      `   📌 ${line}\n` +
-      `   Ask me for the full thread whenever you're ready.`;
-
-    log(`fired (project=${project})`);
-    return { brief };
+    const when = age ? ` ${age}` : "";
+    log(`fired (project=${project}, no open work)`);
+    return { brief: `Picking up on ${project} — last session${when} wrapped up clean, nothing pending.` };
   } catch (e: unknown) {
     log(`pickResumeBrief: ${(e as Error).message}`);
     return null;

--- a/src/notifications/sources/resume-brief.ts
+++ b/src/notifications/sources/resume-brief.ts
@@ -107,7 +107,13 @@ const EMPTY_SECTION = /^(none|n\/?a|n\.a\.|nothing|nothing pending|tbd|—|-)\.?
  */
 export function extractNextSteps(summary: string): string {
   const s = sections(summary);
-  const body = s.get("next steps") || s.get("open questions / todo") || s.get("open questions") || "";
+  // `## Next Steps` is authoritative when present — an empty/`none` body means
+  // "wrapped clean", so do NOT fall back to the older sections (which could
+  // surface a stale TODO). Only fall back when the section is absent entirely
+  // (summaries that predate the Next Steps contract).
+  const body = s.has("next steps")
+    ? (s.get("next steps") ?? "")
+    : (s.get("open questions / todo") || s.get("open questions") || "");
   if (!body) return "";
   for (const raw of body.split(/\r?\n/)) {
     const line = raw.replace(/^[\s>]*[-*]?\s*/, "").replace(/^#+\s*/, "").replace(/[`*_]/g, "").trim();

--- a/tests/claude-code/cli-goal.test.ts
+++ b/tests/claude-code/cli-goal.test.ts
@@ -210,6 +210,58 @@ describe("runGoalCommand — add", () => {
   });
 });
 
+// ── goal add --agent (capture provenance) ───────────────────────────────────
+
+describe("runGoalCommand — add --agent (capture provenance)", () => {
+  it("default provenance stays 'manual' when --agent is absent", async () => {
+    await runGoalCommand(["add", "a plain goal"]);
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("'manual'");
+    expect(sql).not.toContain("'capture'");
+  });
+
+  it("`--agent capture` stamps the agent column as 'capture', not 'manual'", async () => {
+    await runGoalCommand(["add", "--agent", "capture", "Add rate-limiting to webhook handler"]);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("'capture'");
+    // the literal must not also carry the default
+    expect(sql).not.toMatch(/'manual', ''\)$/);
+    expect(sql).toContain("E'Add rate-limiting to webhook handler'");
+  });
+
+  it("parses --agent regardless of position relative to the text", async () => {
+    await runGoalCommand(["add", "park this", "--agent", "capture"]);
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("'capture'");
+    // flag is stripped out of the text, not joined into it
+    expect(sql).toContain("E'park this'");
+    expect(sql).not.toContain("--agent");
+  });
+
+  it("preserves a multi-line body passed as a single arg (the capture context package)", async () => {
+    const body = "Add rate-limiting to webhook handler\n\nStart here: add a per-IP token bucket\nFiles: src/webhook/handler.ts";
+    await runGoalCommand(["add", "--agent", "capture", body]);
+    const sql = queryMock.mock.calls[0][0] as string;
+    // newlines survive as real characters into the E'...' content literal
+    // (sqlStr strips other control chars but preserves \n), so a single
+    // quoted multi-line arg is enough to store the whole context package.
+    expect(sql).toContain("Start here: add a per-IP token bucket\nFiles: src/webhook/handler.ts");
+  });
+
+  it("rejects an unknown --agent value (no INSERT issued — guards the SQL literal)", async () => {
+    await expectExit(1, () => runGoalCommand(["add", "--agent", "robert'); DROP TABLE", "x"]));
+    expect(allErr()).toContain("invalid --agent");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects --agent with no value (no INSERT issued)", async () => {
+    await expectExit(1, () => runGoalCommand(["add", "x", "--agent"]));
+    expect(allErr()).toContain("--agent requires a value");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
 // ── goal list ───────────────────────────────────────────────────────────────
 
 describe("runGoalCommand — list", () => {
@@ -258,6 +310,42 @@ describe("runGoalCommand — list", () => {
     queryMock.mockRejectedValueOnce(new Error("net down"));
     await expectExit(1, () => runGoalCommand(["list"]));
     expect(allErr()).toContain("hivemind goal list: net down");
+  });
+});
+
+// ── goal get (full context package for resume) ──────────────────────────────
+
+describe("runGoalCommand — get", () => {
+  it("prints the FULL multi-line content (not just the first line) for the latest version", async () => {
+    const pkg = "Add rate-limiting to webhook handler\n\nStart here: per-IP token bucket\nFiles: src/webhook/handler.ts";
+    queryMock.mockResolvedValueOnce([{ content: pkg }]);
+    await runGoalCommand(["get", "g-uuid"]);
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toMatch(/^SELECT content FROM "hivemind_goals_test"/);
+    expect(sql).toContain(`WHERE goal_id = 'g-uuid'`);
+    // latest version wins so a re-saved package isn't served stale
+    expect(sql).toContain("ORDER BY version DESC, created_at DESC LIMIT 1");
+    // whole body reaches stdout — this is what resume transfers into the session
+    expect(allOut()).toContain(pkg);
+    expect(allOut()).toContain("Files: src/webhook/handler.ts");
+  });
+
+  it("exits 1 when the goal_id is unknown (no body to transfer)", async () => {
+    queryMock.mockResolvedValueOnce([]);
+    await expectExit(1, () => runGoalCommand(["get", "missing"]));
+    expect(allErr()).toContain("goal not found: missing");
+  });
+
+  it("exits 1 with usage when goal_id is missing", async () => {
+    await expectExit(1, () => runGoalCommand(["get"]));
+    expect(allErr()).toContain("usage: hivemind goal get");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("gates on login", async () => {
+    loadConfigMock.mockReturnValue(null);
+    await expectExit(1, () => runGoalCommand(["get", "g-uuid"]));
+    expect(queryMock).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/claude-code/resume-brief.test.ts
+++ b/tests/claude-code/resume-brief.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractNextSteps } from "../../src/notifications/sources/resume-brief.js";
+import {
+  extractNextSteps,
+  isPlaceholderSummary,
+  selectRealSummaries,
+} from "../../src/notifications/sources/resume-brief.js";
 
 // Fixture mirrors the wiki-summary shape: `# Session` title, metadata, then
 // the ## sections including the new `## Next Steps`.
@@ -42,5 +46,60 @@ describe("extractNextSteps", () => {
   it("takes the first real line of a multi-line section", () => {
     expect(extractNextSteps(summary({ next: "Finish the migration\nThen write docs" })))
       .toBe("Finish the migration");
+  });
+});
+
+// A SessionStart placeholder: metadata skeleton, no `## ` content section
+// (the real shape that was shadowing summaries in prod).
+const PLACEHOLDER =
+  "# Session d3c21026\n- **Source**: /sessions/sasun/x.jsonl\n- **Started**: 2026-05-31T17:09:02.539Z\n- **Project**: hivemind\n- **Status**: in-progress\n";
+
+describe("isPlaceholderSummary", () => {
+  it("flags a SessionStart skeleton (no ## section)", () => {
+    expect(isPlaceholderSummary(PLACEHOLDER)).toBe(true);
+  });
+  it("does not flag a real summary with ## sections", () => {
+    expect(isPlaceholderSummary(summary({ open: "- do the thing" }))).toBe(false);
+  });
+});
+
+describe("selectRealSummaries (windowing)", () => {
+  it("skips placeholders so the walk-back reaches the real summary underneath", () => {
+    const real = summary({ open: "- Re-run CI on f89e70e" });
+    const rows = [
+      { summary: PLACEHOLDER, path: "/s/new.md", last_update_date: "2026-06-01" },
+      { summary: PLACEHOLDER, path: "/s/new2.md", last_update_date: "2026-05-31" },
+      { summary: real, path: "/s/real.md", last_update_date: "2026-05-27" },
+    ];
+    const reals = selectRealSummaries(rows);
+    expect(reals).toHaveLength(1);
+    expect(extractNextSteps(reals[0].summary)).toBe("Re-run CI on f89e70e");
+    expect(reals[0].date).toBe("2026-05-27");
+  });
+
+  it("dedups duplicate rows for the same session by path", () => {
+    const real = summary({ open: "- ship it" });
+    const rows = [
+      { summary: real, path: "/s/a.md", last_update_date: "2026-05-27" },
+      { summary: real, path: "/s/a.md", last_update_date: "2026-05-27" }, // duplicate
+    ];
+    expect(selectRealSummaries(rows)).toHaveLength(1);
+  });
+
+  it("returns nothing when every row is a placeholder (caller renders plain welcome, not 'wrapped clean')", () => {
+    const rows = [
+      { summary: PLACEHOLDER, path: "/s/1.md", last_update_date: "2026-06-01" },
+      { summary: PLACEHOLDER, path: "/s/2.md", last_update_date: "2026-05-31" },
+    ];
+    expect(selectRealSummaries(rows)).toEqual([]);
+  });
+
+  it("caps at the lookback after filtering", () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      summary: summary({ open: `- task ${i}` }),
+      path: `/s/${i}.md`,
+      last_update_date: `2026-05-${20 + i}`,
+    }));
+    expect(selectRealSummaries(rows, 5)).toHaveLength(5);
   });
 });

--- a/tests/claude-code/resume-brief.test.ts
+++ b/tests/claude-code/resume-brief.test.ts
@@ -1,48 +1,46 @@
 import { describe, it, expect } from "vitest";
-import { firstProseSentence } from "../../src/notifications/sources/resume-brief.js";
+import { extractNextSteps } from "../../src/notifications/sources/resume-brief.js";
 
-// Fixture mirrors the real wiki-summary shape: `# Session <uuid>` title, a
-// `- **Key**: value` metadata block, a `## What Happened` header, then the
-// prose narrative, then `## People` / `## Entities` `**Label**` rows.
-const REAL_SHAPE = `# Session 00ea4740-6969-4922-a9ee-600d939abc49
-- **Source**: /sessions/kamo/kamo_activeloop_hivemind_00ea4740.jsonl
-- **Started**: 2026-04-10T22:40:02.632Z
-- **Project**: al-projects
-- **JSONL offset**: 368
+// Fixture mirrors the wiki-summary shape: `# Session` title, metadata, then
+// the ## sections including the new `## Next Steps`.
+function summary(opts: { next?: string; open?: string; whatHappened?: string } = {}): string {
+  let s = `# Session abc\n- **Project**: indra\n\n## What Happened\n${opts.whatHappened ?? "Did stuff."}\n`;
+  if (opts.open !== undefined) s += `\n## Open Questions / TODO\n${opts.open}\n`;
+  if (opts.next !== undefined) s += `\n## Next Steps\n${opts.next}\n`;
+  return s;
+}
 
-## What Happened
-Multi-day sprint across deeplake-claude-code-plugins and hivemind repos. Fixed latency by making async hooks, debugged module.json type issues. Current version: 0.6.25.
-
-## People
-**Kamo** — user/developer — directed work across two repos
-`;
-
-describe("firstProseSentence", () => {
-  it("skips title, metadata bullets, and section headers; returns the first prose sentence", () => {
-    expect(firstProseSentence(REAL_SHAPE)).toBe(
-      "Multi-day sprint across deeplake-claude-code-plugins and hivemind repos.",
-    );
+describe("extractNextSteps", () => {
+  it("prefers the ## Next Steps section", () => {
+    const s = summary({ next: "Wire the resume fallback and run tests", open: "- something else" });
+    expect(extractNextSteps(s)).toBe("Wire the resume fallback and run tests");
   });
 
-  it("does not truncate at mid-token dots (module.json, v0.6.25)", () => {
-    const s = "## What Happened\nTouched module.json and shipped v0.6.25 today. Next bit.";
-    // The cut must land on the sentence-ending period (after 'today.'),
-    // not the dots inside module.json / v0.6.25.
-    expect(firstProseSentence(s)).toBe("Touched module.json and shipped v0.6.25 today.");
+  it("falls back to ## Open Questions / TODO when Next Steps is absent (older summaries)", () => {
+    const s = summary({ open: "- Verify the header parse on Windows" });
+    expect(extractNextSteps(s)).toBe("Verify the header parse on Windows");
   });
 
-  it("skips **Label** rows so a People/Entities-only body yields nothing", () => {
-    const s = "## People\n**Kamo** — developer\n**Emanuele** — colleague";
-    expect(firstProseSentence(s)).toBe("");
+  it("strips a leading bullet marker", () => {
+    expect(extractNextSteps(summary({ next: "- Ship the PR" }))).toBe("Ship the PR");
   });
 
-  it("returns '' for a boilerplate-only summary (no prose)", () => {
-    const s = "# Session abc\n- **Project**: x\n- **Started**: 2026-01-01";
-    expect(firstProseSentence(s)).toBe("");
+  it("treats an explicit 'none' Next Steps as wrapped-clean (empty)", () => {
+    expect(extractNextSteps(summary({ next: "none" }))).toBe("");
+    expect(extractNextSteps(summary({ next: "None." }))).toBe("");
+    expect(extractNextSteps(summary({ next: "N/A" }))).toBe("");
   });
 
-  it("falls back to the whole prose line when it has no sentence punctuation", () => {
-    const s = "## What Happened\nrefactor the deeplog stage layer";
-    expect(firstProseSentence(s)).toBe("refactor the deeplog stage layer");
+  it("returns '' when neither section is present", () => {
+    expect(extractNextSteps(summary({ whatHappened: "Just chatted." }))).toBe("");
+  });
+
+  it("returns '' for an empty section body", () => {
+    expect(extractNextSteps(summary({ next: "" }))).toBe("");
+  });
+
+  it("takes the first real line of a multi-line section", () => {
+    expect(extractNextSteps(summary({ next: "Finish the migration\nThen write docs" })))
+      .toBe("Finish the migration");
   });
 });

--- a/tests/claude-code/resume-brief.test.ts
+++ b/tests/claude-code/resume-brief.test.ts
@@ -1,9 +1,30 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+
+// Mock the network + environment boundary so pickResumeBrief's orchestration
+// (query shape, dedup/placeholder windowing, the three outcomes, relative age)
+// is testable offline — same approach as cli-goal.test.ts.
+const queryMock = vi.fn();
+vi.mock("../../src/config.js", () => ({ loadConfig: vi.fn(() => ({ tableName: "memory" })) }));
+vi.mock("../../src/utils/project-name.js", () => ({ projectNameFromCwd: vi.fn(() => "proj") }));
+vi.mock("../../src/deeplake-api.js", () => ({
+  DeeplakeApi: class {
+    constructor() { /* creds ignored under test */ }
+    query(sql: string) { return queryMock(sql); }
+  },
+}));
+
 import {
   extractNextSteps,
   isPlaceholderSummary,
   selectRealSummaries,
+  pickResumeBrief,
 } from "../../src/notifications/sources/resume-brief.js";
+import { loadConfig } from "../../src/config.js";
+import { projectNameFromCwd } from "../../src/utils/project-name.js";
+
+const loadConfigMock = loadConfig as unknown as ReturnType<typeof vi.fn>;
+const projectMock = projectNameFromCwd as unknown as ReturnType<typeof vi.fn>;
+const CREDS = { token: "t", userName: "u", orgId: "o", workspaceId: "w", apiUrl: "https://api" } as never;
 
 // Fixture mirrors the wiki-summary shape: `# Session` title, metadata, then
 // the ## sections including the new `## Next Steps`.
@@ -39,8 +60,18 @@ describe("extractNextSteps", () => {
     expect(extractNextSteps(summary({ whatHappened: "Just chatted." }))).toBe("");
   });
 
+  it("falls back to a bare ## Open Questions heading (no '/ TODO')", () => {
+    const s = "# Session x\n## What Happened\nstuff\n\n## Open Questions\n- Check the Windows path\n";
+    expect(extractNextSteps(s)).toBe("Check the Windows path");
+  });
+
   it("returns '' for an empty section body", () => {
     expect(extractNextSteps(summary({ next: "" }))).toBe("");
+  });
+
+  it("returns '' when the section body is only an empty bullet marker", () => {
+    // body is non-empty ("-") but every line strips to nothing → fall through
+    expect(extractNextSteps(summary({ next: "-" }))).toBe("");
   });
 
   it("takes the first real line of a multi-line section", () => {
@@ -86,6 +117,16 @@ describe("selectRealSummaries (windowing)", () => {
     expect(selectRealSummaries(rows)).toHaveLength(1);
   });
 
+  it("tolerates rows with no path (can't dedup) and no summary (treated as placeholder)", () => {
+    const real = summary({ open: "- do it" });
+    const rows = [
+      { summary: real, last_update_date: "2026-05-27" },           // no path
+      { last_update_date: "2026-05-26" },                          // no summary → placeholder, skipped
+      { summary: real, last_update_date: "2026-05-25" },           // no path
+    ];
+    expect(selectRealSummaries(rows)).toHaveLength(2);
+  });
+
   it("returns nothing when every row is a placeholder (caller renders plain welcome, not 'wrapped clean')", () => {
     const rows = [
       { summary: PLACEHOLDER, path: "/s/1.md", last_update_date: "2026-06-01" },
@@ -101,5 +142,130 @@ describe("selectRealSummaries (windowing)", () => {
       last_update_date: `2026-05-${20 + i}`,
     }));
     expect(selectRealSummaries(rows, 5)).toHaveLength(5);
+  });
+});
+
+describe("pickResumeBrief", () => {
+  const real = (next: string) => `# Session x\n## What Happened\nstuff\n\n## Next Steps\n${next}\n`;
+  const placeholder = "# Session x\n- **Status**: in-progress\n";
+
+  beforeEach(() => {
+    queryMock.mockReset().mockResolvedValue([]);
+    loadConfigMock.mockReset().mockReturnValue({ tableName: "memory" });
+    projectMock.mockReset().mockReturnValue("proj");
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns null without usable creds — the gate, no query issued", async () => {
+    expect(await pickResumeBrief(null)).toBeNull();
+    expect(await pickResumeBrief({ token: "", userName: "u", orgId: "o" } as never)).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the cwd resolves to no project", async () => {
+    projectMock.mockReturnValue("");
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on an invalid table identifier (never queries)", async () => {
+    loadConfigMock.mockReturnValue({ tableName: "bad name!" });
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes the query to project + author, newest-first", async () => {
+    queryMock.mockResolvedValue([{ summary: real("Ship it"), path: "/s/a.md", last_update_date: "2026-05-30" }]);
+    await pickResumeBrief(CREDS);
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain("project = 'proj'");
+    expect(sql).toContain("author = 'u'");
+    expect(sql).toContain("ORDER BY last_update_date DESC");
+  });
+
+  it("outcome 3 — no summaries at all → null (plain welcome)", async () => {
+    queryMock.mockResolvedValue([]);
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+  });
+
+  it("only placeholders → null (must NOT claim 'wrapped clean')", async () => {
+    queryMock.mockResolvedValue([
+      { summary: placeholder, path: "/s/1.md", last_update_date: "2026-06-01" },
+      { summary: placeholder, path: "/s/2.md", last_update_date: "2026-05-31" },
+    ]);
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+  });
+
+  it("outcome 1 — surfaces the next step from the most recent real summary, skipping a newer placeholder", async () => {
+    queryMock.mockResolvedValue([
+      { summary: placeholder, path: "/s/new.md", last_update_date: "2026-06-01" },
+      { summary: real("Wire the fallback and run tests"), path: "/s/real.md", last_update_date: "2026-05-30" },
+    ]);
+    const b = await pickResumeBrief(CREDS);
+    expect(b?.brief).toContain("Picking up on proj");
+    expect(b?.brief).toContain("you left off here");
+    expect(b?.brief).toContain("Wire the fallback and run tests");
+  });
+
+  it("outcome 2 — real summaries but every one wrapped clean → no CTA", async () => {
+    queryMock.mockResolvedValue([
+      { summary: real("none"), path: "/s/a.md", last_update_date: "2026-05-30" },
+    ]);
+    const b = await pickResumeBrief(CREDS);
+    expect(b?.brief).toContain("wrapped up clean, nothing pending");
+    expect(b?.brief).not.toContain("you left off here");
+  });
+
+  it("truncates a long next-step line to one terminal row", async () => {
+    queryMock.mockResolvedValue([{ summary: real("Do " + "x".repeat(200)), path: "/s/a.md", last_update_date: "2026-05-30" }]);
+    const b = await pickResumeBrief(CREDS);
+    expect(b!.brief).toContain("…");
+  });
+
+  it("returns null when the query throws (withTimeout swallows to the null fallback)", async () => {
+    queryMock.mockRejectedValue(new Error("net down"));
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+  });
+
+  it("returns null if anything in the body throws (outer guard)", async () => {
+    loadConfigMock.mockImplementation(() => { throw new Error("boom"); });
+    expect(await pickResumeBrief(CREDS)).toBeNull();
+  });
+
+  it("truncates a long next step on a word boundary, not mid-word", async () => {
+    const longSpaced = Array.from({ length: 40 }, (_, i) => `word${i}`).join(" "); // >120 chars, spaces throughout
+    queryMock.mockResolvedValue([{ summary: real(longSpaced), path: "/s/a.md", last_update_date: "2026-05-30" }]);
+    const b = await pickResumeBrief(CREDS);
+    expect(b!.brief).toMatch(/word\d+…/); // cut at a space then ellipsis
+  });
+
+  it("drops the age clause when the date is missing or unparseable", async () => {
+    // missing date → relativeAge sees undefined
+    queryMock.mockResolvedValue([{ summary: real("Resume A"), path: "/s/a.md" }]);
+    let b = await pickResumeBrief(CREDS);
+    expect(b?.brief).toContain("Picking up on proj — you left off here");
+    expect(b?.brief).not.toContain("(");
+    // unparseable date → relativeAge sees NaN
+    queryMock.mockResolvedValue([{ summary: real("Resume B"), path: "/s/b.md", last_update_date: "not-a-date" }]);
+    b = await pickResumeBrief(CREDS);
+    expect(b?.brief).toContain("you left off here");
+    expect(b?.brief).not.toContain("(");
+  });
+
+  it("renders each relative-age bucket", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+    const cases: Array<[string, string]> = [
+      ["2026-06-01T06:00:00Z", "earlier today"],
+      ["2026-05-31T12:00:00Z", "yesterday"],
+      ["2026-05-29T12:00:00Z", "3 days ago"],
+      ["2026-05-22T12:00:00Z", "last week"],
+      ["2026-05-11T12:00:00Z", "weeks ago"],
+    ];
+    for (const [date, expected] of cases) {
+      queryMock.mockResolvedValue([{ summary: real("Resume X"), path: "/s/a.md", last_update_date: date }]);
+      const b = await pickResumeBrief(CREDS);
+      expect(b?.brief).toContain(expected);
+    }
   });
 });

--- a/tests/claude-code/resume-brief.test.ts
+++ b/tests/claude-code/resume-brief.test.ts
@@ -65,6 +65,19 @@ describe("extractNextSteps", () => {
     expect(extractNextSteps(s)).toBe("Check the Windows path");
   });
 
+  it("treats a present-but-blank ## Next Steps as wrapped-clean — does NOT fall back to a stale TODO", () => {
+    // New-format summary: the heading exists but the worker wrote no body.
+    // Next Steps is authoritative when present, so this must resolve to "" even
+    // though there's a stale Open Questions / TODO underneath.
+    const s = summary({ next: "", open: "- stale: re-run the old migration" });
+    expect(extractNextSteps(s)).toBe("");
+  });
+
+  it("still falls back to ## Open Questions / TODO only when ## Next Steps is absent", () => {
+    const s = summary({ open: "- Verify header parse on Windows" }); // no Next Steps section at all
+    expect(extractNextSteps(s)).toBe("Verify header parse on Windows");
+  });
+
   it("returns '' for an empty section body", () => {
     expect(extractNextSteps(summary({ next: "" }))).toBe("");
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -367,6 +367,11 @@ export default defineConfig({
         "src/notifications/rules/registry.ts":    { statements: 90, branches: 90, functions: 90, lines: 90 },
         "src/notifications/rules/welcome.ts":     { statements: 90, branches: 90, functions: 90, lines: 90 },
         "src/notifications/sources/backend.ts":   { statements: 90, branches: 90, functions: 80, lines: 90 },
+        // feat/resume-next-steps — resume-brief windowing (skip placeholders +
+        // dedup) and the goal capture/get CLI. pickResumeBrief is exercised via
+        // a mocked DeeplakeApi boundary (see resume-brief.test.ts).
+        "src/notifications/sources/resume-brief.ts": { statements: 90, branches: 90, functions: 90, lines: 90 },
+        "src/commands/goal.ts":                   { statements: 90, branches: 90, functions: 90, lines: 90 },
         "src/notifications/delivery/index.ts":    { statements: 90, branches: 90, functions: 90, lines: 90 },
         "src/notifications/delivery/claude-code.ts": { statements: 90, branches: 90, functions: 90, lines: 90 },
         // feat/hivemind-savings-recap — per-session "Hivemind has saved you Nk tokens"


### PR DESCRIPTION
## Resume "pick up where you left off" — now actually fires

Two related pieces so a new session reliably resumes prior work.

### 1. Resume-brief: stop the pickup from being starved (bug fix)
`pickResumeBrief` was correct but **starved**. The `memory` table carries a
SessionStart **placeholder** row per session (a skeleton with no `##` section
until the wiki worker fills it at SessionEnd), plus duplicate rows per session.
Those filled the `LIMIT 5` window, so the walk-back never reached real
summaries and every session looked *"wrapped up clean."*

- over-fetch (`SCAN_LIMIT=40`), **dedup by session path**, **drop
  placeholders**, then walk `LOOKBACK` real summaries
- when only placeholders exist → return `null` (plain welcome) instead of
  falsely claiming *"wrapped clean"*
- pulled the windowing into pure `isPlaceholderSummary` + `selectRealSummaries`
  so it's unit-tested without the network

Verified against real data — now surfaces:
> Picking up on hivemind (5 days ago) — you left off here:
>    📌 Pending: CI re-run against commit f89e70e on fix/skip-missing-table-reads branch…

### 2. `## Next Steps` parity across agents
claude-code already emitted a dedicated `## Next Steps`; added it to the
codex / cursor / hermes wiki-worker prompts too. resume-brief prefers it and
falls back to `## Open Questions / TODO` for older summaries.

## Capture a task with context, resume it later (new feature)

Explicit, in-session **Save↔Resume** pair on the existing goals primitive — no
Stop-hook / gate / detached worker (the auto-detection design is deferred; see
`docs/CAPTURE_TASKS.md` for the decision record).

- **Save** — *"save this for later"* writes a goal whose body is a resumable
  **context package**: label + `Start here / Files / Branch / Run / Why`, filled
  from the live conversation.
- **Resume** — *"let's work on that task"* finds the goal, pulls the **full**
  body back, flips it to `in_progress`, and continues from `Start here:` — no
  re-explaining.
- **CLI:** `goal add --agent capture` (provenance, allowlisted) and
  `goal get <goal_id>` (full-body read — `goal list` only showed the first
  line, so resume had no way to transfer the package back).
- capture/resume operations added to all four agent skill copies
  (claude-code / codex / hermes / openclaw).

## Tests
- `resume-brief.test.ts`: placeholder detection, dedup, placeholder-shadowing,
  lookback cap, all-placeholders→null.
- `cli-goal.test.ts`: `--agent capture` vs default, agent allowlist guard,
  multi-line body preservation, full-body `goal get`.
- Full suite green (3658 tests).
