### PR TITLE
fix(pre-tool-use): don't intercept incidental memory-path mentions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,11 @@ jobs:
           echo "body-file=/tmp/pr-coverage.md" >> "$GITHUB_OUTPUT"
 
       - name: Post coverage comment on PR
-        if: github.event_name == 'pull_request' && always() && steps.pr-coverage.outputs.body-file != ''
+        # Fork PRs get a read-only GITHUB_TOKEN: the comment API returns
+        # "Resource not accessible by integration", failing the job and
+        # skipping the bundle build/smoke steps below. Skip the comment
+        # there — the coverage gate itself already ran above.
+        if: github.event_name == 'pull_request' && always() && steps.pr-coverage.outputs.body-file != '' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: pr-coverage-report

--- a/src/hooks/memory-path-utils.ts
+++ b/src/hooks/memory-path-utils.ts
@@ -134,7 +134,10 @@ export function parseBashTokens(cmd: string): string[][] {
     const char = cmd[i];
 
     if (escape) { currentToken += char; escape = false; continue; } // prev char was `\`
-    if (char === "\\") { escape = true; currentToken += char; continue; }
+    // Backslash is literal inside single quotes (bash semantics) — treating it
+    // as an escape there would swallow the closing quote and hide a following
+    // `; cmd …` stage inside the quoted token.
+    if (char === "\\" && !inSingle) { escape = true; currentToken += char; continue; }
     if (char === "'" && !inDouble) { inSingle = !inSingle; currentToken += char; continue; } // keep quotes
     if (char === '"' && !inSingle) { inDouble = !inDouble; currentToken += char; continue; }
 
@@ -145,6 +148,13 @@ export function parseBashTokens(cmd: string): string[][] {
       if (char === ">") { // own token, so `>file` (no space) is detectable
         pushToken();
         if (cmd[i + 1] === ">") { currentStage.push(">>"); i++; } else currentStage.push(">");
+        continue;
+      }
+      if (char === "<") { // own token, so `<file` (no space) is detectable;
+        pushToken();      // `<<`/`<<<` (heredoc/herestring) lump into one token
+        let run = "<";    // so only a lone `<` reads a file path
+        while (cmd[i + 1] === "<" && run.length < 3) { run += "<"; i++; }
+        currentStage.push(run);
         continue;
       }
       if (/\s/.test(char)) { pushToken(); continue; }
@@ -164,25 +174,31 @@ export function parseBashTokens(cmd: string): string[][] {
 const PASSTHROUGH_COMMANDS = new Set(["echo", "printf", "claude"]);
 
 export function bashTouchesMemory(cmd: string): boolean {
+  // Substitutions — $(), backticks, <(…) — run on the host no matter whose
+  // argv they sit in, and isSafe() (which rejects them) only runs AFTER this
+  // function returns true. So they get no carve-out: any memory mention next
+  // to one is intercepted and lands on the guidance/deny path downstream.
+  if (/\$\(|`|<\(/.test(cmd) && touchesMemory(cmd)) return true;
+
   const stages = parseBashTokens(stripHeredocBodies(cmd));
 
   for (const stage of stages) {
     if (stage.length === 0) continue;
     const program = stage[0].replace(/^["']|["']$/g, "");
 
-    // A redirection target into memory is a WRITE — always intercept
-    // (e.g. `echo '<content>' > '<path>'`), regardless of the command.
+    // A redirection on a memory path is a real interaction regardless of the
+    // command: `>`/`>>` writes (the documented `echo '<content>' > '<path>'`
+    // path), `<` reads (`claude -p 'summarize' < '<path>'`) — always intercept.
     for (let i = 0; i < stage.length; i++) {
-      if ((stage[i] === ">" || stage[i] === ">>") && i + 1 < stage.length
-          && touchesMemory(stage[i + 1])) {
+      if ((stage[i] === ">" || stage[i] === ">>" || stage[i] === "<")
+          && i + 1 < stage.length && touchesMemory(stage[i + 1])) {
         return true;
       }
     }
 
-    // echo/printf/claude with the path as inert text → skip this stage, UNLESS
-    // it smuggles a command substitution ($()/backticks) that would run on the
-    // host — those fall through to be caught below.
-    if (PASSTHROUGH_COMMANDS.has(program) && !/\$\(|`/.test(stage.join(" "))) {
+    // echo/printf/claude with the path as inert text → skip this stage
+    // (substitution smuggling is already handled above).
+    if (PASSTHROUGH_COMMANDS.has(program)) {
       continue;
     }
 

--- a/src/hooks/memory-path-utils.ts
+++ b/src/hooks/memory-path-utils.ts
@@ -111,3 +111,87 @@ export function rewritePaths(cmd: string): string {
     .replace(new RegExp('"' + escapeRe(HOME_VAR_PATH) + tail + '"', "g"), '"/"')
     .replace(new RegExp(escapeRe(HOME_VAR_PATH) + tail, "g"), "/");
 }
+
+// Split a bash command into pipe/chain stages, each an argv array, respecting
+// quotes and escapes. `>`/`>>` are emitted as their own tokens.
+export function parseBashTokens(cmd: string): string[][] {
+  const stages: string[][] = [];
+  let currentStage: string[] = [];
+  let currentToken = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escape = false;
+
+  const pushToken = () => {
+    if (currentToken.length > 0) { currentStage.push(currentToken); currentToken = ""; }
+  };
+  const pushStage = () => {
+    pushToken();
+    if (currentStage.length > 0) { stages.push(currentStage); currentStage = []; }
+  };
+
+  for (let i = 0; i < cmd.length; i++) {
+    const char = cmd[i];
+
+    if (escape) { currentToken += char; escape = false; continue; } // prev char was `\`
+    if (char === "\\") { escape = true; currentToken += char; continue; }
+    if (char === "'" && !inDouble) { inSingle = !inSingle; currentToken += char; continue; } // keep quotes
+    if (char === '"' && !inSingle) { inDouble = !inDouble; currentToken += char; continue; }
+
+    if (!inSingle && !inDouble) { // separators only act outside quotes
+      if (char === "\n" || char === ";") { pushStage(); continue; }
+      if (char === "|") { if (cmd[i + 1] === "|") i++; pushStage(); continue; } // `|` / `||`
+      if (char === "&" && cmd[i + 1] === "&") { i++; pushStage(); continue; }   // `&&`
+      if (char === ">") { // own token, so `>file` (no space) is detectable
+        pushToken();
+        if (cmd[i + 1] === ">") { currentStage.push(">>"); i++; } else currentStage.push(">");
+        continue;
+      }
+      if (/\s/.test(char)) { pushToken(); continue; }
+    }
+
+    currentToken += char;
+  }
+
+  pushStage();
+  return stages;
+}
+
+// echo/printf print their args; `claude -p` takes a natural-language prompt —
+// a memory path in their arguments is inert text (the #87 false positive).
+// Interpreters (python/node/ruby/…) and fetchers (curl) are deliberately NOT
+// here: they execute/read their args, so a memory path is a real interaction.
+const PASSTHROUGH_COMMANDS = new Set(["echo", "printf", "claude"]);
+
+export function bashTouchesMemory(cmd: string): boolean {
+  const stages = parseBashTokens(stripHeredocBodies(cmd));
+
+  for (const stage of stages) {
+    if (stage.length === 0) continue;
+    const program = stage[0].replace(/^["']|["']$/g, "");
+
+    // A redirection target into memory is a WRITE — always intercept
+    // (e.g. `echo '<content>' > '<path>'`), regardless of the command.
+    for (let i = 0; i < stage.length; i++) {
+      if ((stage[i] === ">" || stage[i] === ">>") && i + 1 < stage.length
+          && touchesMemory(stage[i + 1])) {
+        return true;
+      }
+    }
+
+    // echo/printf/claude with the path as inert text → skip this stage, UNLESS
+    // it smuggles a command substitution ($()/backticks) that would run on the
+    // host — those fall through to be caught below.
+    if (PASSTHROUGH_COMMANDS.has(program) && !/\$\(|`/.test(stage.join(" "))) {
+      continue;
+    }
+
+    // Default (builtins, interpreters, fetchers, anything else): a memory path
+    // in ANY token is a real interaction → intercept. getShellCommand()/isSafe()
+    // decide route-to-VFS vs retry-guidance downstream.
+    for (const token of stage) {
+      if (touchesMemory(token)) return true;
+    }
+  }
+  return false;
+}

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -24,7 +24,7 @@ import {
   readCachedIndexContent,
   writeCachedIndexContent,
 } from "./query-cache.js";
-import { isSafe, touchesMemory, rewritePaths } from "./memory-path-utils.js";
+import { isSafe, touchesMemory, rewritePaths, bashTouchesMemory } from "./memory-path-utils.js";
 import { capOutputForClaude } from "../utils/output-cap.js";
 import { ensureSessionOwner } from "./summary-state.js";
 
@@ -174,7 +174,7 @@ export function getShellCommand(toolName: string, toolInput: Record<string, unkn
     }
     case "Bash": {
       const cmd = toolInput.command as string | undefined;
-      if (!cmd || !touchesMemory(cmd)) break;
+      if (!cmd || !bashTouchesMemory(cmd)) break;
       const rewritten = rewritePaths(cmd);
       if (!isSafe(rewritten)) {
         log(`unsafe command blocked: ${rewritten}`);
@@ -297,7 +297,7 @@ export async function processPreToolUse(input: PreToolUseInput, deps: ClaudePreT
     return buildDenyDecision(WRITE_EDIT_DENY_REASON, `[DeepLake] ${input.tool_name} denied on memory path`);
   }
 
-  if (!shellCmd && (touchesMemory(cmd) || touchesMemory(toolPath))) {
+  if (!shellCmd && (bashTouchesMemory(cmd) || touchesMemory(toolPath))) {
     // Unsupported/unsafe command targeting memory (interpreter, $(), pipes,
     // chains, …). Do NOT rewrite it to a host `cat`: that decision runs on the
     // real filesystem, not the VFS, so `python3 ~/.deeplake/memory/../../etc/passwd`

--- a/tests/claude-code/pre-tool-use.test.ts
+++ b/tests/claude-code/pre-tool-use.test.ts
@@ -544,15 +544,27 @@ describe("pre-tool-use: incidental memory mentions pass through", () => {
     // would swallow it into the echo passthrough.
     const r = runPreToolUse("Bash", { command: "echo 'a\\' ; cat ~/.deeplake/memory/index.md" });
     expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
   });
 
   it("still intercepts `claude` reading memory via input redirect", () => {
     const r = runPreToolUse("Bash", { command: "claude -p 'summarize this' < ~/.deeplake/memory/index.md" });
     expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
   });
 
   it("still intercepts `printf` reading memory via input redirect", () => {
     const r = runPreToolUse("Bash", { command: "printf '%s' < ~/.deeplake/memory/index.md" });
     expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
   });
 });

--- a/tests/claude-code/pre-tool-use.test.ts
+++ b/tests/claude-code/pre-tool-use.test.ts
@@ -505,15 +505,54 @@ describe("pre-tool-use: incidental memory mentions pass through", () => {
   it("still intercepts `echo` redirecting INTO memory (documented write path)", () => {
     const r = runPreToolUse("Bash", { command: "echo 'hi' > ~/.deeplake/memory/note.md" });
     expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
   });
 
   it("still intercepts `echo` with a substitution touching memory", () => {
     const r = runPreToolUse("Bash", { command: "echo $(cat ~/.deeplake/memory/index.md)" });
     expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
   });
 
   it("intercepts a quoted reader path", () => {
     const r = runPreToolUse("Bash", { command: 'cat "~/.deeplake/memory/index.md"' });
+    expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
+  });
+
+  it("still intercepts `echo` with a process substitution reading memory", () => {
+    const r = runPreToolUse("Bash", { command: "echo <(cat ~/.deeplake/memory/secrets.md)" });
+    expect(r.empty).toBe(false);
+    if (!r.empty) {
+      expect(r.decision).toBe("allow");
+      expect(r.updatedCommand).toContain("RETRY REQUIRED");
+    }
+  });
+
+  it("still intercepts a reader stage hidden behind a backslash in single quotes", () => {
+    // In bash, `\` is literal inside single quotes, so the quote closes and
+    // `cat …` is a second stage — a parser that escapes through the quote
+    // would swallow it into the echo passthrough.
+    const r = runPreToolUse("Bash", { command: "echo 'a\\' ; cat ~/.deeplake/memory/index.md" });
+    expect(r.empty).toBe(false);
+  });
+
+  it("still intercepts `claude` reading memory via input redirect", () => {
+    const r = runPreToolUse("Bash", { command: "claude -p 'summarize this' < ~/.deeplake/memory/index.md" });
+    expect(r.empty).toBe(false);
+  });
+
+  it("still intercepts `printf` reading memory via input redirect", () => {
+    const r = runPreToolUse("Bash", { command: "printf '%s' < ~/.deeplake/memory/index.md" });
     expect(r.empty).toBe(false);
   });
 });

--- a/tests/claude-code/pre-tool-use.test.ts
+++ b/tests/claude-code/pre-tool-use.test.ts
@@ -485,3 +485,35 @@ describe("pre-tool-use: Write / Edit on memory paths are denied with Bash guidan
     expect(r.empty).toBe(true);
   });
 });
+
+
+describe("pre-tool-use: incidental memory mentions pass through", () => {
+  it("passes through `claude -p` with a memory path in the prompt", () => {
+    const r = runPreToolUse("Bash", {
+      command: "claude -p 'use the memory at ~/.deeplake/memory/'",
+    });
+    expect(r.empty).toBe(true);
+  });
+
+  it("passes through `echo` of a memory path", () => {
+    const r = runPreToolUse("Bash", { command: "echo '~/.deeplake/memory/'" });
+    expect(r.empty).toBe(true);
+  });
+
+  // ── boundaries: the carve-out must NOT swallow real interactions ──
+
+  it("still intercepts `echo` redirecting INTO memory (documented write path)", () => {
+    const r = runPreToolUse("Bash", { command: "echo 'hi' > ~/.deeplake/memory/note.md" });
+    expect(r.empty).toBe(false);
+  });
+
+  it("still intercepts `echo` with a substitution touching memory", () => {
+    const r = runPreToolUse("Bash", { command: "echo $(cat ~/.deeplake/memory/index.md)" });
+    expect(r.empty).toBe(false);
+  });
+
+  it("intercepts a quoted reader path", () => {
+    const r = runPreToolUse("Bash", { command: 'cat "~/.deeplake/memory/index.md"' });
+    expect(r.empty).toBe(false);
+  });
+});

--- a/tests/shared/memory-path-utils.test.ts
+++ b/tests/shared/memory-path-utils.test.ts
@@ -123,7 +123,7 @@ describe("bashTouchesMemory", () => {
     expect(bashTouchesMemory(`cat "${MEM}/index.md"`)).toBe(true);
   });
 
-  it("intercepts an interpreter on a memory path", () => {
+  it("intercepts an interpreter with a memory-path prefix even when traversal targets elsewhere", () => {
     expect(bashTouchesMemory(`python3 ${MEM}/../../etc/passwd`)).toBe(true);
   });
 

--- a/tests/shared/memory-path-utils.test.ts
+++ b/tests/shared/memory-path-utils.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseBashTokens,
+  bashTouchesMemory,
+  touchesMemory,
+  TILDE_PATH,
+} from "../../src/hooks/memory-path-utils.js";
+
+const MEM = TILDE_PATH; // ~/.deeplake/memory
+
+describe("parseBashTokens", () => {
+  it("splits a simple command into one stage of argv tokens", () => {
+    expect(parseBashTokens("cat foo.md")).toEqual([["cat", "foo.md"]]);
+  });
+
+  it("splits stages on ; | || && and newline", () => {
+    expect(parseBashTokens("a 1; b 2 | c 3 || d 4 && e 5\nf 6")).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+      ["d", "4"],
+      ["e", "5"],
+      ["f", "6"],
+    ]);
+  });
+
+  it("keeps separators inert inside quotes", () => {
+    expect(parseBashTokens("echo 'a; b | c' \"d && e\"")).toEqual([
+      ["echo", "'a; b | c'", '"d && e"'],
+    ]);
+  });
+
+  it("emits > and >> as their own tokens, even unspaced", () => {
+    expect(parseBashTokens("echo hi >file")).toEqual([["echo", "hi", ">", "file"]]);
+    expect(parseBashTokens("echo hi >> file")).toEqual([["echo", "hi", ">>", "file"]]);
+  });
+
+  it("emits < as its own token, lumping << / <<< so they are not read-redirects", () => {
+    expect(parseBashTokens("cat <file")).toEqual([["cat", "<", "file"]]);
+    expect(parseBashTokens("cat <<EOF")).toEqual([["cat", "<<", "EOF"]]);
+    expect(parseBashTokens("cat <<< word")).toEqual([["cat", "<<<", "word"]]);
+  });
+
+  it("escape consumes the next char outside quotes", () => {
+    expect(parseBashTokens("echo a\\ b")).toEqual([["echo", "a\\ b"]]);
+  });
+
+  it("treats backslash as literal inside single quotes (bash semantics)", () => {
+    // `'a\'` closes at the second quote; `; cat x` is a separate stage.
+    expect(parseBashTokens("echo 'a\\' ; cat x")).toEqual([
+      ["echo", "'a\\'"],
+      ["cat", "x"],
+    ]);
+  });
+
+  it("drops empty stages from leading/duplicate separators", () => {
+    expect(parseBashTokens("; cat x ;; ls")).toEqual([["cat", "x"], ["ls"]]);
+  });
+});
+
+describe("bashTouchesMemory", () => {
+  // ── carve-out: inert mentions pass ──
+  it.each(["echo", "printf", "claude"])("passes %s with the path as inert text", (prog) => {
+    expect(bashTouchesMemory(`${prog} 'use the mount at ${MEM}/'`)).toBe(false);
+  });
+
+  it("passes a quoted passthrough program name", () => {
+    expect(bashTouchesMemory(`"echo" '${MEM}/'`)).toBe(false);
+  });
+
+  it("passes commands that do not mention memory at all", () => {
+    expect(bashTouchesMemory("ls -la /tmp")).toBe(false);
+  });
+
+  it("does not false-positive on a sibling path", () => {
+    expect(bashTouchesMemory(`cat ${MEM}-backup/x`)).toBe(false);
+  });
+
+  // ── substitutions: no carve-out ──
+  it("intercepts $() substitution touching memory inside a passthrough command", () => {
+    expect(bashTouchesMemory(`echo $(cat ${MEM}/index.md)`)).toBe(true);
+  });
+
+  it("intercepts backtick substitution touching memory", () => {
+    expect(bashTouchesMemory(`echo \`cat ${MEM}/index.md\``)).toBe(true);
+  });
+
+  it("intercepts <() process substitution touching memory", () => {
+    expect(bashTouchesMemory(`echo <(cat ${MEM}/secrets.md)`)).toBe(true);
+  });
+
+  it("passes a substitution that does not touch memory", () => {
+    expect(bashTouchesMemory("echo $(date)")).toBe(false);
+  });
+
+  // ── redirects: real interactions regardless of command ──
+  it("intercepts > redirect into memory (documented write path)", () => {
+    expect(bashTouchesMemory(`echo 'hi' > ${MEM}/note.md`)).toBe(true);
+  });
+
+  it("intercepts >> append into memory", () => {
+    expect(bashTouchesMemory(`printf '%s' x >> '${MEM}/note.md'`)).toBe(true);
+  });
+
+  it("intercepts < read from memory", () => {
+    expect(bashTouchesMemory(`claude -p 'summarize' < ${MEM}/index.md`)).toBe(true);
+  });
+
+  it("passes a redirect whose target is not memory", () => {
+    expect(bashTouchesMemory("echo hi > /tmp/out.md")).toBe(false);
+  });
+
+  it("passes a trailing redirect with no target token", () => {
+    expect(bashTouchesMemory("echo hi >")).toBe(false);
+  });
+
+  // ── default: any other command with a memory token is a real interaction ──
+  it("intercepts a reader builtin on a memory path", () => {
+    expect(bashTouchesMemory(`cat ${MEM}/index.md`)).toBe(true);
+  });
+
+  it("intercepts a quoted reader path", () => {
+    expect(bashTouchesMemory(`cat "${MEM}/index.md"`)).toBe(true);
+  });
+
+  it("intercepts an interpreter on a memory path", () => {
+    expect(bashTouchesMemory(`python3 ${MEM}/../../etc/passwd`)).toBe(true);
+  });
+
+  it("intercepts when a later stage touches memory even if the first is passthrough", () => {
+    expect(bashTouchesMemory(`echo '${MEM}/' && cat ${MEM}/index.md`)).toBe(true);
+  });
+
+  it("intercepts a reader stage hidden behind a backslash in single quotes", () => {
+    expect(bashTouchesMemory(`echo 'a\\' ; cat ${MEM}/index.md`)).toBe(true);
+  });
+
+  // ── heredoc interplay: quoted heredoc bodies are inert ──
+  it("ignores a memory mention inside a quoted heredoc body", () => {
+    expect(bashTouchesMemory(`cat <<'EOF' > /tmp/x\n${MEM}/\nEOF`)).toBe(false);
+  });
+
+  it("agrees with touchesMemory on the bare-path shapes it builds on", () => {
+    expect(touchesMemory(`${MEM}/index.md`)).toBe(true);
+    expect(touchesMemory("/tmp/other.md")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #87

## Problem
The Bash branch ran `touchesMemory(cmd)` as a substring/regex test, so the
memory path triggered interception even when it only appeared as inert text
in a prompt — e.g. `claude -p 'use ~/.deeplake/memory/'` was rewritten to the
`[RETRY REQUIRED]` echo instead of running.

## Fix
Added `bashTouchesMemory()` (in `memory-path-utils.ts`), which tokenizes the
command (`parseBashTokens`) and applies a **narrow carve-out on top of broad
detection**:
- Default: any memory-path reference is a real interaction → intercept. This
  keeps file builtins routed and interpreters/fetchers/substitutions on the
  retry-guidance path (preserves the host-access + path-traversal protections
  the existing tests pin).
- Carve-out: `echo`/`printf`/`claude` stages where the path is inert text pass
  through — UNLESS it's a redirection target (a write, the documented
  `echo '<content>' > '<path>'` path) or smuggles a `$()`/backtick
  substitution, which fall through to be caught.

Swapped `touchesMemory` → `bashTouchesMemory` in the two Bash-command gates in
`pre-tool-use.ts`; bare-path detection for Read/Grep/Glob/Write/Edit is
unchanged.

## Acceptance (#87)
- [x] `cat ~/.deeplake/memory/index.md` — still intercepted
- [x] `claude -p 'use ~/.deeplake/memory/'` — passes through
- [x] `echo '~/.deeplake/memory/'` — passes through
- [x] `grep foo ~/.deeplake/memory/summaries/` — still intercepted

## Why not the argv/command-name approach from the issue
Command-name alone can't satisfy the acceptance: it can't pass `echo '<path>'`
while keeping `rm`/`python3` on a bare memory path routed/guided, since those
are non-reader commands too. Worse, "unrecognized → pass through" would let
`python3 ~/.deeplake/memory/../../../etc/passwd` reach the host shell. The
carve-out approach passes all four cases and keeps the existing security tests
green.

## Tests
Added a `#87` block covering the two passthrough cases plus boundaries (write
redirect, `$()` substitution, quoted reader still intercept). Full existing
suite stays green.

## Out of scope
`parseBashTokens` handles `; | || && \n`, quotes, and `>`/`>>`; it does not
unescape backslashes, fully model `2>`/`&>` fd-redirects, or parse `<(`
(isSafe() rejects `<(`, `$()`, backticks upstream).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Bash-aware parsing and memory-interaction detection for shell commands, used by pre-tool guidance.

* **Bug Fixes**
  * Avoids false positives for incidental memory-path mentions (e.g., printed, quoted, or heredoc content) while still catching real interactions like redirects, command substitution, and process reads.

* **Tests**
  * Added comprehensive boundary tests for quoting, substitutions, redirections, heredocs, multi-stage commands, and passthrough cases.

* **Chores**
  * CI workflow: tightened condition for posting coverage comments on PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->