### PR TITLE
docs: shorten quick-start install command to npm i -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The agent reaches the answer in fewer turns with less context, because the prior
 One command, all your agents:
 
 ```bash
-npm install -g @deeplake/hivemind && hivemind install
+npm i -g @deeplake/hivemind && hivemind install
 ```
 
 The installer detects every supported assistant on your machine (table below), wires up the hooks, and shows a one-line consent prompt before opening a browser for sign-in. Restart your assistants after install.


### PR DESCRIPTION
Shortens the quick-start install command in the README from `npm install -g` to `npm i -g`.

The `npm install` in the Development section is left unchanged, since it installs local dependencies rather than the global CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start installation command to use the shorthand `npm i -g` instead of the full `npm install -g`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->