### PR TITLE
fix(skillopt): read current skill version by created_at, not the corrupt BIGINT version column

### DIFF
--- a/src/skillify/skill-org-publish.ts
+++ b/src/skillify/skill-org-publish.ts
@@ -63,10 +63,18 @@ export async function readCurrentSkillRow(
     `source_agent, scope, contributors, description, trigger_text, body, version ` +
     `FROM "${sqlIdent(skillsTable)}" ` +
     `WHERE name = '${sqlStr(name)}' AND author = '${sqlStr(author)}' ` +
-    // version DESC, then created_at DESC as a deterministic tie-breaker — if two workers
-    // ever land the same version (cross-machine race), readers resolve the SAME row
-    // instead of an arbitrary one (codex P2).
-    `ORDER BY version DESC, created_at DESC LIMIT 1`,
+    // Order by created_at, NOT version. Deeplake's query engine returns CORRUPTED values
+    // for MAX()/ORDER BY on the BIGINT `version` column when the read lands in the
+    // write-propagation window right after an INSERT — a deterministic 12/12 in a tight
+    // insert→read loop (phantom values like 281473679796896 ≈ 2^48, present in no row).
+    // skillopt reads this immediately before publishing v+1, so `ORDER BY version DESC`
+    // could read a garbage current version and publish a garbage next version (observed
+    // v281473679796898 instead of v6). `created_at` is TEXT and sorts reliably even in
+    // that window (0/12 in the same loop); the row's own `version` value reads clean when
+    // version isn't the sort/agg key. Tie-break by id for determinism on equal timestamps.
+    // Root cause is a Deeplake BIGINT read-after-write bug (filed against deeplake-api);
+    // this is the client-side workaround. See project_skillopt_prod_e2e_findings.
+    `ORDER BY created_at DESC, id DESC LIMIT 1`,
   );
   const r = rows?.[0];
   if (!r) return null;

--- a/tests/shared/skill-org-publish.test.ts
+++ b/tests/shared/skill-org-publish.test.ts
@@ -8,7 +8,11 @@ describe("readCurrentSkillRow", () => {
       expect(sql).toContain('FROM "skills"');
       expect(sql).toContain("name = 'posthog'");
       expect(sql).toContain("author = 'kamo'");
-      expect(sql).toContain("ORDER BY version DESC");
+      // Must order by created_at (TEXT, reliable), NOT version: the BIGINT `version`
+      // column returns corrupted MAX()/ORDER-BY values in the read-after-write window
+      // (Deeplake engine bug), and skillopt reads this right before publishing v+1.
+      expect(sql).toContain("ORDER BY created_at DESC");
+      expect(sql).not.toContain("ORDER BY version"); // negative guard against regressing to the buggy pattern
       return [{
         name: "posthog", author: "kamo", project: "deeplake-api", project_key: "pk1",
         local_path: ".claude/skills", install: "global",


### PR DESCRIPTION
## What

`readCurrentSkillRow` ordered by the BIGINT `version` column; `publishImprovedSkill` does `current.version + 1`. Deeplake's engine returns **corrupted** values for `MAX()`/`ORDER BY` on a BIGINT column in the write-propagation window right after an INSERT — deterministic **12/12** in a tight insert→read loop (phantom values like `281473679796896`≈2^48, present in no row). SkillOpt reads the current version immediately before publishing v+1, so it read garbage and published a garbage version.

## Evidence (full live plugin E2E against the real skillopt org)

A real `claude` session invoked the Skill tool → hooks armed → worker judged → **published `v281473679796898` instead of `v6`**. Root cause isolated: `ORDER BY version DESC`/`MAX(version)` = 12/12 corrupt right after a write; `ORDER BY created_at DESC` = 0/12 (TEXT sorts reliably). Stored data is fine — only BIGINT aggregation/sort during read-after-write is wrong.

## Fix

Order by `created_at DESC, id DESC` (both TEXT) and read the row's own `version`. Validated against the live engine: fixed `readCurrentSkillRow` is **0/8** wrong under tight read-after-write vs 12/12 before. Test asserts the query orders by `created_at` and **not** `version` (negative guard).

## Scope / follow-up

Client-side workaround. The root cause is a Deeplake BIGINT read-after-write bug being fixed in `deeplake-api`. The same `ORDER BY version`/`MAX(version)` pattern exists in `rules/read.ts`, `goal.ts`, `context-renderer.ts`, `deeplake-api.ts` — lower risk (reads aren't post-write-tight), covered by the backend fix.

tsc clean; 16 skillopt tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data consistency issue in skill information retrieval that could cause outdated data to be displayed. The system now correctly prioritizes the most recent skill records.

* **Tests**
  * Updated tests to validate the improved skill retrieval logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->