### PR TITLE
fix(mcp): treat missing memory/sessions tables as empty memory

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { loadCredentials } from "../commands/auth.js";
 import { loadConfig } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
+import { isMissingTableError } from "../deeplake-schema.js";
 import { sqlStr, sqlLike } from "../utils/sql.js";
 import { searchDeeplakeTables, buildGrepSearchOptions, normalizeContent, type GrepMatchParams } from "../shell/grep-core.js";
 import { getVersion } from "../cli/version.js";
@@ -45,6 +46,16 @@ function getContext(): ServerContext | { error: string } {
 function errorResult(text: string): { content: Array<{ type: "text"; text: string }> } {
   return { content: [{ type: "text", text }] };
 }
+
+/**
+ * On a fresh org no session has run yet, so the memory/sessions tables
+ * don't exist — provisioning happens in the per-agent SessionStart hooks,
+ * not here (the MCP server is read-only; a READ-role member couldn't
+ * CREATE TABLE anyway). Treat the backend's missing-table 400 as "memory
+ * is empty" instead of surfacing the raw error (issue #252).
+ */
+const FRESH_ORG_HINT =
+  "Hivemind memory is empty — tables are created when the first agent session starts, and entries appear after it ends.";
 
 const server = new McpServer({
   name: "hivemind",
@@ -87,6 +98,7 @@ server.registerTool(
       return { content: [{ type: "text", text: lines.join("\n\n---\n\n") }] };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      if (isMissingTableError(msg)) return errorResult(`No matches for "${query}". ${FRESH_ORG_HINT}`);
       return errorResult(`Search failed: ${msg}`);
     }
   },
@@ -120,6 +132,7 @@ server.registerTool(
       return { content: [{ type: "text", text }] };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      if (isMissingTableError(msg)) return errorResult(`No content found at ${path}. ${FRESH_ORG_HINT}`);
       return errorResult(`Read failed: ${msg}`);
     }
   },
@@ -160,6 +173,7 @@ server.registerTool(
       return { content: [{ type: "text", text: `path\tlast_updated\tproject\tdescription\n${lines.join("\n")}` }] };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      if (isMissingTableError(msg)) return errorResult(`No summaries found. ${FRESH_ORG_HINT}`);
       return errorResult(`Index failed: ${msg}`);
     }
   },

--- a/tests/claude-code/mcp-server.test.ts
+++ b/tests/claude-code/mcp-server.test.ts
@@ -200,6 +200,15 @@ describe("hivemind_read", () => {
     expect(JSON.stringify(out)).toContain("Read failed: conn refused");
   });
 
+  it("a row with SQL NULL content renders as empty, not as the string 'null'", async () => {
+    // message is a nullable JSONB column, so message::text can be NULL on
+    // real session rows. String(null) would hand the agent a literal "null".
+    queryMock.mockResolvedValue([{ path: "/sessions/alice/s.jsonl", content: null }]);
+    await importServer();
+    const out = await registeredTools.get("hivemind_read")!.handler({ path: "/sessions/alice/s.jsonl" }) as { content: { text: string }[] };
+    expect(out.content[0].text).toBe("");
+  });
+
   it("not authenticated → auth-error short-circuits before any query", async () => {
     loadCredentialsMock.mockReturnValue(null);
     await importServer();
@@ -261,6 +270,18 @@ describe("hivemind_index", () => {
     await importServer();
     const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
     expect(out.content[0].text).toContain("/summaries/alice/a.md\t2026-04-01\tml\tAlice's first session");
+  });
+
+  it("incomplete legacy rows render placeholders, never the strings 'null'/'undefined'", async () => {
+    // Rows from orgs predating a schema-heal can come back with missing
+    // keys or SQL NULLs. The agent reads this output verbatim — feeding it
+    // "undefined\tnull\t..." would poison the recall context.
+    queryMock.mockResolvedValue([
+      { description: null, project: null, last_update_date: null },
+    ]);
+    await importServer();
+    const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
+    expect(out.content[0].text).toBe("path\tlast_updated\tproject\tdescription\n?\t\t\t");
   });
 });
 

--- a/tests/claude-code/mcp-server.test.ts
+++ b/tests/claude-code/mcp-server.test.ts
@@ -271,40 +271,35 @@ describe("fresh org — missing memory/sessions tables (issue #252)", () => {
   const missingTableErr = new Error(
     'Query failed: 400: {"error":"Table does not exist: relation \\"memory\\" does not exist","code":"INVALID_REQUEST","request_id":"fb0c2da8-d02c-4670-8ecd-c232d59b59da"}',
   );
+  const freshOrgHint =
+    "Hivemind memory is empty — tables are created when the first agent session starts, and entries appear after it ends.";
 
   it("hivemind_index: missing table → 'No summaries found.' + fresh-org hint, no raw 400", async () => {
     queryMock.mockRejectedValue(missingTableErr);
     await importServer();
     const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
-    expect(out.content[0].text).toContain("No summaries found.");
-    expect(out.content[0].text).toContain("first agent session");
-    expect(out.content[0].text).not.toContain("Index failed");
-    expect(out.content[0].text).not.toContain("400");
+    expect(out.content[0].text).toBe(`No summaries found. ${freshOrgHint}`);
   });
 
   it("hivemind_search: missing table → 'No matches' + fresh-org hint, no raw 400", async () => {
     searchDeeplakeTablesMock.mockRejectedValue(missingTableErr);
     await importServer();
     const out = await registeredTools.get("hivemind_search")!.handler({ query: "needle" }) as { content: { text: string }[] };
-    expect(out.content[0].text).toContain('No matches for "needle".');
-    expect(out.content[0].text).toContain("first agent session");
-    expect(out.content[0].text).not.toContain("Search failed");
+    expect(out.content[0].text).toBe(`No matches for "needle". ${freshOrgHint}`);
   });
 
   it("hivemind_read: missing table → 'No content found' + fresh-org hint, no raw 400", async () => {
     queryMock.mockRejectedValue(missingTableErr);
     await importServer();
     const out = await registeredTools.get("hivemind_read")!.handler({ path: "/summaries/alice/a.md" }) as { content: { text: string }[] };
-    expect(out.content[0].text).toContain("No content found at /summaries/alice/a.md");
-    expect(out.content[0].text).toContain("first agent session");
-    expect(out.content[0].text).not.toContain("Read failed");
+    expect(out.content[0].text).toBe(`No content found at /summaries/alice/a.md. ${freshOrgHint}`);
   });
 
   it("bare postgres wording (relation ... does not exist) is also classified", async () => {
     queryMock.mockRejectedValue(new Error('relation "sessions" does not exist'));
     await importServer();
     const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
-    expect(out.content[0].text).toContain("No summaries found.");
+    expect(out.content[0].text).toBe(`No summaries found. ${freshOrgHint}`);
   });
 
   it("missing COLUMN is NOT treated as fresh org — raw error still surfaces", async () => {

--- a/tests/claude-code/mcp-server.test.ts
+++ b/tests/claude-code/mcp-server.test.ts
@@ -264,6 +264,58 @@ describe("hivemind_index", () => {
   });
 });
 
+describe("fresh org — missing memory/sessions tables (issue #252)", () => {
+  // Exact error shape captured from a live repro against api.deeplake.ai
+  // (MCP server pointed at a nonexistent table). The backend 400 must be
+  // classified as "memory is empty", not surfaced raw.
+  const missingTableErr = new Error(
+    'Query failed: 400: {"error":"Table does not exist: relation \\"memory\\" does not exist","code":"INVALID_REQUEST","request_id":"fb0c2da8-d02c-4670-8ecd-c232d59b59da"}',
+  );
+
+  it("hivemind_index: missing table → 'No summaries found.' + fresh-org hint, no raw 400", async () => {
+    queryMock.mockRejectedValue(missingTableErr);
+    await importServer();
+    const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
+    expect(out.content[0].text).toContain("No summaries found.");
+    expect(out.content[0].text).toContain("first agent session");
+    expect(out.content[0].text).not.toContain("Index failed");
+    expect(out.content[0].text).not.toContain("400");
+  });
+
+  it("hivemind_search: missing table → 'No matches' + fresh-org hint, no raw 400", async () => {
+    searchDeeplakeTablesMock.mockRejectedValue(missingTableErr);
+    await importServer();
+    const out = await registeredTools.get("hivemind_search")!.handler({ query: "needle" }) as { content: { text: string }[] };
+    expect(out.content[0].text).toContain('No matches for "needle".');
+    expect(out.content[0].text).toContain("first agent session");
+    expect(out.content[0].text).not.toContain("Search failed");
+  });
+
+  it("hivemind_read: missing table → 'No content found' + fresh-org hint, no raw 400", async () => {
+    queryMock.mockRejectedValue(missingTableErr);
+    await importServer();
+    const out = await registeredTools.get("hivemind_read")!.handler({ path: "/summaries/alice/a.md" }) as { content: { text: string }[] };
+    expect(out.content[0].text).toContain("No content found at /summaries/alice/a.md");
+    expect(out.content[0].text).toContain("first agent session");
+    expect(out.content[0].text).not.toContain("Read failed");
+  });
+
+  it("bare postgres wording (relation ... does not exist) is also classified", async () => {
+    queryMock.mockRejectedValue(new Error('relation "sessions" does not exist'));
+    await importServer();
+    const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
+    expect(out.content[0].text).toContain("No summaries found.");
+  });
+
+  it("missing COLUMN is NOT treated as fresh org — raw error still surfaces", async () => {
+    queryMock.mockRejectedValue(new Error('column "description" of relation "memory" does not exist'));
+    await importServer();
+    const out = await registeredTools.get("hivemind_index")!.handler({}) as { content: { text: string }[] };
+    expect(out.content[0].text).toContain("Index failed:");
+    expect(out.content[0].text).not.toContain("No summaries found.");
+  });
+});
+
 describe("error-message coercion (non-Error rejections)", () => {
   // Source uses `err instanceof Error ? err.message : String(err)` — exercise
   // the String(err) branch by rejecting with a non-Error value.


### PR DESCRIPTION
## Summary

Fixes #252.

On a brand-new org no agent session has run yet, so the `memory`/`sessions` tables don't exist — provisioning happens in the per-agent SessionStart hooks (`src/hooks/session-start.ts` and the hermes/cursor/codex variants), not at install time. The MCP server queries the tables directly, so `hivemind_search` / `hivemind_read` / `hivemind_index` surfaced the raw backend 400:

```
Index failed: Query failed: 400: {"error":"Table does not exist: relation \"memory\" does not exist","code":"INVALID_REQUEST",...}
```

## Fix

In the three MCP tool handlers, classify the caught error with `isMissingTableError()` (the same helper `commands/rules.ts` and `skillify/pull.ts` already use for this exact situation) and return the friendly empty result the zero-rows path produces, plus a hint:

```
No summaries found. Hivemind memory is empty — tables are created when the first agent session starts, and entries appear after it ends.
```

Intentionally **no DDL from the MCP server**: it is a read-only path, a READ-role org member couldn't `CREATE TABLE` anyway, and `createTableWithRetry` could block a tool call for ~17s. Tables keep being provisioned by the SessionStart hooks.

## Answers to the questions in #252

- The per-org tables **are** auto-provisioned — on the first agent **session start**, not on install or first write. No manual backend step needed.
- The feared session-end write failure cannot happen: the capture hooks call `ensureSessionsTable` before writing.
- The only broken path was MCP-before-first-session, fixed here.

## Verification

- Reproduced live against `api.deeplake.ai` by running the built MCP server over raw stdio JSON-RPC (same probe as the issue) pointed at nonexistent tables: both tools returned the exact 400 from the issue. After the fix, the same probe returns the clean empty-memory message.
- Also exercised the Hermes `pre_tool_call` grep fallback from the built bundle: on missing tables it logs `fast-path failed, falling through` and stays silent (unchanged by this PR, by design).
- 5 new tests in `tests/claude-code/mcp-server.test.ts` using the exact backend error string (all three tools, bare-postgres wording variant, and a negative test that a missing **column** still surfaces raw). Full suite: 227 files / 4419 tests pass.

## Session Context
[Session transcript](https://gist.github.com/efenocchi/e576b6a459b11618c619de688d415823)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for fresh organizations: search/read/index now return friendly "no matches/content/summaries" messages with a hint that memory/session tables are created during the first agent session, instead of surfacing backend table errors.
  * Render empty content correctly when stored value is SQL NULL (avoids showing the literal "null").

* **Tests**
  * Added tests verifying fresh-org messaging behavior and that other errors continue to surface normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->