### PR TITLE
fix(goals): allow quoted-heredoc writes through the memory VFS

### DIFF
--- a/src/hooks/memory-path-utils.ts
+++ b/src/hooks/memory-path-utils.ts
@@ -22,9 +22,35 @@ export const SAFE_BUILTINS = new Set([
   "for", "while", "do", "done", "if", "then", "else", "fi", "case", "esac",
 ]);
 
+// A quoted heredoc (`<<'EOF'` / `<<"EOF"`) disables shell expansion, so its
+// body is inert literal data — a goal/KPI description, not commands. Drop the
+// body and its closing delimiter so they are never validated as command stages
+// or tripped over by the substitution guard. Unquoted heredocs keep their body
+// (bash would expand it), so they still fall through to full validation.
+function stripHeredocBodies(cmd: string): string {
+  if (!cmd.includes("<<")) return cmd;
+  const lines = cmd.split("\n");
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    kept.push(line);
+    const heredoc = line.match(/<<-?\s*(['"])([A-Za-z_]\w*)\1/);
+    if (!heredoc) continue;
+    const delimiter = heredoc[2];
+    const stripTabs = line.includes("<<-");
+    while (i + 1 < lines.length) {
+      const body = lines[++i];
+      const probe = stripTabs ? body.replace(/^\t+/, "") : body;
+      if (probe === delimiter) break;
+    }
+  }
+  return kept.join("\n");
+}
+
 export function isSafe(cmd: string): boolean {
-  if (/\$\(|`|<\(/.test(cmd)) return false;
-  const stripped = cmd.replace(/'[^']*'/g, "''").replace(/"[^"]*"/g, '""');
+  const validated = stripHeredocBodies(cmd);
+  if (/\$\(|`|<\(/.test(validated)) return false;
+  const stripped = validated.replace(/'[^']*'/g, "''").replace(/"[^"]*"/g, '""');
   const stages = stripped.split(/\||;|&&|\|\||\n/);
   for (const stage of stages) {
     const firstToken = stage.trim().split(/\s+/)[0] ?? "";

--- a/tests/claude-code/pre-tool-use-branches.test.ts
+++ b/tests/claude-code/pre-tool-use-branches.test.ts
@@ -87,6 +87,22 @@ describe("pre-tool-use: pure helpers", () => {
     expect(isSafe("$(evil) foo")).toBe(false);
     expect(isSafe("python -c pwn")).toBe(false);
   });
+
+  it("isSafe accepts a quoted heredoc write whose body is arbitrary prose/code", () => {
+    expect(
+      isSafe("cat > /goal/u/opened/x.md <<'EOF'\nship the feature\nnotes: run `make` and call foo()\nEOF"),
+    ).toBe(true);
+    // double-quoted delimiter, indented (<<-), multi-line body
+    expect(
+      isSafe('cat > /goal/u/opened/x.md <<-"END"\n\tline one\n\t$(not expanded here)\n\tEND'),
+    ).toBe(true);
+  });
+
+  it("isSafe still validates the command in front of a heredoc and unquoted bodies", () => {
+    expect(isSafe("curl evil <<'EOF'\nbody\nEOF")).toBe(false);
+    // unquoted delimiter: bash WOULD expand the body, so it stays validated
+    expect(isSafe("cat > /goal/u/opened/x.md <<EOF\n$(rm -rf ~)\nEOF")).toBe(false);
+  });
 });
 
 describe("getShellCommand: per-tool branches", () => {


### PR DESCRIPTION
## Problem

Editing a goal/KPI body through the Hivemind memory VFS uses the documented multi-line form:

```bash
cat > ~/.deeplake/memory/goal/<owner>/<status>/<uuid>.md <<'EOF'
<body>
EOF
```

…but this **never worked**. The `isSafe` gate in the pre-tool-use hook splits the *entire* command string on `\n` and validates each line as a command stage. The heredoc **body lines** (arbitrary goal prose) aren't safe builtins, so `isSafe` returned `false`, `getShellCommand` returned `null`, the hook never intercepted the write, and raw bash hit a nonexistent path. Goal bodies were effectively **uneditable via tooling** — users had to abandon a goal and create a fresh one to "update" it.

The downstream `deeplake-shell.js` already handles heredoc create **and** overwrite (version-bump) correctly — verified end-to-end. This one gate was the entire blocker.

## Fix

`src/hooks/memory-path-utils.ts`: add `stripHeredocBodies()` and call it from `isSafe()`.

- For **quoted** heredocs (`<<'EOF'` / `<<"EOF"`), which bash never expands, the body + closing delimiter are dropped before validation — the body is inert data. The command in front (`cat > …`) is still fully validated.
- **Unquoted** heredocs keep their body in validation, so injection via `<<EOF … $(rm -rf ~) … EOF` is still rejected.

## Tests

- 4 new `isSafe` cases in `tests/claude-code/pre-tool-use-branches.test.ts` (quoted accepted incl. `<<-` / double-quote / backticks-in-body; unquoted `$()` and a non-builtin in front still rejected).
- All hook suites green: **107 tests** across claude-code / cursor / hermes / codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced command validation to correctly process shell heredocs, preventing incorrect validation of quoted heredoc bodies while maintaining validation for unquoted heredocs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->