### PR TITLE
docs(readme): center Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/28172" target="_blank"><img src="https://trendshift.io/api/badge/repositories/28172" alt="activeloopai%2Fhivemind | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+  <a href="https://trendshift.io/repositories/28172" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/28172" alt="activeloopai/hivemind | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
 > One engineer's agent figures out a tricky migration on Monday.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
   Auto-learning, cloud-backed shared brain for <b>Claude Code • OpenClaw • Codex • Cursor • Hermes • pi</b> agents.<br>
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/28172" target="_blank"><img src="https://trendshift.io/api/badge/repositories/28172" alt="activeloopai%2Fhivemind | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
 > One engineer's agent figures out a tricky migration on Monday.
 >
 > Tuesday, every agent on the team can execute the pattern.


### PR DESCRIPTION
## Summary

Wraps the Trendshift badge in a `<p align="center">` block so it renders centered, matching the other badge blocks in the README header.

## Session Context
[Session transcript](https://gist.github.com/efenocchi/72b7fec2b797292dfbb8b95eb97b45b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Trendshift badge to the README header badge area, linking the repository to Trendshift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->