### PR TITLE
chore(cursor): relocate cursor bundle to harnesses/cursor/bundle/ + agent restructuring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,8 +301,8 @@ jobs:
             harnesses/claude-code/bundle/skillify-worker.js \
             harnesses/codex/bundle/capture.js \
             harnesses/codex/bundle/session-start.js \
-            cursor/bundle/capture.js \
-            cursor/bundle/session-start.js \
+            harnesses/cursor/bundle/capture.js \
+            harnesses/cursor/bundle/session-start.js \
             harnesses/hermes/bundle/capture.js \
             harnesses/hermes/bundle/session-start.js \
             mcp/bundle/server.js \
@@ -424,8 +424,8 @@ jobs:
             harnesses/claude-code/bundle/skillify-worker.js \
             harnesses/codex/bundle/capture.js \
             harnesses/codex/bundle/session-start.js \
-            cursor/bundle/capture.js \
-            cursor/bundle/session-start.js \
+            harnesses/cursor/bundle/capture.js \
+            harnesses/cursor/bundle/session-start.js \
             harnesses/hermes/bundle/capture.js \
             harnesses/hermes/bundle/session-start.js \
             mcp/bundle/server.js \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,7 +116,7 @@ jobs:
             bundle \
             harnesses/claude-code/bundle \
             harnesses/codex/bundle \
-            cursor/bundle \
+            harnesses/cursor/bundle \
             harnesses/hermes/bundle \
             mcp/bundle \
             harnesses/pi/bundle
@@ -135,7 +135,7 @@ jobs:
             bundle \
             harnesses/claude-code/bundle \
             harnesses/codex/bundle \
-            cursor/bundle \
+            harnesses/cursor/bundle \
             harnesses/hermes/bundle \
             mcp/bundle \
             harnesses/pi/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ deploy-to-cache.sh
 bundle/
 harnesses/claude-code/bundle/
 harnesses/codex/bundle/
-cursor/bundle/
+harnesses/cursor/bundle/
 harnesses/hermes/bundle/
 mcp/bundle/
 harnesses/pi/bundle/

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Setup, BYOC, agent integrations, or workflow. Come ask in the community:
 git clone https://github.com/activeloopai/hivemind.git
 cd hivemind
 npm install
-npm run build     # tsc + esbuild → harnesses/claude-code/bundle/ + harnesses/codex/bundle/ + harnesses/cursor/bundle/ + harnesses/openclaw/dist/ + mcp/bundle/ + bundle/cli.js
+npm run build     # tsc + esbuild → harnesses/claude-code/bundle/ + harnesses/codex/bundle/ + cursor/bundle/ + harnesses/openclaw/dist/ + mcp/bundle/ + bundle/cli.js
 npm test          # vitest
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Setup, BYOC, agent integrations, or workflow. Come ask in the community:
 git clone https://github.com/activeloopai/hivemind.git
 cd hivemind
 npm install
-npm run build     # tsc + esbuild → harnesses/claude-code/bundle/ + harnesses/codex/bundle/ + cursor/bundle/ + harnesses/openclaw/dist/ + mcp/bundle/ + bundle/cli.js
+npm run build     # tsc + esbuild → harnesses/claude-code/bundle/ + harnesses/codex/bundle/ + harnesses/cursor/bundle/ + harnesses/openclaw/dist/ + mcp/bundle/ + bundle/cli.js
 npm test          # vitest
 ```
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -204,7 +204,7 @@ await build({
   bundle: true,
   platform: "node",
   format: "esm",
-  outdir: "cursor/bundle",
+  outdir: "harnesses/cursor/bundle",
   external: [
     "node:*",
     "node-liblzma",
@@ -231,9 +231,9 @@ await build({
 });
 
 for (const h of cursorAll) {
-  chmodSync(`cursor/bundle/${h.out}.js`, 0o755);
+  chmodSync(`harnesses/cursor/bundle/${h.out}.js`, 0o755);
 }
-writeFileSync("cursor/bundle/package.json", esmPackageJson);
+writeFileSync("harnesses/cursor/bundle/package.json", esmPackageJson);
 
 // Hermes Agent bundle (auto-capture via on_session_start / pre_llm_call /
 // post_tool_call / post_llm_call / on_session_end).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.97.1",
-        "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "deeplake": "^0.3.30",
         "js-yaml": "^4.1.1",
@@ -38,6 +37,7 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
+        "@huggingface/transformers": "^3.0.0",
         "tree-sitter": "^0.21.1",
         "tree-sitter-c": "0.23.2",
         "tree-sitter-cpp": "^0.23.4",
@@ -1610,6 +1610,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
       "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -1619,6 +1620,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
       "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.3",
         "onnxruntime-node": "1.21.0",
@@ -1631,6 +1633,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2132,6 +2135,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -2406,31 +2410,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2440,31 +2449,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
       "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.13",
@@ -3593,6 +3607,7 @@
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -4013,7 +4028,8 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -4435,6 +4451,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4452,6 +4469,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -4477,6 +4495,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4486,7 +4505,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -4604,7 +4624,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -4659,6 +4680,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -5005,7 +5027,8 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -5175,6 +5198,7 @@
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -5192,6 +5216,7 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -5232,7 +5257,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5249,6 +5275,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5694,7 +5721,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -6111,7 +6139,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -6170,6 +6199,7 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -6342,6 +6372,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6351,6 +6382,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -6525,6 +6557,7 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6581,7 +6614,8 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
       "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/onnxruntime-node": {
       "version": "1.21.0",
@@ -6589,6 +6623,7 @@
       "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32",
         "darwin",
@@ -6605,6 +6640,7 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
@@ -6618,7 +6654,8 @@
       "version": "1.22.0-dev.20250409-89f8206ba4",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/papaparse": {
       "version": "5.5.3",
@@ -6812,7 +6849,8 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -6930,6 +6968,7 @@
       "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -7335,6 +7374,7 @@
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -7458,6 +7498,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7470,7 +7511,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -7503,6 +7545,7 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -7544,6 +7587,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -7975,6 +8019,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -8021,6 +8066,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -8858,6 +8904,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "license": "(MIT OR CC0-1.0)",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -8909,6 +8956,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -9229,6 +9277,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bundle",
     "harnesses/codex/bundle",
     "harnesses/codex/skills",
-    "cursor/bundle",
+    "harnesses/cursor/bundle",
     "harnesses/hermes/bundle",
     "mcp/bundle",
     "harnesses/pi/extension-source",

--- a/src/cli/install-cursor.ts
+++ b/src/cli/install-cursor.ts
@@ -99,7 +99,7 @@ export function stripHooksFromConfig(existing: Record<string, unknown> | null): 
 }
 
 export function installCursor(): void {
-  const srcBundle = join(pkgRoot(), "cursor", "bundle");
+  const srcBundle = join(pkgRoot(), "harnesses", "cursor", "bundle");
   if (!existsSync(srcBundle)) {
     throw new Error(`Cursor bundle missing at ${srcBundle}. Run 'npm run build' first.`);
   }

--- a/tests/claude-code/embeddings-bundle-scan.test.ts
+++ b/tests/claude-code/embeddings-bundle-scan.test.ts
@@ -34,8 +34,8 @@ const AGENTS: AgentBundle[] = [
   },
   {
     agent: "cursor",
-    embedDaemon: join(repoRoot, "cursor", "bundle", "embeddings", "embed-daemon.js"),
-    captureHook: join(repoRoot, "cursor", "bundle", "capture.js"),
+    embedDaemon: join(repoRoot, "harnesses", "cursor", "bundle", "embeddings", "embed-daemon.js"),
+    captureHook: join(repoRoot, "harnesses", "cursor", "bundle", "capture.js"),
   },
   {
     agent: "hermes",
@@ -111,8 +111,8 @@ describe("shipped shell/deeplake-shell.js — embed daemon path resolves to an e
       join(repoRoot, "harnesses", "codex", "bundle", "shell", "deeplake-shell.js"),
       join(repoRoot, "harnesses", "codex", "bundle", "embeddings", "embed-daemon.js")],
     ["cursor",
-      join(repoRoot, "cursor", "bundle", "shell", "deeplake-shell.js"),
-      join(repoRoot, "cursor", "bundle", "embeddings", "embed-daemon.js")],
+      join(repoRoot, "harnesses", "cursor", "bundle", "shell", "deeplake-shell.js"),
+      join(repoRoot, "harnesses", "cursor", "bundle", "embeddings", "embed-daemon.js")],
   ];
 
   it.each(SHELL_BUNDLES)("%s shell bundle exists", (_label, shellPath) => {

--- a/tests/claude-code/plugin-version-resolution.test.ts
+++ b/tests/claude-code/plugin-version-resolution.test.ts
@@ -38,7 +38,7 @@ interface AgentLayout {
 const AGENTS: AgentLayout[] = [
   { agent: "claude-code", bundleDir: resolve(REPO_ROOT, "harnesses", "claude-code", "bundle"), manifestDir: ".claude-plugin" },
   { agent: "codex",       bundleDir: resolve(REPO_ROOT, "harnesses", "codex", "bundle"),       manifestDir: ".codex-plugin" },
-  { agent: "cursor",      bundleDir: resolve(REPO_ROOT, "cursor", "bundle"),      manifestDir: ".claude-plugin" },
+  { agent: "cursor",      bundleDir: resolve(REPO_ROOT, "harnesses", "cursor", "bundle"),      manifestDir: ".claude-plugin" },
   { agent: "hermes",      bundleDir: resolve(REPO_ROOT, "harnesses", "hermes", "bundle"),      manifestDir: ".claude-plugin" },
   { agent: "pi",          bundleDir: resolve(REPO_ROOT, "harnesses", "pi", "bundle"),          manifestDir: ".claude-plugin" },
 ];
@@ -66,7 +66,7 @@ describe("plugin_version is wired into every agent's capture INSERT", () => {
   const CAPTURE_BUNDLES: Array<[string, string]> = [
     ["claude-code capture", resolve(REPO_ROOT, "harnesses", "claude-code", "bundle", "capture.js")],
     ["codex capture",       resolve(REPO_ROOT, "harnesses", "codex", "bundle", "capture.js")],
-    ["cursor capture",      resolve(REPO_ROOT, "cursor", "bundle", "capture.js")],
+    ["cursor capture",      resolve(REPO_ROOT, "harnesses", "cursor", "bundle", "capture.js")],
     ["hermes capture",      resolve(REPO_ROOT, "harnesses", "hermes", "bundle", "capture.js")],
     ["codex stop",          resolve(REPO_ROOT, "harnesses", "codex", "bundle", "stop.js")],
     ["openclaw index",      resolve(REPO_ROOT, "harnesses", "openclaw", "dist", "index.js")],
@@ -86,7 +86,7 @@ describe("plugin_version is wired into every agent's session-start placeholder I
   const PLACEHOLDER_BUNDLES: Array<[string, string]> = [
     ["claude-code session-start", resolve(REPO_ROOT, "harnesses", "claude-code", "bundle", "session-start.js")],
     ["codex session-start-setup", resolve(REPO_ROOT, "harnesses", "codex", "bundle", "session-start-setup.js")],
-    ["cursor session-start",      resolve(REPO_ROOT, "cursor", "bundle", "session-start.js")],
+    ["cursor session-start",      resolve(REPO_ROOT, "harnesses", "cursor", "bundle", "session-start.js")],
     ["hermes session-start",      resolve(REPO_ROOT, "harnesses", "hermes", "bundle", "session-start.js")],
   ];
 

--- a/tests/claude-code/skillify-bundle-scan.test.ts
+++ b/tests/claude-code/skillify-bundle-scan.test.ts
@@ -19,7 +19,7 @@ const AGENTS = ["claude-code", "codex", "cursor", "hermes", "openclaw"] as const
 
 function bundlePath(agent: string, file: string): string {
   const dir = agent === "openclaw" ? "dist" : "bundle";
-  const base = agent === "cursor" ? join(ROOT, agent) : join(ROOT, "harnesses", agent);
+  const base = join(ROOT, "harnesses", agent);
   return join(base, dir, file);
 }
 

--- a/tests/claude-code/skillify-session-start-injection.test.ts
+++ b/tests/claude-code/skillify-session-start-injection.test.ts
@@ -23,7 +23,7 @@ const BUNDLE_ROOT = resolve(process.cwd());
 // auto-loaded `hivemind-memory` skill instead of the hook context.
 const SESSION_START_BUNDLES: Array<[string, string]> = [
   ["claude-code", resolve(BUNDLE_ROOT, "harnesses", "claude-code", "bundle", "session-start.js")],
-  ["cursor",      resolve(BUNDLE_ROOT, "cursor",      "bundle", "session-start.js")],
+  ["cursor",      resolve(BUNDLE_ROOT, "harnesses", "cursor", "bundle", "session-start.js")],
   ["hermes",      resolve(BUNDLE_ROOT, "harnesses", "hermes",      "bundle", "session-start.js")],
 ];
 

--- a/tests/claude-code/version-define-bundles.test.ts
+++ b/tests/claude-code/version-define-bundles.test.ts
@@ -33,7 +33,7 @@ function listBundleFiles(dir: string): string[] {
 const BUNDLE_DIRS = [
   ["claude-code", resolve(ROOT, "harnesses", "claude-code", "bundle")],
   ["codex", resolve(ROOT, "harnesses", "codex", "bundle")],
-  ["cursor", resolve(ROOT, "cursor", "bundle")],
+  ["cursor", resolve(ROOT, "harnesses", "cursor", "bundle")],
   ["hermes", resolve(ROOT, "harnesses", "hermes", "bundle")],
 ];
 

--- a/tests/cli/cli-install-cursor-fs.test.ts
+++ b/tests/cli/cli-install-cursor-fs.test.ts
@@ -21,11 +21,11 @@ beforeEach(() => {
   tmpHome = join(tmpRoot, "home");
   tmpPkg = join(tmpRoot, "pkg");
   mkdirSync(join(tmpHome, ".cursor"), { recursive: true });
-  mkdirSync(join(tmpPkg, "cursor", "bundle"), { recursive: true });
-  writeFileSync(join(tmpPkg, "cursor", "bundle", "session-start.js"), "// fake bundle");
-  writeFileSync(join(tmpPkg, "cursor", "bundle", "capture.js"), "// fake bundle");
-  writeFileSync(join(tmpPkg, "cursor", "bundle", "pre-tool-use.js"), "// fake bundle");
-  writeFileSync(join(tmpPkg, "cursor", "bundle", "session-end.js"), "// fake bundle");
+  mkdirSync(join(tmpPkg, "harnesses", "cursor", "bundle"), { recursive: true });
+  writeFileSync(join(tmpPkg, "harnesses", "cursor", "bundle", "session-start.js"), "// fake bundle");
+  writeFileSync(join(tmpPkg, "harnesses", "cursor", "bundle", "capture.js"), "// fake bundle");
+  writeFileSync(join(tmpPkg, "harnesses", "cursor", "bundle", "pre-tool-use.js"), "// fake bundle");
+  writeFileSync(join(tmpPkg, "harnesses", "cursor", "bundle", "session-end.js"), "// fake bundle");
   writeFileSync(join(tmpPkg, "package.json"), JSON.stringify({ version: "9.9.9" }));
 
   vi.stubEnv("HOME", tmpHome);
@@ -112,7 +112,7 @@ describe("installCursor", () => {
   });
 
   it("throws when the bundle source is missing (build hasn't run)", async () => {
-    rmSync(join(tmpPkg, "cursor", "bundle"), { recursive: true, force: true });
+    rmSync(join(tmpPkg, "harnesses", "cursor", "bundle"), { recursive: true, force: true });
     const { installCursor } = await importInstaller();
     expect(() => installCursor()).toThrow(/Cursor bundle missing/);
   });


### PR DESCRIPTION
## Summary

This is PR 3 in a stacked series. It contains two independent changes that both needed to land after the `harnesses/` reorganisation from PR #265:

1. **Cursor bundle path relocation** - the deferred half of #265. Moves `cursor/bundle/` to `harnesses/cursor/bundle/` for full consistency with every other agent harness.
2. **Cursor agent restructuring** - replaces the initial generic worker-bee roster with 25 hivemind-specific worker-bees tailored to this codebase's actual surfaces (TypeScript/Node, Deep Lake, CI/release pipeline, retrieval, MCP, harness integration).

Stacked on PR #267. The diff against `main` includes PR #267's changes since that PR is not yet merged; the PR #268-specific commits are the last four in the list.

---

## 1. Cursor bundle path relocation

**Why deferred from #265:** the cursor hook bundle and the cursor extension were coupled in the fork. PR #265 added `harnesses/cursor/.gitkeep` as a placeholder and noted this would follow. This is that follow-up.

**Files changed (path-string updates only, zero behavior change):**

| File | Change |
|---|---|
| `esbuild.config.mjs` | `outdir`, `chmodSync`, `writeFileSync` targets |
| `.gitignore` | `cursor/bundle/` -> `harnesses/cursor/bundle/` |
| `package.json` | `files` array entry |
| `.github/workflows/ci.yaml` | 4 bundle smoke-test paths (2 jobs) |
| `.github/workflows/release.yaml` | 2 artifact paths |
| `README.md` | Build-output comment |
| `src/cli/install-cursor.ts` | `srcBundle` join path |
| 5 test files | All `cursor/bundle` path references |

---

## 2. Agent restructuring

Replaces the initial generic 37-bee roster (broad domain advisors) with 25 hivemind-specific worker-bees that know this codebase's actual conventions:

**Added (hivemind-specific):** `typescript-node-worker-bee`, `deeplake-dataset-worker-bee`, `ci-release-worker-bee`, `retrieval-worker-bee`, `embeddings-runtime-worker-bee`, `harness-integration-worker-bee`, `mcp-protocol-worker-bee`, `mcp-tool-docs-worker-bee`

**Retained and updated:** `security-worker-bee`, `quality-worker-bee`, `git-worker-bee`, `github-repo-health-worker-bee`, `cursor-ide-worker-bee`, `dependency-audit-worker-bee`, `library-worker-bee`, `knowledge-worker-bee`, `wiki-worker-bee`, `adr-writing-worker-bee`, `branching-strategy-worker-bee`, `code-review-pr-worker-bee`, `changelog-release-notes-worker-bee`, `readme-writing-worker-bee`, `runbook-writing-worker-bee`, `technical-writing-craft-worker-bee`, `terminal-bash-worker-bee`

**Removed (too generic for this codebase):** `agile-scrum`, `kanban-flow`, `okr-goal-setting`, `retrospective`, `docs-site`, `api-docs`, `ai-tools-platform`, `ai-coding-tools`, `mind`, `db`, `python`, `react`, `devops`, `design-system`, `discovery-research`, `slack-app`, `markdown-mdx`, and others

Also adds `.cursor/model-comparison-matrix.md` (380-line scored model-routing rubric) wired into `/the-smoker`.

---

## Additional fixes

- `package-lock.json`: moves `@huggingface/transformers` from `dependencies` to `optionalDependencies` (embeddings are opt-in).
- `.cursor/rules/plan-construction-protocol.mdc`: fixes stale `legion-shared/model-comparison-matrix.md` path to `.cursor/model-comparison-matrix.md`.

---

## Testing

`npm run build`: green, cursor bundle lands at `harnesses/cursor/bundle/` with no top-level `cursor/bundle/` created.

`npm test`: 4483-4487/4487 passing (the 4 `cli-update` failures are pre-existing sandbox TTY flakes, byte-identical to `upstream/main`, confirmed passing in real CI).

---

*Contribution by [Legion Code Inc.](https://github.com/legioncodeinc) / [Mario Aldayuz](https://www.linkedin.com/in/marioaldayuz/)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal build structure for Cursor bundle assets to improve build consistency and maintainability.
  * Updated CI/CD workflows and test suites to reflect the new build artifact organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->