### PR TITLE
fix(pi): heal sessions/memory schema so plugin_version column lands

### DIFF
--- a/pi/extension-source/hivemind.ts
+++ b/pi/extension-source/hivemind.ts
@@ -1314,7 +1314,7 @@ export default function hivemindExtension(pi: ExtensionAPI): void {
           const rows = await dlQuery(
             creds,
             `SELECT column_name FROM information_schema.columns ` +
-              `WHERE table_name = '${table}' AND table_schema = '${creds.workspaceId}'`,
+              `WHERE table_name = '${sqlStr(table)}' AND table_schema = '${sqlStr(creds.workspaceId)}'`,
           );
           const have = new Set(
             rows.map((r) => String((r as Record<string, unknown>).column_name).toLowerCase()),

--- a/pi/extension-source/hivemind.ts
+++ b/pi/extension-source/hivemind.ts
@@ -1258,7 +1258,8 @@ export default function hivemindExtension(pi: ExtensionAPI): void {
         `summary_embedding FLOAT4[], author TEXT NOT NULL DEFAULT '', ` +
         `mime_type TEXT NOT NULL DEFAULT 'text/plain', size_bytes BIGINT NOT NULL DEFAULT 0, ` +
         `project TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', ` +
-        `agent TEXT NOT NULL DEFAULT '', creation_date TEXT NOT NULL DEFAULT '', ` +
+        `agent TEXT NOT NULL DEFAULT '', plugin_version TEXT NOT NULL DEFAULT '', ` +
+        `creation_date TEXT NOT NULL DEFAULT '', ` +
         `last_update_date TEXT NOT NULL DEFAULT ''` +
         `) USING deeplake`;
       const sessCreate = `CREATE TABLE IF NOT EXISTS "${SESSIONS_TABLE}" (` +
@@ -1267,6 +1268,7 @@ export default function hivemindExtension(pi: ExtensionAPI): void {
         `author TEXT NOT NULL DEFAULT '', mime_type TEXT NOT NULL DEFAULT 'application/json', ` +
         `size_bytes BIGINT NOT NULL DEFAULT 0, project TEXT NOT NULL DEFAULT '', ` +
         `description TEXT NOT NULL DEFAULT '', agent TEXT NOT NULL DEFAULT '', ` +
+        `plugin_version TEXT NOT NULL DEFAULT '', ` +
         `creation_date TEXT NOT NULL DEFAULT '', last_update_date TEXT NOT NULL DEFAULT ''` +
         `) USING deeplake`;
       try { await dlQuery(creds, memCreate); logHm(`session_start: memory CREATE TABLE ok (${MEMORY_TABLE})`); }
@@ -1294,6 +1296,42 @@ export default function hivemindExtension(pi: ExtensionAPI): void {
         }
       }
       logHm(`session_start: sessions table visible=${visible} (probe took ${Date.now() - start}ms)`);
+
+      // Heal pre-existing tables: `CREATE TABLE IF NOT EXISTS` no-ops on a table
+      // that already exists, so a column added to the canonical schema after the
+      // table was first created (e.g. plugin_version, 2026-05-18) never lands —
+      // every INSERT then fails with `column "plugin_version" ... does not exist`
+      // and pi (unlike the other agents) has no DeeplakeApi.healMissingColumns
+      // to recover. Introspect once and ALTER ADD only the genuinely-missing
+      // columns. Never `IF NOT EXISTS` — Deeplake returns HTTP 500 when the
+      // column already exists. Best-effort: failures must not block capture.
+      const SCHEMA_HEAL: Array<[string, Array<[string, string]>]> = [
+        [SESSIONS_TABLE, [["plugin_version", "TEXT NOT NULL DEFAULT ''"]]],
+        [MEMORY_TABLE, [["plugin_version", "TEXT NOT NULL DEFAULT ''"]]],
+      ];
+      for (const [table, cols] of SCHEMA_HEAL) {
+        try {
+          const rows = await dlQuery(
+            creds,
+            `SELECT column_name FROM information_schema.columns ` +
+              `WHERE table_name = '${table}' AND table_schema = '${creds.workspaceId}'`,
+          );
+          const have = new Set(
+            rows.map((r) => String((r as Record<string, unknown>).column_name).toLowerCase()),
+          );
+          for (const [name, type] of cols) {
+            if (have.has(name.toLowerCase())) continue;
+            try {
+              await dlQuery(creds, `ALTER TABLE "${table}" ADD COLUMN ${name} ${type}`);
+              logHm(`session_start: healed missing column ${table}.${name}`);
+            } catch (e: any) {
+              logHm(`session_start: heal ${table}.${name} failed: ${e?.message ?? e}`);
+            }
+          }
+        } catch (e: any) {
+          logHm(`session_start: schema-heal introspect failed for ${table}: ${e?.message ?? e}`);
+        }
+      }
     }
 
     // Auto-pull all-author skills via the bundled worker (same shared

--- a/tests/pi/pi-extension-source.test.ts
+++ b/tests/pi/pi-extension-source.test.ts
@@ -69,6 +69,22 @@ describe("pi extension — embedding wiring", () => {
     expect(sessionsInsertColumns()).toContain("plugin_version");
   });
 
+  // The CREATE/INSERT invariants above only protect FRESH tables. Existing
+  // 13-column pi tables (the actual prod incident — org c2d29f27) are recovered
+  // by the session_start SCHEMA_HEAL pass. Guard that contract too: dropping
+  // plugin_version from the heal, or no longer healing MEMORY_TABLE, would
+  // silently re-break pre-existing tables while the suite stayed green.
+  it("session_start SCHEMA_HEAL heals sessions + memory tables for plugin_version", () => {
+    const block = PI_SRC.match(/const SCHEMA_HEAL[^=]*=\s*\[([\s\S]*?)\];/);
+    expect(block).not.toBeNull();
+    const heal = block![1];
+    expect(heal).toContain("SESSIONS_TABLE");
+    expect(heal).toContain("MEMORY_TABLE");
+    const pluginVersionHeals =
+      heal.match(/\["plugin_version",\s*"TEXT NOT NULL DEFAULT ''"\]/g) ?? [];
+    expect(pluginVersionHeals.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("auto-spawn target is the canonical shared-deps daemon path", () => {
     expect(PI_SRC).toContain('".hivemind"');
     expect(PI_SRC).toContain('"embed-deps"');

--- a/tests/pi/pi-extension-source.test.ts
+++ b/tests/pi/pi-extension-source.test.ts
@@ -32,6 +32,43 @@ describe("pi extension — embedding wiring", () => {
     expect(insertLine![0]).toContain("message_embedding");
   });
 
+  // Regression for the pi `plugin_version` 42703 incident (org c2d29f27 et al.):
+  // the pi extension hard-codes its sessions CREATE TABLE inline (it does NOT go
+  // through DeeplakeApi.ensureSessionsTable / healMissingColumns like the other
+  // agents). When `plugin_version` was added to the canonical SESSIONS_COLUMNS
+  // (2026-05-18) the pi INSERT picked it up but the inline CREATE did not, so
+  // every pi-created sessions table was one column short from birth and every
+  // INSERT failed with `column "plugin_version" ... does not exist` — with no
+  // heal to recover. This invariant locks INSERT ⊆ CREATE so the schemas can
+  // never silently drift again.
+  function sessionsInsertColumns(): string[] {
+    const m = PI_SRC.match(/INSERT INTO "\$\{SESSIONS_TABLE\}"\s*\(([^)]+)\)/);
+    expect(m).not.toBeNull();
+    return m![1].split(",").map(c => c.trim().toLowerCase());
+  }
+  function sessionsCreateColumns(): string[] {
+    const block = PI_SRC.match(/const sessCreate =([\s\S]*?)USING deeplake/);
+    expect(block).not.toBeNull();
+    const cols = new Set<string>();
+    for (const m of block![1].matchAll(
+      /[(,`]\s*([a-z_][a-z0-9_]*)\s+(?:TEXT|JSONB|FLOAT4|BIGINT|INT|BOOLEAN|DOUBLE)/gi,
+    )) {
+      cols.add(m[1].toLowerCase());
+    }
+    return [...cols];
+  }
+
+  it("every column the sessions INSERT writes exists in the sessions CREATE TABLE", () => {
+    const created = new Set(sessionsCreateColumns());
+    const missing = sessionsInsertColumns().filter(c => !created.has(c));
+    expect(missing).toEqual([]);
+  });
+
+  it("plugin_version is in both the sessions CREATE and INSERT", () => {
+    expect(sessionsCreateColumns()).toContain("plugin_version");
+    expect(sessionsInsertColumns()).toContain("plugin_version");
+  });
+
   it("auto-spawn target is the canonical shared-deps daemon path", () => {
     expect(PI_SRC).toContain('".hivemind"');
     expect(PI_SRC).toContain('"embed-deps"');

--- a/tests/shared/agent-sessions-insert-schema.test.ts
+++ b/tests/shared/agent-sessions-insert-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SESSIONS_COLUMNS } from "../../src/deeplake-schema.js";
+
+/**
+ * Every agent builds its own `sessions` INSERT as an inline SQL string — a
+ * hand-maintained copy of the canonical column set. The `pi` extension already
+ * shipped exactly this drift: its INSERT wrote `plugin_version` while its
+ * CREATE/heal did not, so every pi sessions table was one column short and every
+ * INSERT failed permanently with `column "plugin_version" ... does not exist`
+ * (42703). (pi has its own INSERT ⊆ CREATE guard in tests/pi.)
+ *
+ * The shared-path agents below derive their CREATE TABLE and schema-heal from
+ * SESSIONS_COLUMNS, so the invariant that keeps them safe is: every column an
+ * INSERT writes must exist in SESSIONS_COLUMNS — otherwise CREATE/heal never
+ * create it and the write 42703s. Lock it so the pi bug can't reappear here.
+ */
+const SESSIONS_INSERT_FILES = [
+  "src/hooks/capture.ts",
+  "src/hooks/codex/capture.ts",
+  "src/hooks/cursor/capture.ts",
+  "src/hooks/hermes/capture.ts",
+  "src/hooks/session-queue.ts",
+];
+
+const CANONICAL = new Set(SESSIONS_COLUMNS.map(c => c.name.toLowerCase()));
+
+// The column list is the only parenthesised group that begins with the
+// canonical leading columns; the VALUES tuples start with quoted literals.
+function sessionsInsertColumns(src: string): string[] {
+  const m = src.match(/\(\s*id,\s*path,\s*filename,\s*message\b[^)]*\)/);
+  expect(m).not.toBeNull();
+  return m![0]
+    .replace(/^\(|\)$/g, "")
+    .split(",")
+    .map(c => c.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+describe("agent sessions INSERT ⊆ canonical SESSIONS_COLUMNS", () => {
+  for (const rel of SESSIONS_INSERT_FILES) {
+    it(`${rel}: every sessions INSERT column exists in SESSIONS_COLUMNS`, () => {
+      const src = readFileSync(join(process.cwd(), rel), "utf-8");
+      const missing = sessionsInsertColumns(src).filter(c => !CANONICAL.has(c));
+      expect(missing).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

The `pi` agent extension (`pi/extension-source/hivemind.ts`) hard-codes its `sessions`/`memory` `CREATE TABLE` inline instead of going through `DeeplakeApi.ensureSessionsTable` / `healMissingColumns` like every other agent (claude-code, codex, cursor, hermes).

When `plugin_version` was added to the canonical `SESSIONS_COLUMNS` (2026-05-18), the pi **INSERT** picked it up but the inline **CREATE did not** — so every pi-created `sessions` table was 13 columns from birth, and pi had **no schema-heal** to add the missing column. Result: every session write failed with

```
column "plugin_version" of relation "sessions" does not exist   (sqlstate 42703)
```

…permanently, with no recovery. Diagnosed in prod: pi org `c2d29f27` generated 230 real 42703s over 2 days and ran **zero** `information_schema` introspections (pi never heals), while claude-code/codex/cursor/hermes orgs self-healed. The org's `sessions` dataset was literally "initialized with 13 columns" — the stale pi CREATE.

## Fix

- Add `plugin_version` to the inline `sessCreate` (and `memCreate` for consistency) so fresh pi tables match the canonical schema.
- Add a `session_start` **schema-heal**: introspect `information_schema` once and `ALTER ADD COLUMN` only the genuinely-missing columns (never `IF NOT EXISTS` — Deeplake returns HTTP 500 when the column already exists). Best-effort so it never blocks capture. Existing 13-column pi tables self-heal on next start.
- Lock an **INSERT ⊆ CREATE** schema-consistency invariant in the pi source test so the two can never silently drift again (the same source-level guard style as the existing `message_embedding` check).

## Tests

- `tests/pi/pi-extension-source.test.ts`: two new invariants — fail before the fix (`missing: ['plugin_version']`), pass after.
- 106/106 pi + shared-schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `plugin_version` tracking to session and memory tables.
* **Bug Fixes**
  * Improved schema consistency by automatically healing missing `plugin_version` columns after the sessions table becomes queryable (non-blocking).
* **Tests**
  * Added/expanded tests to verify session `INSERT` column lists match the canonical `CREATE TABLE` definitions, including `plugin_version`.
  * Added shared checks to prevent column drift between agent-maintained session `INSERT` statements and the canonical schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->