### PR TITLE
fix: self-heal stale marketplace cache on first-install

### DIFF
--- a/src/cli/install-claude.ts
+++ b/src/cli/install-claude.ts
@@ -219,7 +219,8 @@ export function cleanupBrokenSettingsHooks(): { removed: number; events: string[
 export function installClaude(): void {
   requireClaudeCli();
 
-  if (!marketplaceAlreadyAdded()) {
+  const marketplacePreexisting = marketplaceAlreadyAdded();
+  if (!marketplacePreexisting) {
     const add = runClaude(["plugin", "marketplace", "add", MARKETPLACE_SOURCE]);
     if (!add.ok) {
       throw new Error(
@@ -229,8 +230,18 @@ export function installClaude(): void {
   }
 
   if (!pluginAlreadyInstalled()) {
-    // First-time install path: just install. The marketplace fetch is
-    // implicit in `claude plugin install`.
+    // First-time install path. If the marketplace was already on disk we
+    // must refresh its cache first: a `marketplace add` that finds the
+    // marketplace already present is a no-op and leaves the STALE cached
+    // marketplace.json in place, so `plugin install` would resolve the old
+    // pinned sha/path. This bit users whose earlier attempt added the
+    // marketplace but failed to install (e.g. the harnesses/claude-code
+    // path regression) — a plain `hivemind install` re-run kept hitting the
+    // stale catalog. A fresh `marketplace add` already fetched the latest,
+    // so only refresh when the marketplace pre-existed.
+    if (marketplacePreexisting) {
+      runClaude(["plugin", "marketplace", "update", MARKETPLACE_NAME]);
+    }
     const inst = runClaude(["plugin", "install", "hivemind"]);
     if (!inst.ok) {
       throw new Error(

--- a/tests/cli/cli-install-claude.test.ts
+++ b/tests/cli/cli-install-claude.test.ts
@@ -139,6 +139,25 @@ describe("installClaude — happy path argv shape", () => {
     expect(argvList).toContain("plugin enable hivemind@hivemind");
   });
 
+  it("refreshes the marketplace BEFORE install when the marketplace pre-existed but the plugin is not installed (stale-cache self-heal)", async () => {
+    // Regression guard for the SSO/install failure: a prior attempt added
+    // the marketplace but failed to install, leaving a STALE marketplace.json
+    // cached (old pinned sha/path). A plain re-run skips `marketplace add`
+    // (already present) and would `plugin install` against the stale catalog
+    // — re-failing forever. We now `marketplace update` first so the newest
+    // marketplace.json (with the fixed path) is used.
+    setupClaudeResponses({ marketplaceList: "hivemind", pluginList: "" });
+    const { installClaude } = await importFresh();
+    installClaude();
+
+    const argvList = calls().map(c => c.args.join(" "));
+    expect(argvList).not.toContain("plugin marketplace add activeloopai/hivemind");
+    const refreshIdx = argvList.indexOf("plugin marketplace update hivemind");
+    const installIdx = argvList.indexOf("plugin install hivemind");
+    expect(refreshIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeGreaterThan(refreshIdx);
+  });
+
   it("skips 'plugin install' AND triggers 'plugin update' across all 4 scopes when already installed", async () => {
     // When `plugin list` already shows the plugin, we no longer skip and
     // do nothing. We refresh the marketplace cache and run


### PR DESCRIPTION
## Problem

After the `harnesses/claude-code` path fix (#272, v0.7.99), users who had **already attempted** an install before the fix still cannot install by re-running `hivemind install`. Their machine has the marketplace added but pinned to a stale cached `marketplace.json` (old sha/path `claude-code`), and the plugin is not installed.

`installClaude()` first-install branch did NOT refresh the marketplace — the comment claimed "the marketplace fetch is implicit in `plugin install`", but it isn't: `marketplace add` is a no-op when already present, so `plugin install` resolves the stale catalog and re-fails with `Subdirectory 'claude-code' not found`.

This is exactly the situation of any customer (e.g. Krisp) who hit the original SSO bug: telling them to re-run `hivemind install` would fail again.

## Fix

In the first-install branch, when the marketplace **pre-existed**, run `claude plugin marketplace update hivemind` before `plugin install`. A freshly-added marketplace already fetched the latest, so the refresh only fires when the marketplace was already on disk (stale-cache case). Cold installs are unchanged.

## Verification (real end-to-end, not just unit)

Reproduced a faithful stale-cache machine: marketplace cache rolled back to a pre-fix commit (`8a9670e`, path `claude-code`, v0.7.98), plugin uninstalled.

- Negative control — raw `claude plugin install hivemind` → `Subdirectory 'claude-code' not found` (re-fails).
- New `installClaude()` (compiled) → ran `marketplace update` (cache advanced to current main, path → `harnesses/claude-code`) → `plugin install` → **installed, no manual step**.

Unit tests: added a guard asserting `marketplace update` runs BEFORE `plugin install` when the marketplace pre-exists and the plugin is absent; existing cold-install tests (exact argv sequence, no `marketplace update`) still pass. 33/33 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the plugin installation process to properly refresh marketplace data when needed before installing, preventing failures that could result from using outdated cached marketplace information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->