### PR TITLE
fix(notifications): guard open-goals banner SELECT behind table pre-flight (42P01)

### DIFF
--- a/src/notifications/sources/open-goals.ts
+++ b/src/notifications/sources/open-goals.ts
@@ -52,6 +52,18 @@ export async function fetchOpenGoals(
       creds.workspaceId ?? "default",
       goalsTableName,
     );
+    // Pre-flight existence guard (mirrors the SessionStart context block's
+    // `tableExists` skip): on a fresh org that never created hivemind_goals,
+    // sending the SELECT logs a 42P01 server-side on EVERY SessionStart even
+    // though the catch below hides it from the user. knownTablesOrNull returns
+    // the trusted table list (skip the read when goals is absent) and null when
+    // the lookup couldn't be trusted (fall back to SELECT-then-catch so a
+    // transient blip doesn't suppress a table that really exists).
+    const known = await api.knownTablesOrNull();
+    if (known && !known.includes(goalsTableName)) {
+      log(`fetchOpenGoals: table "${goalsTableName}" not present — skipping read`);
+      return null;
+    }
     // Reuse the canonical goal reader: it matches the owner by exact
     // full form, exact short form, and `short@%` alias (never a
     // `'%user%'` substring scan, which collides — e.g. 'ali' matching

--- a/tests/claude-code/notifications-open-goals-source.test.ts
+++ b/tests/claude-code/notifications-open-goals-source.test.ts
@@ -19,6 +19,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const queryMock = vi.fn();
+// Default: resolve `null` ("untrusted table list") so the pre-flight guard
+// falls back to the SELECT-then-catch path — keeps every pre-existing test
+// (which only stubs `query`) exercising the query as before.
+const knownTablesMock = vi.fn(async (): Promise<string[] | null> => null);
 
 vi.mock("../../src/deeplake-api.js", () => ({
   DeeplakeApi: class {
@@ -30,6 +34,7 @@ vi.mock("../../src/deeplake-api.js", () => ({
       _tableName: string,
     ) { /* nothing */ }
     query(sql: string) { return queryMock(sql); }
+    knownTablesOrNull() { return knownTablesMock(); }
   },
 }));
 
@@ -45,6 +50,9 @@ const BASE_CREDS = {
 
 beforeEach(() => {
   queryMock.mockReset();
+  knownTablesMock.mockReset();
+  // Restore the default "untrusted list -> fall back to query" behavior.
+  knownTablesMock.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -108,6 +116,35 @@ describe("fetchOpenGoals — SQL shape", () => {
     const result = await fetchOpenGoals(BASE_CREDS as any, 'evil"; DROP TABLE x; --');
     expect(result).toBeNull();
     expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── pre-flight table-existence guard (42P01 prevention) ──────────────────────
+
+describe("fetchOpenGoals — table-existence pre-flight", () => {
+  it("skips the SELECT entirely when the goals table is absent from the trusted list (no server-side 42P01)", async () => {
+    // Fresh org that never created hivemind_goals: the table list is trusted
+    // and does not include it. The banner must NOT issue the SELECT — sending
+    // it would log a 42P01 server-side on every SessionStart even though the
+    // catch hides it from the user.
+    knownTablesMock.mockResolvedValue(["sessions", "memory", "hivemind_rules"]);
+    const result = await fetchOpenGoals(BASE_CREDS as any, "hivemind_goals");
+    expect(result).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("issues the SELECT when the goals table IS present in the trusted list", async () => {
+    knownTablesMock.mockResolvedValue(["sessions", "hivemind_goals"]);
+    queryMock.mockResolvedValue([]);
+    await fetchOpenGoals(BASE_CREDS as any, "hivemind_goals");
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the SELECT when the table list is untrusted (null) — a transient lookup blip must not hide a real table", async () => {
+    knownTablesMock.mockResolvedValue(null);
+    queryMock.mockResolvedValue([]);
+    await fetchOpenGoals(BASE_CREDS as any, "hivemind_goals");
+    expect(queryMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Problem
pg-deeplake prod logs ~150 `sqlstate=42P01 ERROR: relation \"hivemind_goals\" does not exist` per day, spread across many orgs. Source: the SessionStart **banner** path (`fetchOpenGoals` → `listOpenGoals`) issues the goals `SELECT` **unconditionally**. The SessionStart **context-block** path already guards the same read with `knownTablesOrNull()` and skips it when the table is absent. On any org that never created `hivemind_goals` (i.e. never wrote a goal), the banner sends the SELECT on every SessionStart; the server logs 42P01 even though the client-side `try/catch` hides it from the user.

## Fix
Add the same pre-flight in `fetchOpenGoals`:
- `knownTablesOrNull()` returns the trusted table list → if it omits the goals table, **skip the read** (no server-side 42P01).
- returns `null` (untrusted/lookup failed) → fall back to SELECT-then-catch, so a transient blip can't hide a table that really exists.

This mirrors the proven context-block pattern exactly and does **not** create the table as a side effect (the banner is read-only/best-effort).

## Tests
Extended the existing mock with `knownTablesOrNull` and added 3 cases: skip-when-absent (asserts `query` never called), query-when-present, fall-back-when-null. **21/21 green.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized open goals notifications by verifying table availability before querying, preventing failed requests in organizations without the required table setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->