### PR TITLE
fix(release): publish openclaw to ClawHub from harnesses/openclaw

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -348,7 +348,7 @@ jobs:
         # `Package already exists as a code-plugin; family changes are not
         # allowed` (convex/packages.ts:4305). Pinning the family explicitly
         # matches what's already registered and lets the publish proceed.
-        run: clawhub package publish ./openclaw --family code-plugin
+        run: clawhub package publish ./harnesses/openclaw --family code-plugin
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Problem
The post-merge Release run for #265 **failed at the `Publish openclaw bundle to ClawHub` step**:
```
clawhub package publish ./openclaw --family code-plugin
Error: Path must be a folder or ClawPack .tgz
```
npm publish itself **succeeded** (0.7.95 is live with Sigstore provenance) — only the ClawHub publish failed.

## Root cause
The harness reorg (#265) moved `openclaw/` → `harnesses/openclaw/` and updated every reference **except** the operative command on `release.yaml:351`. The surrounding comments were updated to `harnesses/openclaw/...`; the `run:` line was missed. `./openclaw` no longer exists, so ClawHub rejects the path.

## Fix
One line: `./openclaw` → `./harnesses/openclaw`.

## Effect
Merging this triggers a fresh release (auto `npm version patch` → 0.7.96) that re-publishes **both** npm and ClawHub from the correct path. (Re-running the failed job alone wouldn't work — `npm publish` would reject the duplicate 0.7.95 before reaching ClawHub.) npm 0.7.95 stays as-is; ClawHub catches up at 0.7.96.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build system configuration for publishing the openclaw bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->