### PR TITLE
ci: add CodeQL static analysis + CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/yaml-configuration
+# This repo-level file overrides the org UI settings for hivemind.
+language: en-US
+reviews:
+  profile: chill # fewer low-value nitpicks; "assertive" is the only alternative
+  request_changes_workflow: false
+  high_level_summary: true
+  auto_review:
+    enabled: true
+    base_branches: ["main"]
+  # Don't spend review on generated / vendored / lock artifacts.
+  path_filters:
+    - "!**/package-lock.json"
+    - "!**/bundle/**"
+    - "!**/dist/**"
+    - "!docs/screenshots/**"
+  # Repo-specific context so CodeRabbit stops re-raising known won't-fix items.
+  path_instructions:
+    - path: "src/hooks/**"
+      instructions: >
+        These pre-tool-use hooks are a best-effort STRING-based gate over a
+        virtual filesystem at ~/.deeplake/memory. They match literal path
+        patterns in the command text; they CANNOT intercept dynamically
+        computed paths (e.g. os.homedir() + "...") — do not suggest runtime
+        path resolution. Decisions are tool-shaped: Read needs file_path,
+        Bash/Grep/Glob use a command-shaped echo. The key invariant to flag is
+        that a memory-touching command must never be handed to the real host
+        shell.
+    - path: ".github/workflows/**"
+      instructions: >
+        Read-only jobs should set persist-credentials: false. The `release`
+        job legitimately persists GITHUB_TOKEN because it runs `git fetch
+        origin main` AND `git push`; only flag it if proposing a COMPLETE
+        inline-auth replacement for BOTH operations, not a partial patch.
+    - path: "tests/**"
+      instructions: >
+        Prefer asserting on specific values (paths, messages) over generic
+        substrings.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+# Static security analysis (SAST) for the TypeScript sources. Surfaces
+# command-injection / path-traversal / unsafe-shell patterns — the bug class the
+# pre-tool-use VFS hooks deal in — as alerts in the repo's Security tab and as
+# inline annotations on PRs. Findings do NOT fail the build by default; gate on
+# them later via branch protection if desired.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays 06:00 UTC) so new CodeQL queries catch latent
+    # issues even when the code itself hasn't changed.
+    - cron: "0 6 * * 1"
+
+# Least privilege at the top; the analyze job adds only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF results to the Security tab
+      actions: read # required for CodeQL on private repos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          # Read-only job: don't leave GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.36.1
+        with:
+          languages: javascript-typescript
+          # `security-extended` adds the broader security query suite on top of
+          # the default — appropriate for a security-sensitive codebase. It only
+          # surfaces more alerts; it does not fail the run.
+          queries: security-extended
+
+      # No build step: CodeQL analyzes JS/TS source directly (no compilation
+      # needed), so we skip the autobuild/manual-build phase entirely.
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4.36.1
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

Two CI/tooling additions for security & review quality:

### 1. CodeQL — `.github/workflows/codeql.yaml`
GitHub-native static analysis (SAST) for the TypeScript sources. Scans for command-injection / path-traversal / unsafe-shell patterns (the bug class the pre-tool-use VFS hooks deal in); findings land in the **Security** tab + inline PR annotations. Runs on PRs to `main`, pushes to `main`, and weekly.

Pinned to latest released action versions (repo's exact-pin convention):
- `actions/checkout@v6.0.3`
- `github/codeql-action/init@v4.36.1`, `analyze@v4.36.1`

**Non-blocking by default** — make it a required check via branch protection later to gate merges. Read-only checkout, least-privilege permissions, `persist-credentials: false`.

### 2. CodeRabbit config — `.coderabbit.yaml`
Tunes CodeRabbit based on the #211 review experience:
- `profile: chill` (fewer low-value nitpicks)
- `path_filters` exclude generated/vendored/lock artifacts (bundles, `package-lock.json`, `dist`, screenshots)
- `path_instructions` encode repo context so it stops re-raising known won't-fix items (the hooks are a string-based gate that can't resolve dynamic paths; the release job legitimately persists its push token).

> Note: a repo-level `.coderabbit.yaml` **overrides org UI settings** for this repo.

## Version Bump
No version bump — CI/tooling only, no release needed.

## Test plan
- [ ] CodeQL workflow runs green and populates the Security tab.
- [ ] CodeRabbit picks up the config on its next review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)