### PR TITLE
fix(auth): heal orgName + workspace drift, not just the token

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -239,9 +239,13 @@ export async function healDriftedOrgToken(
     const healed: Credentials = { ...creds, token: tokenData.token.token };
 
     // Realign orgName + workspaceId to creds.orgId so billingUrl() and the
-    // SessionStart banner stop pointing at the stale org. Best-effort: any
-    // failure here is swallowed so the token heal above still persists. Uses
-    // the freshly-minted token, which is bound to creds.orgId.
+    // SessionStart banner stop pointing at the stale org. Two INDEPENDENT
+    // best-effort blocks: a failed orgName lookup must not also skip the
+    // workspace repair (and vice versa) — otherwise one transient 5xx on the
+    // single session that heals the token leaves the OTHER field stale, and
+    // the heal trigger (jwt.org_id !== creds.orgId) won't re-fire next session
+    // to retry it. Both swallow errors so the token heal above still persists.
+    // Each uses the freshly-minted token, which is bound to creds.orgId.
     try {
       const orgs = await listOrgs(healed.token, apiUrl);
       const matchedOrg = orgs.find(o => o.id === creds.orgId);
@@ -249,11 +253,16 @@ export async function healDriftedOrgToken(
         log(`orgName realigned: ${creds.orgName ?? "(unset)"} -> ${matchedOrg.name}`);
         healed.orgName = matchedOrg.name;
       }
-      // "default" is the per-org sentinel the backend resolves itself, so it
-      // needs no validation. Only a concrete workspace id/name can belong to
-      // the previous org and must be re-resolved (or reset) against the new one.
-      const currentWs = creds.workspaceId ?? "default";
-      if (currentWs !== "default") {
+    } catch (e) {
+      log(`orgName realign skipped: ${(e as Error).message}`);
+    }
+
+    // "default" is the per-org sentinel the backend resolves itself, so it
+    // needs no validation. Only a concrete workspace id/name can belong to
+    // the previous org and must be re-resolved (or reset) against the new one.
+    const currentWs = creds.workspaceId ?? "default";
+    if (currentWs !== "default") {
+      try {
         const wsList = await listWorkspaces(healed.token, apiUrl, creds.orgId);
         const lcWs = currentWs.toLowerCase();
         const wsMatch = wsList.find(w => w.id === currentWs || (w.name && w.name.toLowerCase() === lcWs));
@@ -264,9 +273,9 @@ export async function healDriftedOrgToken(
           log(`workspace '${currentWs}' resolved to id '${wsMatch.id}'`);
           healed.workspaceId = wsMatch.id;
         }
+      } catch (e) {
+        log(`workspace realign skipped: ${(e as Error).message}`);
       }
-    } catch (e) {
-      log(`org/workspace realign skipped: ${(e as Error).message}`);
     }
 
     saveCredentials(healed);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -198,6 +198,22 @@ export async function switchOrg(orgId: string, orgName?: string): Promise<void> 
 // when a heal happens, the input creds when nothing to do, and the input
 // creds (after logging) when the mint fails — never throws, never blocks
 // session start.
+//
+// The same legacy regression that drifted the token also left `orgName` and
+// `workspaceId` pointing at the previous org. Re-minting the token realigns
+// every query (it carries the X-Activeloop-Org-Id header + an org-bound JWT)
+// to creds.orgId, but two consumers read the OTHER fields and would still
+// resolve to the stale org:
+//   - billingUrl() (src/deeplake-api.ts) builds the "top up" link from
+//     orgName → the user pays into the wrong org and the low-balance banner,
+//     driven by creds.orgId's real balance, never clears.
+//   - the SessionStart banner prints `org: ${orgName}` → "the shell said the
+//     wrong org".
+// So when we heal the token we also realign orgName and validate workspaceId
+// against creds.orgId. The realign is best-effort and gated behind the token
+// drift trigger: it costs one extra GET (two when a non-default workspace is
+// set) only on the rare session where drift is actually detected, and a
+// failure here must never undo the token heal.
 export async function healDriftedOrgToken(
   creds: Credentials,
   log: (msg: string) => void = () => {},
@@ -220,7 +236,39 @@ export async function healDriftedOrgToken(
       duration: 365 * 24 * 3600,
       organization_id: creds.orgId,
     }, creds.token, apiUrl) as { token: { token: string } };
-    const healed = { ...creds, token: tokenData.token.token };
+    const healed: Credentials = { ...creds, token: tokenData.token.token };
+
+    // Realign orgName + workspaceId to creds.orgId so billingUrl() and the
+    // SessionStart banner stop pointing at the stale org. Best-effort: any
+    // failure here is swallowed so the token heal above still persists. Uses
+    // the freshly-minted token, which is bound to creds.orgId.
+    try {
+      const orgs = await listOrgs(healed.token, apiUrl);
+      const matchedOrg = orgs.find(o => o.id === creds.orgId);
+      if (matchedOrg && matchedOrg.name !== creds.orgName) {
+        log(`orgName realigned: ${creds.orgName ?? "(unset)"} -> ${matchedOrg.name}`);
+        healed.orgName = matchedOrg.name;
+      }
+      // "default" is the per-org sentinel the backend resolves itself, so it
+      // needs no validation. Only a concrete workspace id/name can belong to
+      // the previous org and must be re-resolved (or reset) against the new one.
+      const currentWs = creds.workspaceId ?? "default";
+      if (currentWs !== "default") {
+        const wsList = await listWorkspaces(healed.token, apiUrl, creds.orgId);
+        const lcWs = currentWs.toLowerCase();
+        const wsMatch = wsList.find(w => w.id === currentWs || (w.name && w.name.toLowerCase() === lcWs));
+        if (!wsMatch) {
+          log(`workspace '${currentWs}' not in org ${creds.orgId} — reset to default`);
+          healed.workspaceId = "default";
+        } else if (wsMatch.id !== currentWs) {
+          log(`workspace '${currentWs}' resolved to id '${wsMatch.id}'`);
+          healed.workspaceId = wsMatch.id;
+        }
+      }
+    } catch (e) {
+      log(`org/workspace realign skipped: ${(e as Error).message}`);
+    }
+
     saveCredentials(healed);
     log(`token re-minted for org=${creds.orgId}`);
     return healed;

--- a/src/notifications/sources/cold-start-brief.ts
+++ b/src/notifications/sources/cold-start-brief.ts
@@ -134,7 +134,7 @@ function writeState(sessionsScanned: number, isFirstRun: boolean): void {
 }
 
 // ─── Text utilities ─────────────────────────────────────────────────────
-function parseTs(s: string | undefined): Date | null {
+export function parseTs(s: string | undefined): Date | null {
   if (!s) return null;
   const d = new Date(s);
   return Number.isNaN(d.getTime()) ? null : d;
@@ -146,7 +146,7 @@ function parseTs(s: string | undefined): Date | null {
  * cuts mid-word and never leaves a dangling opener. Strips surrounding
  * quotes and collapses whitespace/markdown noise.
  */
-function cleanSnippet(raw: string, maxLen = 150): string {
+export function cleanSnippet(raw: string, maxLen = 150): string {
   let s = raw
     .replace(/[`*_#>]/g, "")
     .replace(/\s+/g, " ")
@@ -167,7 +167,7 @@ function cleanSnippet(raw: string, maxLen = 150): string {
   return stripDanglingOpener(cut.trim() + "…");
 }
 
-function stripDanglingOpener(s: string): string {
+export function stripDanglingOpener(s: string): string {
   let out = s;
   const opens = (out.match(/\(/g) || []).length;
   const closes = (out.match(/\)/g) || []).length;
@@ -175,7 +175,7 @@ function stripDanglingOpener(s: string): string {
   return out.replace(/[\s,;:(]+$/, "").trim();
 }
 
-function deriveProjectLabel(projDirName: string, cwdSeen: string | undefined): string {
+export function deriveProjectLabel(projDirName: string, cwdSeen: string | undefined): string {
   if (cwdSeen) {
     const seg = cwdSeen.split(/[/\\]/).filter(Boolean);
     return seg[seg.length - 1] || projDirName;
@@ -216,7 +216,7 @@ interface UserRow { ts: Date; content: string; cwd?: string }
 /** Parse complete jsonl lines from a chunk into user-message rows. Partial
  *  first/last lines (from a mid-file byte cut) fail JSON.parse and are
  *  skipped — exactly what we want. */
-function parseUserRows(chunk: string): UserRow[] {
+export function parseUserRows(chunk: string): UserRow[] {
   const rows: UserRow[] = [];
   for (const line of chunk.split("\n")) {
     if (!line) continue;
@@ -283,7 +283,7 @@ function mineLocal(cutoff: Date): SessionMeta[] {
 }
 
 // ─── Signal extraction ──────────────────────────────────────────────────
-function pickSignal(sessions: SessionMeta[]): Signal {
+export function pickSignal(sessions: SessionMeta[]): Signal {
   if (sessions.length === 0) return { kind: "quiet", description: "nothing in window" };
 
   const sorted = [...sessions].sort((a, b) => b.lastTs.getTime() - a.lastTs.getTime());
@@ -343,7 +343,7 @@ function pickSignal(sessions: SessionMeta[]): Signal {
 }
 
 // ─── Render — hard 3-4 sentence cap ─────────────────────────────────────
-function renderBrief(sessions: SessionMeta[], signal: Signal, authed: boolean): string | null {
+export function renderBrief(sessions: SessionMeta[], signal: Signal, authed: boolean): string | null {
   if (sessions.length === 0 || signal.kind === "quiet") return null;
 
   // Generic, privacy-safe copy. The mined signal is used only as a GATE

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -246,6 +246,12 @@ describe("listOrgs / listWorkspaces", () => {
     expect(init.headers["X-Activeloop-Org-Id"]).toBe("o1");
   });
 
+  it("listWorkspaces returns [] for a non-array, non-envelope body", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ something: "else" })); // no data, not an array
+    const { listWorkspaces } = await importAuth();
+    expect(await listWorkspaces("tok", "https://api.example", "o1")).toEqual([]);
+  });
+
   it("listWorkspaces accepts a bare array body", async () => {
     fetchMock.mockResolvedValueOnce(ok([{ id: "ws1", name: "default" }]));
     const { listWorkspaces } = await importAuth();
@@ -457,6 +463,86 @@ describe("healDriftedOrgToken", () => {
     expect(out.orgName).toBe("stale-name"); // org block failed, left as-is
     expect(out.workspaceId).toBe("default"); // workspace block still ran
     expect(logged).toContain("orgName realign skipped: API 500: boom");
+  });
+
+  it("falls back to DEFAULT_API_URL when creds.apiUrl is missing", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }]));
+    const { healDriftedOrgToken } = await importAuth();
+    // apiUrl is absent → must use DEFAULT_API_URL without throwing.
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "old-name" } as any,
+    );
+    expect(out.token).toBe("fresh-tok");
+    // /users/me/tokens was called against the default API URL (not undefined).
+    expect(fetchMock.mock.calls[0][0]).toMatch(/^https:\/\//);
+  });
+
+  it("skips orgName update when target org is not found in the listOrgs response", async () => {
+    // matchedOrg is undefined → the if(matchedOrg && ...) is false → no update.
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "other-org", name: "other" }])); // target-org absent
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "old-name", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+    expect(out.orgName).toBe("old-name"); // not updated — org not found
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips orgName update when the name is already correct", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "already-correct" }]));
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "already-correct", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+    // orgName unchanged — no realign log, no extra save field change.
+    expect(out.orgName).toBe("already-correct");
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(saveCredentialsMock.mock.calls[0][0].orgName).toBe("already-correct");
+  });
+
+  it("skips workspace update when canonical id already matches", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }]))
+      .mockResolvedValueOnce(ok({ data: [{ id: "ws-canonical", name: "prod" }] }));
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      // workspaceId is already the canonical id → wsMatch.id === currentWs → no update
+      { token: stale, orgId: "target-org", orgName: "target-name", workspaceId: "ws-canonical", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+    expect(out.workspaceId).toBe("ws-canonical"); // unchanged
+    expect(saveCredentialsMock.mock.calls[0][0].workspaceId).toBe("ws-canonical");
+  });
+
+  it("swallows workspace realign failure and still persists the token heal", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }])) // listOrgs ok
+      .mockResolvedValueOnce(new Response("service error", { status: 503 }));  // listWorkspaces fails
+    const logged: string[] = [];
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "target-name", workspaceId: "ws-stale", apiUrl: "https://api.example", savedAt: "x" } as any,
+      (m) => logged.push(m),
+    );
+
+    // Token heal + orgName realign landed; only workspace was skipped.
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(out.token).toBe("fresh-tok");
+    expect(out.orgName).toBe("target-name"); // org block succeeded
+    expect(out.workspaceId).toBe("ws-stale"); // workspace block failed → unchanged
+    expect(logged).toContain("workspace realign skipped: API 503: service error");
   });
 
   it("returns the original creds and does NOT persist when the mint call fails", async () => {
@@ -711,6 +797,60 @@ describe("saveCredentialsFromToken — org-pinning", () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+
+  it("throws when the account has no organizations", async () => {
+    const token = makeToken({ user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([])); // empty org list
+    const { saveCredentialsFromToken } = await importAuth();
+    await expect(saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true }))
+      .rejects.toThrow("No organizations found");
+  });
+
+  it("uses the single org automatically when the account belongs to exactly one", async () => {
+    const token = makeToken({ user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([{ id: "only-org", name: "solo" }]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.orgId).toBe("only-org");
+    expect(creds.orgName).toBe("solo");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // /me + /organizations, no mint
+  });
+
+  it("falls back to orgs[0] silently when skipTokenMint=true and token has no org_id claim", async () => {
+    // Token has NO org_id claim → claimOrg is undefined → preferredOrgId stays undefined
+    // → matched is undefined + orgs.length > 1 → multi-org fallback (orgs[0]).
+    const token = makeToken({ user_id: "u1" }); // no org_id
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "Alice" }))
+      .mockResolvedValueOnce(ok([{ id: "o1", name: "acme" }, { id: "o2", name: "globex" }]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.orgId).toBe("o1"); // orgs[0]
+  });
+
+  it("derives userName from email when user.name is empty", async () => {
+    const token = makeToken({ user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "", email: "alice@example.com" }))
+      .mockResolvedValueOnce(ok([{ id: "o1", name: "acme" }]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.userName).toBe("alice"); // email prefix
+  });
+
+  it("falls back to 'unknown' when both user.name and user.email are absent", async () => {
+    const token = makeToken({ user_id: "u1" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ id: "u1", name: "" })) // no email field
+      .mockResolvedValueOnce(ok([{ id: "o1", name: "acme" }]));
+    const { saveCredentialsFromToken } = await importAuth();
+    const creds = await saveCredentialsFromToken(token, "https://api.example", { skipTokenMint: true });
+    expect(creds.userName).toBe("unknown");
   });
 
   it("skipTokenMint=false (device flow) does NOT decode the token — picks orgs[0] as before", async () => {

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -436,7 +436,27 @@ describe("healDriftedOrgToken", () => {
     expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
     expect(out.token).toBe("fresh-tok");
     expect(out.orgName).toBe("stale-name"); // unchanged — realign couldn't run
-    expect(logged.some(m => /realign skipped/.test(m))).toBe(true);
+    expect(logged).toContain("orgName realign skipped: API 500: boom");
+  });
+
+  it("still repairs the workspace when the orgName lookup fails (independent blocks)", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 })) // listOrgs fails
+      .mockResolvedValueOnce(ok({ data: [{ id: "ws-of-target", name: "prod" }] })); // listWorkspaces ok
+    const logged: string[] = [];
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "stale-name", workspaceId: "ws-of-old-org", apiUrl: "https://api.example", savedAt: "x" } as any,
+      (m) => logged.push(m),
+    );
+
+    // listWorkspaces runs even though listOrgs threw → workspace gets reset.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(out.orgName).toBe("stale-name"); // org block failed, left as-is
+    expect(out.workspaceId).toBe("default"); // workspace block still ran
+    expect(logged).toContain("orgName realign skipped: API 500: boom");
   });
 
   it("returns the original creds and does NOT persist when the mint call fails", async () => {

--- a/tests/claude-code/auth.test.ts
+++ b/tests/claude-code/auth.test.ts
@@ -353,24 +353,90 @@ describe("healDriftedOrgToken", () => {
     expect(saveCredentialsMock).not.toHaveBeenCalled();
   });
 
-  it("re-mints and persists when JWT org_id differs from creds.orgId", async () => {
+  it("re-mints, realigns orgName, and persists when JWT org_id differs from creds.orgId", async () => {
     const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
-    fetchMock.mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }));
+    // 1: token re-mint. 2: listOrgs (orgName realign). Default workspace → no
+    // listWorkspaces call, so exactly two fetches.
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }, { id: "stale-org", name: "stale-name" }]));
     const { healDriftedOrgToken } = await importAuth();
     const out = await healDriftedOrgToken(
-      { token: stale, orgId: "target-org", apiUrl: "https://api.example", savedAt: "x" } as any,
+      { token: stale, orgId: "target-org", orgName: "stale-name", apiUrl: "https://api.example", savedAt: "x" } as any,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("https://api.example/users/me/tokens");
     expect(init.method).toBe("POST");
     expect(init.headers.Authorization).toBe(`Bearer ${stale}`);
     expect(JSON.parse(init.body).organization_id).toBe("target-org");
+    // listOrgs runs with the freshly-minted token, not the stale one.
+    const [orgsUrl, orgsInit] = fetchMock.mock.calls[1];
+    expect(orgsUrl).toBe("https://api.example/organizations");
+    expect(orgsInit.headers.Authorization).toBe("Bearer fresh-tok");
 
     expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
-    expect(saveCredentialsMock.mock.calls[0][0].token).toBe("fresh-tok");
+    const written = saveCredentialsMock.mock.calls[0][0];
+    expect(written.token).toBe("fresh-tok");
+    expect(written.orgName).toBe("target-name"); // realigned away from "stale-name"
     expect(out.token).toBe("fresh-tok");
+    expect(out.orgName).toBe("target-name");
+  });
+
+  it("resets a stale concrete workspace that is absent from the new org", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }]))
+      .mockResolvedValueOnce(ok({ data: [{ id: "ws-of-target", name: "prod" }] }));
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "target-name", workspaceId: "ws-of-old-org", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+
+    // mint + listOrgs + listWorkspaces = three fetches (non-default workspace).
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2][0]).toBe("https://api.example/workspaces");
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(out.workspaceId).toBe("default"); // old-org workspace dropped
+  });
+
+  it("normalizes a stale workspace NAME to its canonical id in the new org", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(ok([{ id: "target-org", name: "target-name" }]))
+      .mockResolvedValueOnce(ok({ data: [{ id: "ws-of-target", name: "prod" }] }));
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "target-name", workspaceId: "prod", apiUrl: "https://api.example", savedAt: "x" } as any,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    // The name "prod" exists in the target org → resolved to its canonical id.
+    expect(saveCredentialsMock.mock.calls[0][0].workspaceId).toBe("ws-of-target");
+    expect(out.workspaceId).toBe("ws-of-target");
+  });
+
+  it("persists the token heal even when the orgName realign fails (best-effort)", async () => {
+    const stale = fakeJwt({ user_id: "u", org_id: "stale-org", type: "api_token" });
+    fetchMock
+      .mockResolvedValueOnce(ok({ token: { token: "fresh-tok" } }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    const logged: string[] = [];
+    const { healDriftedOrgToken } = await importAuth();
+    const out = await healDriftedOrgToken(
+      { token: stale, orgId: "target-org", orgName: "stale-name", apiUrl: "https://api.example", savedAt: "x" } as any,
+      (m) => logged.push(m),
+    );
+
+    // The token heal still lands; only the realign was skipped.
+    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(out.token).toBe("fresh-tok");
+    expect(out.orgName).toBe("stale-name"); // unchanged — realign couldn't run
+    expect(logged.some(m => /realign skipped/.test(m))).toBe(true);
   });
 
   it("returns the original creds and does NOT persist when the mint call fails", async () => {

--- a/tests/claude-code/cold-start-brief-fs.test.ts
+++ b/tests/claude-code/cold-start-brief-fs.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Integration tests for cold-start-brief using a real (temp) filesystem.
+ * Mocks only `node:os.homedir` to redirect ~/.claude/projects to a tmpdir
+ * so readHeadTail / loadLocalSession / mineLocal / pickColdStartBrief run
+ * their real I/O paths without touching the developer's actual home.
+ *
+ * These tests cover lines 191-282 (readHeadTail, loadLocalSession, mineLocal)
+ * and 401-403 (pickColdStartBrief success path) which the unit tests in
+ * cold-start-brief.test.ts can't reach because they mock node:fs globally.
+ */
+
+let tempHome: string;
+
+vi.mock("node:os", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:os")>();
+  return {
+    ...real,
+    homedir: () => tempHome,
+  };
+});
+
+function jsonlRow(content: string, ts: string, cwd?: string): string {
+  return JSON.stringify({ type: "user", message: { content }, timestamp: ts, cwd });
+}
+
+function writeSession(dir: string, name: string, rows: string[]): void {
+  writeFileSync(join(dir, name), rows.join("\n") + "\n", "utf-8");
+}
+
+function projectDir(name: string): string {
+  const d = join(tempHome, ".claude", "projects", name);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "hivemind-test-"));
+  mkdirSync(join(tempHome, ".claude", "projects"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe("cold-start-brief filesystem paths", () => {
+  it("returns null for authed user when state file exists (no re-import needed)", async () => {
+    // Write a state file to simulate already-onboarded user.
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".claude", ".hivemind_brief_state.json"),
+      JSON.stringify({ lastBriefTs: new Date().toISOString(), sessionsScanned: 3, fireReason: "first_run" }),
+    );
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief({ token: "t" } as never);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when projects dir does not exist", async () => {
+    // Remove the projects dir so mineLocal returns [].
+    rmSync(join(tempHome, ".claude", "projects"), { recursive: true, force: true });
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when sessions are all older than the 60-day window", async () => {
+    const d = projectDir("old-proj");
+    const oldTs = new Date(Date.now() - 65 * 86_400_000).toISOString();
+    writeSession(d, "session.jsonl", [jsonlRow("what was I doing?", oldTs)]);
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when jsonl has no valid user rows", async () => {
+    const d = projectDir("empty-proj");
+    writeSession(d, "session.jsonl", [
+      JSON.stringify({ type: "assistant", message: { content: "hi" }, timestamp: new Date().toISOString() }),
+      "not json at all",
+    ]);
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull();
+  });
+
+  it("skips files that don't end in .jsonl", async () => {
+    const d = projectDir("mixed-proj");
+    writeFileSync(join(d, "notes.txt"), "not a session");
+    writeFileSync(join(d, "session.json"), jsonlRow("hello", new Date().toISOString()));
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull();
+  });
+
+  it("fires a brief (authed first run) when recall-seeking sessions exist", async () => {
+    const recallPhrases = [
+      "what was I doing last time?",
+      "continue where I left off",
+      "what is my todo list for this project",
+    ];
+    const proj = projectDir("my-proj");
+    for (let i = 0; i < recallPhrases.length; i++) {
+      const ts = new Date(Date.now() - (i + 1) * 24 * 3_600_000).toISOString();
+      writeSession(proj, `session-${i}.jsonl`, [
+        jsonlRow(recallPhrases[i], ts, "/home/user/my-proj"),
+        jsonlRow("done for now", new Date(Date.now() - i * 3_600_000).toISOString()),
+      ]);
+    }
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief({ token: "t" } as never);
+    // Authed first run with enough recall-seeking sessions → brief fires.
+    expect(result).not.toBeNull();
+    expect(result?.brief).toContain("found context");
+    expect(result?.firstRun).toBe(true);
+  });
+
+  it("fires a brief (anonymous first run) when a dominant project exists", async () => {
+    const proj = projectDir("big-proj");
+    for (let i = 0; i < 4; i++) {
+      const ts = new Date(Date.now() - (i + 1) * 3_600_000).toISOString();
+      writeSession(proj, `s${i}.jsonl`, [jsonlRow(`task ${i}`, ts, "/work/big-proj")]);
+    }
+    const other = projectDir("small-proj");
+    writeSession(other, "s.jsonl", [jsonlRow("one task", new Date().toISOString())]);
+
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null); // anonymous
+    expect(result).not.toBeNull();
+    expect(result?.brief).toContain("Sign in");
+    expect(result?.firstRun).toBe(true);
+  });
+
+  it("returns null when state file has non-string lastBriefTs (lastBriefMs NaN branch)", async () => {
+    // Write state with a non-string lastBriefTs → lastBriefMs returns null → re-nudge allowed.
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".claude", ".hivemind_brief_state.json"),
+      JSON.stringify({ lastBriefTs: 12345, sessionsScanned: 0, fireReason: "first_run" }),
+    );
+    // No sessions → returns null (not because of state, but because mineLocal is empty).
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull(); // no sessions → quiet → null
+  });
+
+  it("handles mtime < cutoff gracefully (loadLocalSession returns null for old files)", async () => {
+    const proj = projectDir("aged-proj");
+    const sessionPath = join(proj, "old.jsonl");
+    writeFileSync(sessionPath, jsonlRow("hello", new Date().toISOString()) + "\n");
+    // Set mtime to 70 days ago so loadLocalSession rejects the file.
+    const { utimesSync } = await import("node:fs");
+    const oldDate = new Date(Date.now() - 70 * 86_400_000);
+    utimesSync(sessionPath, oldDate, oldDate);
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    const result = await pickColdStartBrief({ token: "t" } as never);
+    expect(result).toBeNull(); // file too old → no sessions → null
+  });
+
+  it("reads head AND tail of a large-ish file (readHeadTail both branches)", async () => {
+    const proj = projectDir("large-proj");
+    // Build a session > HEAD_TAIL_BYTES (32KB) so both head and tail are read.
+    const rows: string[] = [];
+    const baseTs = new Date(Date.now() - 3_600_000);
+    rows.push(jsonlRow("what was I doing?", baseTs.toISOString()));
+    // Fill with enough data to exceed 32KB.
+    for (let i = 0; i < 600; i++) {
+      const ts = new Date(baseTs.getTime() + i * 1000).toISOString();
+      rows.push(JSON.stringify({ type: "assistant", message: { content: "a".repeat(60) }, timestamp: ts }));
+    }
+    const lastTs = new Date(Date.now() - 60_000).toISOString();
+    rows.push(jsonlRow("next time pick this up", lastTs));
+    writeSession(proj, "big.jsonl", rows);
+
+    const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
+    // Just assert it doesn't throw and returns something or null (we can't guarantee
+    // signal strength, but the code path through readHeadTail's tail branch runs).
+    await expect(pickColdStartBrief({ token: "t" } as never)).resolves.not.toThrow();
+  });
+});

--- a/tests/claude-code/cold-start-brief-fs.test.ts
+++ b/tests/claude-code/cold-start-brief-fs.test.ts
@@ -180,6 +180,6 @@ describe("cold-start-brief filesystem paths", () => {
     const { pickColdStartBrief } = await import("../../src/notifications/sources/cold-start-brief.js");
     // Just assert it doesn't throw and returns something or null (we can't guarantee
     // signal strength, but the code path through readHeadTail's tail branch runs).
-    await expect(pickColdStartBrief({ token: "t" } as never)).resolves.not.toThrow();
+    await expect(pickColdStartBrief({ token: "t" } as never)).resolves.toBeDefined();
   });
 });

--- a/tests/claude-code/cold-start-brief.test.ts
+++ b/tests/claude-code/cold-start-brief.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for the pure helper functions exported from cold-start-brief.ts.
+ * Mocks node:fs so pickColdStartBrief's state/filesystem paths are testable
+ * offline. The pure functions (parseTs, cleanSnippet, stripDanglingOpener,
+ * deriveProjectLabel, parseUserRows, pickSignal, renderBrief) are exercised
+ * directly to maximise branch coverage without touching real disk.
+ */
+
+vi.mock("node:fs", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...real,
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+    statSync: vi.fn(() => ({ size: 0, mtime: new Date(0) })),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => "{}"),
+    openSync: vi.fn(() => 1),
+    readSync: vi.fn(() => 0),
+    closeSync: vi.fn(),
+  };
+});
+
+import {
+  parseTs,
+  cleanSnippet,
+  stripDanglingOpener,
+  deriveProjectLabel,
+  parseUserRows,
+  pickSignal,
+  renderBrief,
+  pickColdStartBrief,
+} from "../../src/notifications/sources/cold-start-brief.js";
+
+// ─── parseTs ────────────────────────────────────────────────────────────────
+describe("parseTs", () => {
+  it("parses a valid ISO string", () => {
+    const d = parseTs("2026-01-15T10:00:00.000Z");
+    expect(d).toBeInstanceOf(Date);
+    expect(d!.toISOString()).toBe("2026-01-15T10:00:00.000Z");
+  });
+
+  it("returns null for an invalid string", () => {
+    expect(parseTs("not-a-date")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(parseTs(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseTs("")).toBeNull();
+  });
+});
+
+// ─── stripDanglingOpener ─────────────────────────────────────────────────────
+describe("stripDanglingOpener", () => {
+  it("removes an unclosed parenthesis", () => {
+    expect(stripDanglingOpener("fix the bug (see issue")).toBe("fix the bug");
+  });
+
+  it("leaves balanced parentheses intact", () => {
+    expect(stripDanglingOpener("fix the bug (now closed)")).toBe("fix the bug (now closed)");
+  });
+
+  it("trims trailing punctuation", () => {
+    expect(stripDanglingOpener("hello,")).toBe("hello");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripDanglingOpener("")).toBe("");
+  });
+});
+
+// ─── cleanSnippet ───────────────────────────────────────────────────────────
+describe("cleanSnippet", () => {
+  it("returns short strings unchanged (after noise strip)", () => {
+    expect(cleanSnippet("fix the auth bug")).toBe("fix the auth bug");
+  });
+
+  it("strips markdown noise characters", () => {
+    expect(cleanSnippet("**bold** and `code`")).toBe("bold and code");
+  });
+
+  it("truncates at a sentence boundary when possible", () => {
+    // sentenceEnd (14) must be >= maxLen * 0.5; use maxLen=20 so 14 >= 10.
+    const long = "First sentence. Second sentence that is quite long and goes on.";
+    const result = cleanSnippet(long, 20);
+    expect(result).toBe("First sentence.");
+  });
+
+  it("truncates at a clause boundary when no sentence fits", () => {
+    const long = "First clause part, second clause part that exceeds limit";
+    const result = cleanSnippet(long, 30);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.includes(",")).toBe(false); // comma was the cut point
+  });
+
+  it("truncates at a word boundary as last resort", () => {
+    const long = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLM"; // no punctuation
+    const result = cleanSnippet(long, 30);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(32); // cut + ellipsis
+  });
+
+  it("strips leading quote and converts trailing quote", () => {
+    // ^["'\s]+ strips the opening ", then " → ' converts the closing one.
+    expect(cleanSnippet('"quoted text"')).toBe("quoted text'");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(cleanSnippet("too   many   spaces")).toBe("too many spaces");
+  });
+});
+
+// ─── deriveProjectLabel ──────────────────────────────────────────────────────
+describe("deriveProjectLabel", () => {
+  it("uses the last path segment from cwdSeen when provided", () => {
+    expect(deriveProjectLabel("hashed-dir", "/home/user/myproject")).toBe("myproject");
+  });
+
+  it("uses the last dash-segment from projDirName when cwdSeen is absent", () => {
+    expect(deriveProjectLabel("home-user-myproject", undefined)).toBe("myproject");
+  });
+
+  it("returns projDirName verbatim when there are no dashes and no cwd", () => {
+    expect(deriveProjectLabel("nodashes", undefined)).toBe("nodashes");
+  });
+
+  it("handles Windows-style backslash paths in cwdSeen", () => {
+    expect(deriveProjectLabel("x", "C:\\Users\\user\\project")).toBe("project");
+  });
+});
+
+// ─── parseUserRows ───────────────────────────────────────────────────────────
+describe("parseUserRows", () => {
+  function row(content: string, ts = "2026-01-01T10:00:00.000Z", cwd?: string) {
+    return JSON.stringify({ type: "user", message: { content }, timestamp: ts, cwd });
+  }
+
+  it("parses a valid user row", () => {
+    const rows = parseUserRows(row("hello"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("hello");
+    expect(rows[0].ts).toBeInstanceOf(Date);
+  });
+
+  it("skips rows that are not type='user'", () => {
+    const assistant = JSON.stringify({ type: "assistant", message: { content: "hi" }, timestamp: "2026-01-01T10:00:00.000Z" });
+    expect(parseUserRows(assistant)).toHaveLength(0);
+  });
+
+  it("skips sidechain rows", () => {
+    const sc = JSON.stringify({ type: "user", isSidechain: true, message: { content: "hi" }, timestamp: "2026-01-01T10:00:00.000Z" });
+    expect(parseUserRows(sc)).toHaveLength(0);
+  });
+
+  it("skips rows with non-string content", () => {
+    const bad = JSON.stringify({ type: "user", message: { content: [{ text: "hi" }] }, timestamp: "2026-01-01T10:00:00.000Z" });
+    expect(parseUserRows(bad)).toHaveLength(0);
+  });
+
+  it("skips rows with an invalid timestamp", () => {
+    expect(parseUserRows(row("hi", "not-a-date"))).toHaveLength(0);
+  });
+
+  it("skips malformed JSON lines without throwing", () => {
+    expect(parseUserRows("{broken json")).toHaveLength(0);
+  });
+
+  it("skips empty lines", () => {
+    expect(parseUserRows("\n\n")).toHaveLength(0);
+  });
+
+  it("carries the cwd field when present", () => {
+    const rows = parseUserRows(row("hi", "2026-01-01T10:00:00.000Z", "/my/project"));
+    expect(rows[0].cwd).toBe("/my/project");
+  });
+
+  it("parses multiple rows from a multi-line chunk", () => {
+    const chunk = [row("first"), row("second", "2026-01-01T11:00:00.000Z")].join("\n");
+    expect(parseUserRows(chunk)).toHaveLength(2);
+  });
+});
+
+// ─── pickSignal ──────────────────────────────────────────────────────────────
+describe("pickSignal", () => {
+  const ts = (offset = 0) => new Date(Date.now() - offset * 3_600_000);
+
+  function session(opts: {
+    project?: string;
+    firstMessage?: string;
+    lastMessage?: string;
+    firstTsOffset?: number;
+    lastTsOffset?: number;
+  } = {}) {
+    return {
+      project: opts.project ?? "myproj",
+      firstTs: ts(opts.firstTsOffset ?? 24),
+      lastTs: ts(opts.lastTsOffset ?? 1),
+      firstMessage: opts.firstMessage,
+      lastMessage: opts.lastMessage,
+    };
+  }
+
+  it("returns quiet when given no sessions", () => {
+    expect(pickSignal([])).toMatchObject({ kind: "quiet" });
+  });
+
+  it("returns quiet when sessions are spread across enough projects (no dominant one)", () => {
+    // 3 sessions on 3 different projects: none >= 50%, no recall/abandon triggers.
+    const sessions = [
+      session({ project: "alpha" }),
+      session({ project: "beta" }),
+      session({ project: "gamma" }),
+    ];
+    expect(pickSignal(sessions)).toMatchObject({ kind: "quiet" });
+  });
+
+  it("returns recall when enough sessions open with recall-seeking phrases", () => {
+    const sessions = Array.from({ length: 3 }, (_, i) =>
+      session({ project: "p", firstMessage: `what was I doing on task ${i}?` }),
+    );
+    expect(pickSignal(sessions)).toMatchObject({ kind: "recall", project: "p" });
+  });
+
+  it("returns abandoned when last message contains a handoff phrase", () => {
+    const sessions = [
+      session({ lastMessage: "next time I need to finish the auth flow" }),
+    ];
+    expect(pickSignal(sessions)).toMatchObject({ kind: "abandoned" });
+  });
+
+  it("returns volume when one project dominates (≥50%)", () => {
+    const sessions = [
+      session({ project: "main" }),
+      session({ project: "main" }),
+      session({ project: "main" }),
+      session({ project: "other" }),
+    ];
+    const sig = pickSignal(sessions);
+    expect(sig).toMatchObject({ kind: "volume", project: "main" });
+    expect((sig as { count: number }).count).toBe(3);
+  });
+
+  it("returns quiet when top project is below 50%", () => {
+    const sessions = [
+      session({ project: "a" }),
+      session({ project: "b" }),
+      session({ project: "c" }),
+    ];
+    expect(pickSignal(sessions)).toMatchObject({ kind: "quiet" });
+  });
+
+  it("recall signal includes oneDay when all hits are on the same day", () => {
+    const sameDay = "2026-01-15T10:00:00.000Z";
+    const sessions = Array.from({ length: 3 }, () =>
+      session({ firstMessage: "what was I doing?", firstTsOffset: 0, lastTsOffset: 0 }),
+    ).map(s => ({ ...s, firstTs: new Date(sameDay), lastTs: new Date(sameDay) }));
+    const sig = pickSignal(sessions) as { kind: string; date?: string };
+    expect(sig.kind).toBe("recall");
+    expect(sig.date).toBe("2026-01-15");
+  });
+});
+
+// ─── renderBrief ─────────────────────────────────────────────────────────────
+describe("renderBrief", () => {
+  const ts = () => new Date();
+  const session = { project: "p", firstTs: ts(), lastTs: ts() };
+
+  it("returns authed copy when authed=true and signal is not quiet", () => {
+    const result = renderBrief([session], { kind: "recall", description: "x", project: "p", count: 3 }, true);
+    expect(result).toContain("found context");
+    expect(result).not.toContain("Sign in");
+  });
+
+  it("returns anonymous copy when authed=false and signal is not quiet", () => {
+    const result = renderBrief([session], { kind: "recall", description: "x", project: "p", count: 3 }, false);
+    expect(result).toContain("Sign in");
+  });
+
+  it("returns null when signal kind is quiet", () => {
+    expect(renderBrief([session], { kind: "quiet", description: "nothing" }, true)).toBeNull();
+  });
+
+  it("returns null when sessions list is empty", () => {
+    expect(renderBrief([], { kind: "recall", description: "x", project: "p", count: 3 }, true)).toBeNull();
+  });
+});
+
+// ─── pickColdStartBrief (entry-point paths via mocked fs) ───────────────────
+describe("pickColdStartBrief", () => {
+  let existsMock: ReturnType<typeof vi.fn>;
+  let readdirMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const fs = await import("node:fs");
+    existsMock = fs.existsSync as ReturnType<typeof vi.fn>;
+    readdirMock = fs.readdirSync as ReturnType<typeof vi.fn>;
+    existsMock.mockReturnValue(false);
+    readdirMock.mockReturnValue([]);
+  });
+
+  it("returns null for authed user with existing state (already onboarded)", async () => {
+    existsMock.mockReturnValue(true); // state file exists
+    const result = await pickColdStartBrief({ token: "t" } as never);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for anonymous user with no local history (nothing to mine)", async () => {
+    existsMock.mockReturnValue(false); // no state, no projects dir
+    const result = await pickColdStartBrief(null);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no creds are provided and no history exists", async () => {
+    const result = await pickColdStartBrief(undefined);
+    expect(result).toBeNull();
+  });
+
+  it("returns null (no crash) on unexpected fs errors", async () => {
+    existsMock.mockImplementation(() => { throw new Error("disk error"); });
+    const result = await pickColdStartBrief({ token: "t" } as never);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/claude-code/cold-start-brief.test.ts
+++ b/tests/claude-code/cold-start-brief.test.ts
@@ -272,13 +272,12 @@ describe("renderBrief", () => {
 
   it("returns authed copy when authed=true and signal is not quiet", () => {
     const result = renderBrief([session], { kind: "recall", description: "x", project: "p", count: 3 }, true);
-    expect(result).toContain("found context");
-    expect(result).not.toContain("Sign in");
+    expect(result).toBe("I found context from your recent sessions — from now on I'll keep it, so your next session picks up where you left off.");
   });
 
   it("returns anonymous copy when authed=false and signal is not quiet", () => {
     const result = renderBrief([session], { kind: "recall", description: "x", project: "p", count: 3 }, false);
-    expect(result).toContain("Sign in");
+    expect(result).toBe("I found context from your recent sessions. Sign in to save it, so future sessions start with what you've already learned.");
   });
 
   it("returns null when signal kind is quiet", () => {

--- a/tests/claude-code/path-match.test.ts
+++ b/tests/claude-code/path-match.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { homedir } from "node:os";
+import { extractMemoryOp } from "../../src/path-match.js";
+
+const HOME = homedir();
+const MEM = `${HOME}/.deeplake/memory`;
+
+describe("extractMemoryOp", () => {
+  describe("Read", () => {
+    it("returns read op when file_path starts with memoryPath", () => {
+      const op = extractMemoryOp("Read", { file_path: `${MEM}/foo.md` }, MEM);
+      expect(op).toEqual({ path: `${MEM}/foo.md`, op: "read" });
+    });
+
+    it("returns null when file_path is outside memoryPath", () => {
+      expect(extractMemoryOp("Read", { file_path: "/tmp/other.md" }, MEM)).toBeNull();
+    });
+
+    it("expands tilde in file_path", () => {
+      const op = extractMemoryOp("Read", { file_path: "~/.deeplake/memory/foo.md" }, MEM);
+      expect(op?.op).toBe("read");
+      expect(op?.path).toBe(`${HOME}/.deeplake/memory/foo.md`);
+    });
+
+    it("returns null when file_path is absent", () => {
+      expect(extractMemoryOp("Read", {}, MEM)).toBeNull();
+    });
+  });
+
+  describe("Write", () => {
+    it("returns write op for a matching path", () => {
+      expect(extractMemoryOp("Write", { file_path: `${MEM}/x.md` }, MEM))
+        .toEqual({ path: `${MEM}/x.md`, op: "write" });
+    });
+
+    it("returns null for a non-matching path", () => {
+      expect(extractMemoryOp("Write", { file_path: "/home/user/other.md" }, MEM)).toBeNull();
+    });
+  });
+
+  describe("Edit", () => {
+    it("returns edit op for a matching path", () => {
+      expect(extractMemoryOp("Edit", { file_path: `${MEM}/a.md` }, MEM))
+        .toEqual({ path: `${MEM}/a.md`, op: "edit" });
+    });
+  });
+
+  describe("Glob", () => {
+    it("returns list op when path matches", () => {
+      expect(extractMemoryOp("Glob", { path: `${MEM}/**` }, MEM))
+        .toEqual({ path: `${MEM}/**`, op: "list" });
+    });
+
+    it("returns null when path is outside memory", () => {
+      expect(extractMemoryOp("Glob", { path: "/tmp/**" }, MEM)).toBeNull();
+    });
+  });
+
+  describe("Grep", () => {
+    it("returns search op when path matches", () => {
+      expect(extractMemoryOp("Grep", { path: MEM }, MEM))
+        .toEqual({ path: MEM, op: "search" });
+    });
+
+    it("returns null when path is outside memory", () => {
+      expect(extractMemoryOp("Grep", { path: "/tmp" }, MEM)).toBeNull();
+    });
+  });
+
+  describe("Bash", () => {
+    it("returns bash op when command contains the expanded memoryPath", () => {
+      const op = extractMemoryOp("Bash", { command: `cat ${MEM}/foo.md` }, MEM);
+      expect(op).toEqual({ path: MEM, op: "bash" });
+    });
+
+    it("returns bash op when command contains the literal ~/.deeplake/memory sentinel", () => {
+      const op = extractMemoryOp("Bash", { command: "cat ~/.deeplake/memory/foo.md" }, MEM);
+      expect(op).toEqual({ path: MEM, op: "bash" });
+    });
+
+    it("returns null when command does not reference memory", () => {
+      expect(extractMemoryOp("Bash", { command: "ls /tmp" }, MEM)).toBeNull();
+    });
+
+    it("returns null when command is absent", () => {
+      expect(extractMemoryOp("Bash", {}, MEM)).toBeNull();
+    });
+  });
+
+  describe("unknown tool", () => {
+    it("returns null for unrecognised tool names", () => {
+      expect(extractMemoryOp("Unknown", { file_path: MEM }, MEM)).toBeNull();
+    });
+  });
+
+  describe("tilde expansion in memoryPath", () => {
+    it("expands tilde in the memoryPath argument itself", () => {
+      const op = extractMemoryOp("Read", { file_path: `${HOME}/.deeplake/memory/x.md` }, "~/.deeplake/memory");
+      expect(op?.op).toBe("read");
+    });
+  });
+});

--- a/tests/claude-code/path-match.test.ts
+++ b/tests/claude-code/path-match.test.ts
@@ -96,7 +96,7 @@ describe("extractMemoryOp", () => {
   describe("tilde expansion in memoryPath", () => {
     it("expands tilde in the memoryPath argument itself", () => {
       const op = extractMemoryOp("Read", { file_path: `${HOME}/.deeplake/memory/x.md` }, "~/.deeplake/memory");
-      expect(op?.op).toBe("read");
+      expect(op).toEqual({ path: `${HOME}/.deeplake/memory/x.md`, op: "read" });
     });
   });
 });


### PR DESCRIPTION
## Problem

`healDriftedOrgToken` runs at every SessionStart and repairs the legacy regression where `org switch` left the API token bound to the *previous* org. It re-mints the token against `creds.orgId` — but it only fixed the **token**, leaving `orgName` and `workspaceId` pointing at the old org.

Two consumers read those stale fields, so the drift stayed user-visible even after the token healed:

- **`billingUrl()`** (`src/deeplake-api.ts:173-184`) builds the "top up" link from `orgName`. A user with drifted creds tops up the **wrong org**, while the low-balance banner is driven by `creds.orgId`'s real balance → **the banner never clears even after paying** ("ho ricaricato ma vedo ancora l'errore").
- The **SessionStart banner** (`src/hooks/session-start.ts:293`) prints `org: ${orgName}` → **the shell shows the wrong org name** ("was in org X, shell said org Y").

## Fix

After re-minting the token, the healer now also realigns the other org-scoped fields against `creds.orgId`:

- **`orgName`** — resolved via `listOrgs`, matched by `id === creds.orgId` (only overwritten on an exact id match, so an unrelated org response can't clobber it).
- **`workspaceId`** — validated via `listWorkspaces`: a concrete stale workspace absent from the new org is reset to `"default"`; a name is normalized to its canonical id. The `"default"` sentinel is skipped (the backend resolves it per-org).

Realign is **best-effort** (wrapped in try/catch) so a lookup failure never undoes the token heal, and it's **gated behind the drift trigger** — it costs one extra GET (two with a non-default workspace) only on the rare session where drift is actually detected.

## Tests

`tests/claude-code/auth.test.ts` — added/updated healer cases:
- re-mint + `orgName` realign (asserts the realign uses the fresh token, count = 2)
- stale concrete workspace reset to `default`
- workspace **name → canonical id** normalization
- best-effort path: `orgName` realign failure still persists the token heal

Full suite green: **185 files, 3839 tests passing**. `tsc --noEmit` clean. Codex review: no blocking issues.

## Session Context
[Session transcript](https://gist.github.com/efenocchi/946c7f47f73103be636a7c8d38271a22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token recovery to best-effort realign organization name and workspace after token rotation; resolves workspace names to canonical IDs, falls back to the default workspace when unresolved, and never blocks token healing (realignment failures are logged).

* **New Features**
  * Made notification helper functionality available for parsing timestamps, cleaning snippets, deriving project labels, choosing signals, and rendering cold-start briefs.

* **Tests**
  * Added and expanded tests for org/workspace drift and repair, token-derived credential saving, cold-start brief logic (unit + filesystem), and path-matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->