### PR TITLE
fix(deps): move @huggingface/transformers to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.97.1",
-    "@huggingface/transformers": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "deeplake": "^0.3.30",
     "js-yaml": "^4.1.1",
@@ -65,6 +64,7 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
+    "@huggingface/transformers": "^3.0.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-c": "0.23.2",
     "tree-sitter-cpp": "^0.23.4",


### PR DESCRIPTION
## Summary

- Moves `@huggingface/transformers` from `dependencies` to `optionalDependencies`
- `sharp` (transitive dep via `@huggingface/transformers`) has no prebuilt binary for Node v26 on macOS and requires `node-gyp` to build from source, causing `npm install -g @deeplake/hivemind` to fail
- Embeddings are already opt-in (`hivemind embeddings install`) and the code already handles the package being absent gracefully — this aligns the package.json with runtime behavior

## Test plan

- [ ] `npm install -g @deeplake/hivemind` succeeds on Node v26 macOS without `node-gyp` installed
- [ ] `hivemind embeddings install` still works and downloads `@huggingface/transformers` on demand
- [ ] Existing tests pass (no logic changed, only package.json metadata)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Hugging Face Transformers library is now marked as an optional dependency, allowing for smaller installations for users who don't require this functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->