### PR TITLE
fix: marketplace plugin path points at harnesses/claude-code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/activeloopai/hivemind.git",
-        "path": "claude-code",
+        "path": "harnesses/claude-code",
         "sha": "9c160f0da7a8453c62a5d6d37d2b6585003b3590"
       },
       "homepage": "https://github.com/activeloopai/hivemind"

--- a/tests/scripts/marketplace-source-path.test.ts
+++ b/tests/scripts/marketplace-source-path.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for the SSO/plugin-install failure where
+// `claude plugin install hivemind` died with:
+//   "Subdirectory 'claude-code' not found in repository ... at the specified ref/s"
+//
+// Root cause: commit 0fdfe698 ("consolidate agent harnesses under harnesses/")
+// moved claude-code/ -> harnesses/claude-code/, but `.claude-plugin/marketplace.json`
+// still pinned source.path = "claude-code". The release workflow only rewrites
+// source.sha, never source.path, so the stale path shipped to every user.
+//
+// Invariant: the git-subdir source.path MUST point at a real plugin directory
+// in this repo (one that contains .claude-plugin/plugin.json). Because each
+// release commit is built from this working tree, working-tree correctness
+// implies the pinned-sha checkout will also resolve.
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../../..");
+
+describe("marketplace.json git-subdir source.path", () => {
+  const marketplace = JSON.parse(
+    readFileSync(resolve(repoRoot, ".claude-plugin/marketplace.json"), "utf-8"),
+  );
+
+  it("points every git-subdir plugin at a directory that exists and is a plugin", () => {
+    expect(Array.isArray(marketplace.plugins)).toBe(true);
+    expect(marketplace.plugins.length).toBeGreaterThan(0);
+
+    for (const plugin of marketplace.plugins) {
+      const src = plugin.source;
+      if (!src || src.source !== "git-subdir") continue;
+
+      const dir = resolve(repoRoot, src.path);
+      expect(existsSync(dir), `marketplace path "${src.path}" must exist in repo`).toBe(true);
+
+      const manifest = resolve(dir, ".claude-plugin/plugin.json");
+      expect(
+        existsSync(manifest),
+        `marketplace path "${src.path}" must contain .claude-plugin/plugin.json`,
+      ).toBe(true);
+    }
+  });
+
+  it("does NOT use the pre-consolidation root path 'claude-code'", () => {
+    for (const plugin of marketplace.plugins) {
+      expect(plugin.source?.path).not.toBe("claude-code");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`claude plugin install hivemind` (run during SSO login / fresh install) fails with:

```
Failed to install plugin "hivemind": Subdirectory 'claude-code' not found in repository
https://github.com/activeloopai/hivemind.git. Check that the path is correct and exists at the specified ref/sha.
```

## Root cause

`0fdfe698` ("consolidate agent harnesses under harnesses/") moved `claude-code/` to `harnesses/claude-code/`, but `.claude-plugin/marketplace.json` still pinned the git-subdir `source.path` to `claude-code`. The release workflow only rewrites `source.sha`, never `source.path`, so every release pinned to a post-consolidation commit shipped an install that resolves a non-existent subdir.

Affected: every fresh install / SSO login pinned to a release `>= 26c96546` (first broken release on 2026-06-16); releases `<= 5f278bf9` still resolve because their pinned sha predates the move.

## Fix

`source.path`: `claude-code` -> `harnesses/claude-code`. Verified `git cat-file -e <pinned-sha>:harnesses/claude-code` resolves to a full plugin (`.claude-plugin/bundle/commands/hooks/skills`).

## Verification (real CLI, isolated)

- Before: `claude plugin marketplace add activeloopai/hivemind && claude plugin install hivemind` -> the error above.
- After (marketplace pointed at this branch): `Successfully installed plugin: hivemind@hivemind`.

## Regression guard

`tests/scripts/marketplace-source-path.test.ts` asserts every git-subdir `source.path` points at a directory containing `.claude-plugin/plugin.json`, and explicitly rejects the pre-consolidation `claude-code`. Fails on the stale path, passes on the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to validate the plugin marketplace configuration, verifying that all configured source paths correctly resolve to existing directories with required plugin manifest files, while ensuring no legacy path patterns are retained in the configuration.

* **Chores**
  * Updated internal plugin directory structure and marketplace configuration paths for improved organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->