### PR TITLE
fix(memory): resolve claude on PATH for backfill + surface per-session failures (#276)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -513,7 +513,7 @@ async function main(): Promise<void> {
         `${r.failed ? `, ${r.failed} failed` : ""}.`);
       return;
     }
-    warn("Usage: hivemind memory backfill [--dry-run] [--force] [--n <num|all>] [--window-days N] [--project-only] | flush");
+    warn("Usage: hivemind memory backfill [--dry-run] [--force] [--n <num|all>] [--window-days N] [--project-only] [--verbose] | flush");
     process.exit(1);
   }
 

--- a/src/commands/backfill-memory.ts
+++ b/src/commands/backfill-memory.ts
@@ -71,6 +71,7 @@ const DEFAULT_BUDGET_MS = 15 * 60 * 1000;
  */
 const IN_FLIGHT_MAX_AGE_MS = 60_000;
 
+/** Parsed options controlling a `memory backfill` run. */
 export interface BackfillOptions {
   /** Look-back window in days (sessions older than this are skipped). */
   windowDays: number;
@@ -88,6 +89,7 @@ export interface BackfillOptions {
   cwd: string;
 }
 
+/** Parse `memory backfill` argv into options, ignoring malformed numeric flags. */
 export function parseBackfillArgs(argv: string[], cwd: string): BackfillOptions {
   const opts: BackfillOptions = {
     windowDays: DEFAULT_WINDOW_DAYS,
@@ -119,6 +121,7 @@ export function parseBackfillArgs(argv: string[], cwd: string): BackfillOptions 
   return opts;
 }
 
+/** The computed work-list for a run: what's in-window, deduped, and to extract. */
 export interface BackfillPlan {
   windowDays: number;
   /** Cutoff epoch-ms; sessions with mtime < cutoff are excluded. */
@@ -192,6 +195,7 @@ export function planBackfill(opts: BackfillOptions, now: number): BackfillPlan {
   return planFromSessions(all, stagedSessionIds(), opts, now);
 }
 
+/** Render the human-readable plan/dry-run report (window, cap, by-agent counts). */
 export function renderPlan(plan: BackfillPlan, opts: BackfillOptions): string {
   const lines: string[] = [];
   lines.push(`memory backfill — ${opts.dryRun ? "DRY RUN" : "plan"}`);
@@ -208,6 +212,7 @@ export function renderPlan(plan: BackfillPlan, opts: BackfillOptions): string {
   return lines.join("\n");
 }
 
+/** One session's failed-extraction outcome, surfaced in the run report. */
 export interface BackfillFailure {
   /** Composite agent-id staging key (matches the manifest key). */
   session: string;
@@ -215,6 +220,7 @@ export interface BackfillFailure {
   reason: string;
 }
 
+/** Tally of an extract run: counts plus per-reason / per-session failure detail. */
 export interface ExtractSummary {
   attempted: number;
   staged: number;
@@ -326,17 +332,18 @@ export function releaseBackfillLock(lockPath: string = PENDING_MEMORY_LOCK_PATH)
   } catch { /* best-effort */ }
 }
 
+/** CLI entry for `hivemind memory backfill`: plan, then extract unless --dry-run. */
 export async function runBackfillMemory(argv: string[]): Promise<number> {
   const cwd = process.cwd();
   const opts = parseBackfillArgs(argv, cwd);
-  const plan = planBackfill(opts, Date.now());
-
-  process.stdout.write(renderPlan(plan, opts) + "\n");
-
-  // Dry-run doesn't acquire/own the lock (the spawn path only locks for a
-  // real run), so leave it untouched here.
-  if (opts.dryRun) return 0;
+  // Everything that can throw runs inside the try so the finally always
+  // releases the lock — a planBackfill/renderPlan failure must not strand a
+  // worker-owned lock. releaseBackfillLock is itself a no-op unless this
+  // process owns the lock, so the dry-run early return is safe under it.
   try {
+    const plan = planBackfill(opts, Date.now());
+    process.stdout.write(renderPlan(plan, opts) + "\n");
+    if (opts.dryRun) return 0;
     return await runExtract(plan, cwd, opts);
   } finally {
     releaseBackfillLock();
@@ -385,6 +392,11 @@ export function summarizeExtract(
   return { lines, exitCode };
 }
 
+/**
+ * Execute the planned extraction and print the outcome. Returns the process
+ * exit code (1 only on a total wash — see {@link summarizeExtract}); a no-op
+ * when the plan is empty.
+ */
 export async function runExtract(plan: BackfillPlan, cwd: string, opts: BackfillOptions): Promise<number> {
 
   if (plan.toExtract.length === 0) {

--- a/src/commands/backfill-memory.ts
+++ b/src/commands/backfill-memory.ts
@@ -82,6 +82,8 @@ export interface BackfillOptions {
   projectOnly: boolean;
   /** Max sessions to extract this run. null = no cap (`--n all`). */
   maxSessions: number | null;
+  /** List every per-session failure (key → reason) in the report. */
+  verbose: boolean;
   /** Working directory used for cwd-bias and project scoping. */
   cwd: string;
 }
@@ -93,12 +95,14 @@ export function parseBackfillArgs(argv: string[], cwd: string): BackfillOptions 
     force: false,
     projectOnly: false,
     maxSessions: DEFAULT_MAX_SESSIONS,
+    verbose: false,
     cwd,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--dry-run") opts.dryRun = true;
     else if (a === "--force") opts.force = true;
+    else if (a === "--verbose" || a === "-v") opts.verbose = true;
     else if (a === "--project-only") opts.projectOnly = true;
     else if (a === "--window-days") {
       const n = Number(argv[++i]);
@@ -204,16 +208,29 @@ export function renderPlan(plan: BackfillPlan, opts: BackfillOptions): string {
   return lines.join("\n");
 }
 
+export interface BackfillFailure {
+  /** Composite agent-id staging key (matches the manifest key). */
+  session: string;
+  /** Why it failed: a stageSession reason code, or `threw: <message>`. */
+  reason: string;
+}
+
 export interface ExtractSummary {
   attempted: number;
   staged: number;
   embedded: number;
   failed: number;
   timedOutOnBudget: boolean;
+  /** Per-reason failure tally, so a bare `N failed` is self-diagnosable. */
+  failureReasons: Record<string, number>;
+  /** Per-session failure detail, surfaced verbatim under --verbose. */
+  failures: BackfillFailure[];
 }
 
 /** One session → staged outcome. Injectable so the executor is testable. */
-export type StageFn = (session: SessionFile) => Promise<{ ok: boolean; embedded: boolean }>;
+export type StageFn = (
+  session: SessionFile,
+) => Promise<{ ok: boolean; embedded: boolean; reason?: string }>;
 
 /** Clock injectable for budget tests. */
 export type NowFn = () => number;
@@ -227,7 +244,7 @@ function defaultStageFn(cwd: string, perSessionTimeoutMs: number): StageFn {
       { sessionId: s.sessionId, jsonlPath: s.path, agent: s.agent, project },
       { claudeBin, timeoutMs: perSessionTimeoutMs, skipEmbed: false, now: () => new Date().toISOString() },
     );
-    return { ok: res.ok, embedded: res.embedded };
+    return { ok: res.ok, embedded: res.embedded, reason: res.reason };
   };
 }
 
@@ -251,7 +268,16 @@ export async function executeBackfill(
 ): Promise<ExtractSummary> {
   const stage = opts.stage ?? defaultStageFn(opts.cwd, opts.perSessionTimeoutMs);
   const now = opts.now ?? Date.now;
-  const summary: ExtractSummary = { attempted: 0, staged: 0, embedded: 0, failed: 0, timedOutOnBudget: false };
+  const summary: ExtractSummary = {
+    attempted: 0, staged: 0, embedded: 0, failed: 0,
+    timedOutOnBudget: false, failureReasons: {}, failures: [],
+  };
+
+  const recordFailure = (s: SessionFile, reason: string): void => {
+    summary.failed++;
+    summary.failureReasons[reason] = (summary.failureReasons[reason] ?? 0) + 1;
+    summary.failures.push({ session: backfillSessionKey(s.agent, s.sessionId), reason });
+  };
 
   const queue = [...toExtract];
   const deadline = opts.startMs + opts.budgetMs;
@@ -271,12 +297,12 @@ export async function executeBackfill(
           summary.staged++;
           if (res.embedded) summary.embedded++;
         } else {
-          summary.failed++;
+          recordFailure(s, res.reason ?? "unknown");
         }
-      } catch {
+      } catch (e) {
         // A stager that throws must not abort the whole run — count it as a
         // failed session and move on to the rest of the queue.
-        summary.failed++;
+        recordFailure(s, `threw: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
   }
@@ -293,10 +319,10 @@ export async function executeBackfill(
  * `hivemind memory backfill` invocation never owns the lock, so it must not
  * delete one another (spawned) process is holding.
  */
-function releaseBackfillLock(): void {
+export function releaseBackfillLock(lockPath: string = PENDING_MEMORY_LOCK_PATH): void {
   if (process.env.HIVEMIND_BACKFILL_LOCK_OWNED !== "1") return;
   try {
-    if (existsSync(PENDING_MEMORY_LOCK_PATH)) unlinkSync(PENDING_MEMORY_LOCK_PATH);
+    if (existsSync(lockPath)) unlinkSync(lockPath);
   } catch { /* best-effort */ }
 }
 
@@ -311,13 +337,55 @@ export async function runBackfillMemory(argv: string[]): Promise<number> {
   // real run), so leave it untouched here.
   if (opts.dryRun) return 0;
   try {
-    return await runExtract(plan, cwd);
+    return await runExtract(plan, cwd, opts);
   } finally {
     releaseBackfillLock();
   }
 }
 
-async function runExtract(plan: BackfillPlan, cwd: string): Promise<number> {
+/**
+ * Render the failure diagnostics for a finished run. Always emits a
+ * per-reason tally when anything failed (so a bare `N failed` is never a
+ * dead end), and lists every failing session under --verbose. Returns the
+ * lines to print; empty when nothing failed.
+ */
+export function renderFailures(result: ExtractSummary, verbose: boolean): string[] {
+  if (result.failed === 0) return [];
+  const lines: string[] = [];
+  const reasons = Object.keys(result.failureReasons).sort();
+  lines.push(`  ${result.failed} session(s) failed:`);
+  for (const r of reasons) lines.push(`    ${r}: ${result.failureReasons[r]}`);
+  if (verbose) {
+    lines.push("  failing sessions:");
+    for (const f of result.failures) lines.push(`    ${f.session} — ${f.reason}`);
+  } else {
+    lines.push("  re-run with --verbose to list each failing session.");
+  }
+  return lines;
+}
+
+/**
+ * Pure render of a finished extract run: the staged-count headline, the
+ * failure diagnostics, and the process exit code. Exit 1 only when the run
+ * was a total wash (something failed and nothing staged) so install-time
+ * callers can detect a hard failure; a partial success still exits 0.
+ */
+export function summarizeExtract(
+  result: ExtractSummary,
+  verbose: boolean,
+): { lines: string[]; exitCode: number } {
+  const lines: string[] = [
+    `staged ${result.staged}/${result.attempted} session(s) ` +
+      `(${result.embedded} embedded, ${result.failed} failed` +
+      `${result.timedOutOnBudget ? ", budget reached" : ""}). ` +
+      `Sign in and run the flush to push them into team memory.`,
+    ...renderFailures(result, verbose),
+  ];
+  const exitCode = result.failed > 0 && result.staged === 0 ? 1 : 0;
+  return { lines, exitCode };
+}
+
+export async function runExtract(plan: BackfillPlan, cwd: string, opts: BackfillOptions): Promise<number> {
 
   if (plan.toExtract.length === 0) {
     process.stdout.write("nothing to extract; all in-window sessions already staged.\n");
@@ -332,12 +400,8 @@ async function runExtract(plan: BackfillPlan, cwd: string): Promise<number> {
     startMs: Date.now(),
   });
 
-  process.stdout.write(
-    `staged ${result.staged}/${result.attempted} session(s) ` +
-      `(${result.embedded} embedded, ${result.failed} failed` +
-      `${result.timedOutOnBudget ? ", budget reached" : ""}). ` +
-      `Sign in and run the flush to push them into team memory.\n`,
-  );
+  const { lines, exitCode } = summarizeExtract(result, opts.verbose);
+  process.stdout.write(lines.join("\n") + "\n");
   void homedir;
-  return result.failed > 0 && result.staged === 0 ? 1 : 0;
+  return exitCode;
 }

--- a/src/skillify/stage-memory.ts
+++ b/src/skillify/stage-memory.ts
@@ -21,7 +21,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "
 import { join } from "node:path";
 
 import { WIKI_PROMPT_TEMPLATE } from "../hooks/spawn-wiki-worker.js";
-import { findAgentBin } from "./gate-runner.js";
+import { buildClaudeInvocation } from "../hooks/wiki-worker-spawn.js";
+import { resolveCliBin } from "../utils/resolve-cli-bin.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
 import {
@@ -82,25 +83,55 @@ function countLines(path: string): number {
   }
 }
 
+/** Spawn shape derived from a ClaudeInvocation: how to wire stdio + the prompt. */
+export interface ClaudeSpawnPlan {
+  file: string;
+  args: string[];
+  /** stdin is piped only when the prompt rides stdin (Windows `.cmd` shim). */
+  stdio: ["pipe" | "ignore", "ignore", "ignore"];
+  shell: boolean;
+  /** Prompt to write to stdin, or null when it's passed as a positional arg. */
+  stdinInput: string | null;
+}
+
+/**
+ * Pure translation of a ClaudeInvocation into spawn options. Isolating the
+ * Unix (prompt-as-arg) vs Windows (`.cmd` → prompt-over-stdin) branching here
+ * keeps it unit-testable on any platform — `runClaude` itself stays a thin,
+ * branch-light spawn wrapper.
+ */
+export function planClaudeSpawn(inv: ReturnType<typeof buildClaudeInvocation>): ClaudeSpawnPlan {
+  const shell = inv.options.shell === true;
+  const stdinInput = shell && typeof inv.options.input === "string" ? inv.options.input : null;
+  return {
+    file: inv.file,
+    args: inv.args,
+    // stdout/stderr stay ignored — success is judged by the summary file
+    // landing on disk, and the backfill executor surfaces a `claude-failed`
+    // reason on non-zero exit.
+    stdio: [stdinInput !== null ? "pipe" : "ignore", "ignore", "ignore"],
+    shell,
+    stdinInput,
+  };
+}
+
 function runClaude(claudeBin: string, prompt: string, timeoutMs: number): Promise<boolean> {
+  // Reuse the live wiki-worker's invocation builder so the prompt-as-arg vs
+  // prompt-over-stdin (Windows `.cmd` shim) handling stays identical to the
+  // proven SessionEnd path. A bare `spawn(bin, ["-p", prompt, ...])` cannot
+  // launch a `.cmd` shim and would blow the command-line length on Windows.
+  const plan = planClaudeSpawn(buildClaudeInvocation(claudeBin, prompt));
   return new Promise((resolve) => {
-    const child = spawn(
-      claudeBin,
-      [
-        "-p", prompt,
-        "--no-session-persistence",
-        "--model", "haiku",
-        "--permission-mode", "bypassPermissions",
-      ],
-      {
-        stdio: ["ignore", "ignore", "ignore"],
-        // HIVEMIND_CAPTURE=false: our own extraction claude -p calls must
-        // not re-trigger the capture/wiki hooks and recurse.
-        env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
-        timeout: timeoutMs,
-      },
-    );
+    const child = spawn(plan.file, plan.args, {
+      stdio: plan.stdio,
+      // HIVEMIND_CAPTURE=false: our own extraction claude -p calls must
+      // not re-trigger the capture/wiki hooks and recurse.
+      env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
+      timeout: timeoutMs,
+      shell: plan.shell,
+    });
     child.on("error", () => resolve(false));
+    if (plan.stdinInput !== null) child.stdin?.end(plan.stdinInput);
     child.on("close", (code) => resolve(code === 0));
   });
 }
@@ -205,7 +236,17 @@ export async function stageSession(input: StageSessionInput, opts: StageOptions)
   return { sessionId: key, ok: true, embedded };
 }
 
-/** Resolve the claude binary for the extraction gate. */
+/**
+ * Resolve the claude binary for the extraction gate.
+ *
+ * Uses the same PATH-aware resolver as the live wiki-worker
+ * (`resolveCliBin`, which shells out to `which`/`where`) instead of a
+ * hard-coded candidate list. The candidate-list resolver missed claude when
+ * it was installed somewhere not on the list (e.g. an nvm/npm-global bin) and
+ * fell back to a `~/.claude/local/claude` that may not exist — so every
+ * backfill spawn ENOENT'd and reported `claude-failed` for every session on
+ * an otherwise-healthy install. Aligning with the proven path fixes that.
+ */
 export function resolveClaudeBin(): string {
-  return findAgentBin("claude_code");
+  return resolveCliBin("claude");
 }

--- a/src/skillify/stage-memory.ts
+++ b/src/skillify/stage-memory.ts
@@ -32,6 +32,7 @@ import {
   type PendingMemoryEntry,
 } from "./pending-memory-manifest.js";
 
+/** Inputs identifying one local session to stage into pending memory. */
 export interface StageSessionInput {
   sessionId: string;
   /** Absolute path to the local session JSONL. */
@@ -42,6 +43,7 @@ export interface StageSessionInput {
   project: string;
 }
 
+/** Knobs + injectable seams (agent runner, embedder, paths, clock) for staging. */
 export interface StageOptions {
   /** Path to the claude binary used to run the extraction prompt. */
   claudeBin: string;
@@ -65,6 +67,7 @@ export interface StageOptions {
   embed?: (text: string) => Promise<number[] | null>;
 }
 
+/** Outcome of staging one session: success/embedded flags + a failure reason. */
 export interface StageResult {
   sessionId: string;
   ok: boolean;
@@ -160,6 +163,12 @@ export function backfillSessionKey(agent: string, sessionId: string): string {
   return `${agent}-${sessionId}`;
 }
 
+/**
+ * Stage one local session: run the wiki prompt through the agent CLI, persist
+ * the summary (+ a local embedding) under the staging dir, and append an
+ * `uploaded: false` manifest row. Returns a reason-tagged failure rather than
+ * throwing so the backfill executor can surface why a session didn't stage.
+ */
 export async function stageSession(input: StageSessionInput, opts: StageOptions): Promise<StageResult> {
   const stagingDir = opts.stagingDir ?? PENDING_MEMORY_DIR;
   const key = backfillSessionKey(input.agent, input.sessionId);

--- a/tests/claude-code/backfill-memory.test.ts
+++ b/tests/claude-code/backfill-memory.test.ts
@@ -9,14 +9,23 @@
  * away, so these run fast and deterministically.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parseBackfillArgs,
   planFromSessions,
   executeBackfill,
   renderPlan,
+  renderFailures,
+  summarizeExtract,
+  runExtract,
+  releaseBackfillLock,
   runBackfillMemory,
   type BackfillOptions,
+  type BackfillPlan,
+  type ExtractSummary,
 } from "../../src/commands/backfill-memory.js";
 import type { SessionFile } from "../../src/skillify/local-source.js";
 
@@ -39,6 +48,7 @@ const baseOpts: BackfillOptions = {
   force: false,
   projectOnly: false,
   maxSessions: 50,
+  verbose: false,
   cwd: "/proj",
 };
 
@@ -53,6 +63,11 @@ describe("parseBackfillArgs", () => {
   });
   it("--n all lifts the cap", () => {
     expect(parseBackfillArgs(["--n", "all"], "/proj").maxSessions).toBeNull();
+  });
+  it("--verbose / -v sets verbose", () => {
+    expect(parseBackfillArgs(["--verbose"], "/proj").verbose).toBe(true);
+    expect(parseBackfillArgs(["-v"], "/proj").verbose).toBe(true);
+    expect(parseBackfillArgs([], "/proj").verbose).toBe(false);
   });
   it("ignores invalid numbers", () => {
     const o = parseBackfillArgs(["--window-days", "-5", "--n", "0"], "/proj");
@@ -183,6 +198,30 @@ describe("executeBackfill", () => {
     expect(r).toMatchObject({ attempted: 3, staged: 2, embedded: 1, failed: 1, timedOutOnBudget: false });
   });
 
+  it("surfaces the per-session failure reason instead of swallowing it", async () => {
+    const items = [sess("a", DAY), sess("b", DAY), sess("c", DAY)];
+    const stage = async (s: SessionFile) => {
+      if (s.sessionId === "a") return { ok: false, embedded: false, reason: "claude-failed" };
+      if (s.sessionId === "b") return { ok: false, embedded: false, reason: "claude-failed" };
+      return { ok: false, embedded: false, reason: "no-summary" };
+    };
+    const r = await executeBackfill(items, opts({ stage }));
+    expect(r.failed).toBe(3);
+    expect(r.failureReasons).toEqual({ "claude-failed": 2, "no-summary": 1 });
+    expect(r.failures).toEqual([
+      { session: "claude_code-a", reason: "claude-failed" },
+      { session: "claude_code-b", reason: "claude-failed" },
+      { session: "claude_code-c", reason: "no-summary" },
+    ]);
+  });
+
+  it("labels a missing reason as 'unknown' rather than dropping it", async () => {
+    const stage = async () => ({ ok: false, embedded: false }); // no reason field
+    const r = await executeBackfill([sess("a", DAY)], opts({ stage }));
+    expect(r.failureReasons).toEqual({ unknown: 1 });
+    expect(r.failures).toEqual([{ session: "claude_code-a", reason: "unknown" }]);
+  });
+
   it("counts a stager that throws as failed and continues the queue", async () => {
     const items = [sess("a", DAY), sess("b", DAY), sess("c", DAY)];
     const stage = async (s: SessionFile) => {
@@ -191,6 +230,15 @@ describe("executeBackfill", () => {
     };
     const r = await executeBackfill(items, opts({ stage }));
     expect(r).toMatchObject({ attempted: 3, staged: 2, failed: 1, timedOutOnBudget: false });
+    expect(r.failureReasons).toEqual({ "threw: stager boom": 1 });
+    expect(r.failures).toEqual([{ session: "claude_code-b", reason: "threw: stager boom" }]);
+  });
+
+  it("stringifies a non-Error throw in the reason", async () => {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    const stage = async () => { throw "plain string boom"; };
+    const r = await executeBackfill([sess("a", DAY)], opts({ stage }));
+    expect(r.failures).toEqual([{ session: "claude_code-a", reason: "threw: plain string boom" }]);
   });
 
   it("respects the wall-clock budget and flags it", async () => {
@@ -218,5 +266,133 @@ describe("executeBackfill", () => {
     const r = await executeBackfill(items, opts({ stage, concurrency: 2 }));
     expect(r.staged).toBe(6);
     expect(peak).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("renderFailures", () => {
+  const summary = (over: Partial<ExtractSummary> = {}): ExtractSummary => ({
+    attempted: 0, staged: 0, embedded: 0, failed: 0,
+    timedOutOnBudget: false, failureReasons: {}, failures: [], ...over,
+  });
+
+  it("emits nothing when there were no failures", () => {
+    expect(renderFailures(summary(), false)).toEqual([]);
+    expect(renderFailures(summary({ staged: 3 }), true)).toEqual([]);
+  });
+
+  it("always prints the per-reason tally (sorted) even without --verbose", () => {
+    const out = renderFailures(summary({
+      failed: 3,
+      failureReasons: { "no-summary": 1, "claude-failed": 2 },
+      failures: [
+        { session: "claude_code-a", reason: "claude-failed" },
+        { session: "claude_code-b", reason: "claude-failed" },
+        { session: "claude_code-c", reason: "no-summary" },
+      ],
+    }), false);
+    expect(out[0]).toBe("  3 session(s) failed:");
+    expect(out[1]).toBe("    claude-failed: 2");
+    expect(out[2]).toBe("    no-summary: 1");
+    // Non-verbose hides the per-session list but points at the flag.
+    expect(out.join("\n")).toContain("--verbose");
+    expect(out.join("\n")).not.toContain("claude_code-a");
+  });
+
+  it("lists each failing session under --verbose", () => {
+    const out = renderFailures(summary({
+      failed: 1,
+      failureReasons: { "claude-failed": 1 },
+      failures: [{ session: "claude_code-a", reason: "claude-failed" }],
+    }), true);
+    expect(out.join("\n")).toContain("claude_code-a — claude-failed");
+    expect(out.join("\n")).not.toContain("--verbose to list");
+  });
+});
+
+describe("summarizeExtract", () => {
+  const summary = (over: Partial<ExtractSummary> = {}): ExtractSummary => ({
+    attempted: 0, staged: 0, embedded: 0, failed: 0,
+    timedOutOnBudget: false, failureReasons: {}, failures: [], ...over,
+  });
+
+  it("headline + exit 0 on a clean run, no failure lines", () => {
+    const { lines, exitCode } = summarizeExtract(summary({ attempted: 2, staged: 2, embedded: 2 }), false);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("staged 2/2 session(s) (2 embedded, 0 failed).");
+    expect(lines[0]).not.toContain("budget reached");
+    expect(exitCode).toBe(0);
+  });
+
+  it("notes budget reached when the run was cut short", () => {
+    const { lines } = summarizeExtract(summary({ attempted: 5, staged: 1, timedOutOnBudget: true }), false);
+    expect(lines[0]).toContain("budget reached");
+  });
+
+  it("exit 1 only when something failed AND nothing staged", () => {
+    expect(summarizeExtract(summary({ attempted: 1, failed: 1, failureReasons: { "claude-failed": 1 } }), false).exitCode).toBe(1);
+    // partial success (some staged) still exits 0
+    expect(summarizeExtract(summary({ attempted: 2, staged: 1, failed: 1, failureReasons: { "claude-failed": 1 } }), false).exitCode).toBe(0);
+    // nothing failed → 0
+    expect(summarizeExtract(summary({ attempted: 1, staged: 1 }), false).exitCode).toBe(0);
+  });
+
+  it("appends the failure diagnostics after the headline", () => {
+    const { lines } = summarizeExtract(summary({
+      attempted: 1, failed: 1,
+      failureReasons: { "claude-failed": 1 },
+      failures: [{ session: "claude_code-a", reason: "claude-failed" }],
+    }), true);
+    expect(lines[0]).toContain("staged 0/1");
+    expect(lines.join("\n")).toContain("claude_code-a — claude-failed");
+  });
+});
+
+describe("runExtract", () => {
+  it("short-circuits with a message and exit 0 when nothing is to extract", async () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const plan: BackfillPlan = {
+        windowDays: 42, cutoffMs: 0, inWindow: [], alreadyStaged: [],
+        toExtract: [], skippedByCap: 0, byAgent: {},
+      };
+      const code = await runExtract(plan, "/proj", { ...baseOpts });
+      expect(code).toBe(0);
+      expect(spy.mock.calls.map((c) => String(c[0])).join("")).toContain("nothing to extract");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("releaseBackfillLock", () => {
+  let dir: string;
+  let lock: string;
+  const prev = process.env.HIVEMIND_BACKFILL_LOCK_OWNED;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "lock-"));
+    lock = join(dir, "backfill.lock");
+    writeFileSync(lock, "1");
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.HIVEMIND_BACKFILL_LOCK_OWNED;
+    else process.env.HIVEMIND_BACKFILL_LOCK_OWNED = prev;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("removes the lock only when this process owns it", () => {
+    delete process.env.HIVEMIND_BACKFILL_LOCK_OWNED;
+    releaseBackfillLock(lock);
+    expect(existsSync(lock)).toBe(true); // not owned → untouched
+
+    process.env.HIVEMIND_BACKFILL_LOCK_OWNED = "1";
+    releaseBackfillLock(lock);
+    expect(existsSync(lock)).toBe(false); // owned → removed
+  });
+
+  it("is a no-op (no throw) when the owned lock file is already gone", () => {
+    process.env.HIVEMIND_BACKFILL_LOCK_OWNED = "1";
+    rmSync(lock);
+    expect(() => releaseBackfillLock(lock)).not.toThrow();
   });
 });

--- a/tests/claude-code/stage-memory-embed.test.ts
+++ b/tests/claude-code/stage-memory-embed.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Covers the real `defaultEmbed` path of stageSession — the branch where
+ * embeddings are ENABLED, so the stager computes a vector locally via
+ * EmbedClient and persists it. The rest of the stage-memory suite runs with
+ * embeddings disabled (no `@huggingface/transformers` in the dev tree), which
+ * only exercises the early-return. Here we flip the gate via the disable.ts
+ * test hooks and stub EmbedClient so no real daemon is spawned.
+ *
+ * Isolated file so the EmbedClient module mock doesn't leak into the suites
+ * that assert the disabled (embedded:false) behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../src/embeddings/client.js", () => ({
+  EmbedClient: class {
+    async embed(): Promise<number[]> {
+      return [0.5, 0.25, 0.125];
+    }
+  },
+}));
+
+import { stageSession } from "../../src/skillify/stage-memory.js";
+import {
+  _setResolveForTesting,
+  _setEnabledReaderForTesting,
+  _resetForTesting,
+} from "../../src/embeddings/disable.js";
+
+let dir: string;
+let stagingDir: string;
+let manifestPath: string;
+let jsonlPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "stage-embed-"));
+  stagingDir = join(dir, "staging");
+  manifestPath = join(dir, "pending-memory.json");
+  jsonlPath = join(dir, "session.jsonl");
+  writeFileSync(jsonlPath, '{"type":"user"}\n');
+  // Force embeddingsDisabled() === false: enabled in config AND the
+  // transformers resolve "succeeds" (no throw).
+  _setEnabledReaderForTesting(() => true);
+  _setResolveForTesting(() => { /* resolvable */ });
+});
+afterEach(() => {
+  _resetForTesting();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("stageSession — default local embed path", () => {
+  it("computes and persists an embedding when embeddings are enabled", async () => {
+    const r = await stageSession(
+      { sessionId: "s1", jsonlPath, agent: "claude_code", project: "proj" },
+      {
+        claudeBin: "/fake/claude",
+        timeoutMs: 1000,
+        skipEmbed: false,
+        now: () => "2026-06-16T00:00:00.000Z",
+        stagingDir,
+        manifestPath,
+        // Stub the agent so a summary lands; leave `embed` UNSET so the real
+        // defaultEmbed (→ mocked EmbedClient) runs.
+        runAgent: async (_bin, prompt) => {
+          const m = prompt.match(/SUMMARY FILE to write: (\S+)/);
+          if (m) writeFileSync(m[1], "# Session s1\n## What Happened\nreal content\n");
+          return true;
+        },
+      },
+    );
+    expect(r).toMatchObject({ ok: true, embedded: true });
+    const embPath = join(stagingDir, "claude_code-s1.embedding.json");
+    expect(existsSync(embPath)).toBe(true);
+    expect(JSON.parse(readFileSync(embPath, "utf-8"))).toEqual([0.5, 0.25, 0.125]);
+  });
+
+  it("skips embedding (embedded:false, no file) when the user opted out", async () => {
+    // User-disabled → defaultEmbed early-returns null before touching EmbedClient.
+    _setEnabledReaderForTesting(() => false);
+    const r = await stageSession(
+      { sessionId: "s2", jsonlPath, agent: "claude_code", project: "proj" },
+      {
+        claudeBin: "/fake/claude",
+        timeoutMs: 1000,
+        skipEmbed: false,
+        now: () => "2026-06-16T00:00:00.000Z",
+        stagingDir,
+        manifestPath,
+        runAgent: async (_bin, prompt) => {
+          const m = prompt.match(/SUMMARY FILE to write: (\S+)/);
+          if (m) writeFileSync(m[1], "# Session s2\n## What Happened\nreal content\n");
+          return true;
+        },
+      },
+    );
+    expect(r).toMatchObject({ ok: true, embedded: false });
+    expect(existsSync(join(stagingDir, "claude_code-s2.embedding.json"))).toBe(false);
+  });
+});

--- a/tests/claude-code/stage-memory-shell-spawn.test.ts
+++ b/tests/claude-code/stage-memory-shell-spawn.test.ts
@@ -87,6 +87,8 @@ describe("default runClaude — shell/stdin (Windows .cmd) branch", () => {
     );
     expect(r.ok).toBe(true);
     expect(existsSync(join(stagingDir, "claude_code-s1.md"))).toBe(true);
-    expect(readFileSync(join(stagingDir, "claude_code-s1.md"), "utf-8")).toContain("from stdin");
+    expect(readFileSync(join(stagingDir, "claude_code-s1.md"), "utf-8")).toBe(
+      "# Session s1\n## What Happened\nfrom stdin\n",
+    );
   });
 });

--- a/tests/claude-code/stage-memory-shell-spawn.test.ts
+++ b/tests/claude-code/stage-memory-shell-spawn.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Covers the Windows `.cmd`-shim spawn branch of the default `runClaude`,
+ * where the prompt rides STDIN instead of argv. `binNeedsShell` only returns
+ * true on win32, so we can't reach this path on a Linux CI by passing a
+ * `.cmd` path — instead we mock `buildClaudeInvocation` to return the exact
+ * shell-style invocation it produces for a shim (shell:true + input), and
+ * assert the prompt is delivered over stdin to a real child process.
+ *
+ * Isolated in its own file so the module mock doesn't leak into the
+ * argv-path spawn tests in stage-memory.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// A real node program that reads the prompt from STDIN, pulls the summary
+// path out of it, and writes the summary file — exactly what the prompt asks
+// a claude `.cmd` shim to do, but deterministic and offline. Written to disk
+// in vi.hoisted so the path is available to the (hoisted) vi.mock factory.
+const { reader } = vi.hoisted(() => {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "shellclaude-"));
+  const p = path.join(dir, "reader.mjs");
+  fs.writeFileSync(
+    p,
+    [
+      'import { writeFileSync } from "node:fs";',
+      'let buf = "";',
+      'process.stdin.setEncoding("utf-8");',
+      'process.stdin.on("data", (c) => { buf += c; });',
+      'process.stdin.on("end", () => {',
+      '  const m = buf.match(/SUMMARY FILE to write: (\\S+)/);',
+      '  if (m) writeFileSync(m[1], "# Session s1\\n## What Happened\\nfrom stdin\\n");',
+      "  process.exit(0);",
+      "});",
+    ].join("\n"),
+  );
+  return { reader: p };
+});
+
+vi.mock("../../src/hooks/wiki-worker-spawn.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/hooks/wiki-worker-spawn.js")>();
+  return {
+    ...actual,
+    // Mirror the shell branch of the real builder: prompt over stdin, shell on.
+    buildClaudeInvocation: (_bin: string, prompt: string) => ({
+      file: "node",
+      args: [reader],
+      options: { input: prompt, stdio: ["pipe", "pipe", "pipe"], shell: true },
+    }),
+  };
+});
+
+import { stageSession } from "../../src/skillify/stage-memory.js";
+
+let dir: string;
+let stagingDir: string;
+let manifestPath: string;
+let jsonlPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "stage-shell-"));
+  stagingDir = join(dir, "staging");
+  manifestPath = join(dir, "pending-memory.json");
+  jsonlPath = join(dir, "session.jsonl");
+  mkdirSync(stagingDir, { recursive: true });
+  writeFileSync(jsonlPath, '{"type":"user"}\n');
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("default runClaude — shell/stdin (Windows .cmd) branch", () => {
+  it("delivers the prompt over stdin and stages the summary it writes", async () => {
+    const r = await stageSession(
+      { sessionId: "s1", jsonlPath, agent: "claude_code", project: "proj" },
+      {
+        claudeBin: "claude.cmd",
+        timeoutMs: 10_000,
+        skipEmbed: true,
+        now: () => "2026-06-16T00:00:00.000Z",
+        stagingDir,
+        manifestPath,
+      },
+    );
+    expect(r.ok).toBe(true);
+    expect(existsSync(join(stagingDir, "claude_code-s1.md"))).toBe(true);
+    expect(readFileSync(join(stagingDir, "claude_code-s1.md"), "utf-8")).toContain("from stdin");
+  });
+});

--- a/tests/claude-code/stage-memory.test.ts
+++ b/tests/claude-code/stage-memory.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { stageSession, resolveClaudeBin, type StageOptions } from "../../src/skillify/stage-memory.js";
+import { stageSession, resolveClaudeBin, planClaudeSpawn, type StageOptions } from "../../src/skillify/stage-memory.js";
 import { readPendingMemoryManifest } from "../../src/skillify/pending-memory-manifest.js";
 
 let dir: string;
@@ -143,6 +143,49 @@ describe("stageSession", () => {
   it("resolveClaudeBin returns a non-empty path", () => {
     expect(typeof resolveClaudeBin()).toBe("string");
     expect(resolveClaudeBin().length).toBeGreaterThan(0);
+  });
+
+  describe("planClaudeSpawn", () => {
+    it("Unix (prompt-as-arg): prompt rides argv, stdin ignored, no shell", () => {
+      // What buildClaudeInvocation returns on Unix / a Windows .exe.
+      const plan = planClaudeSpawn({
+        file: "/usr/bin/claude",
+        args: ["-p", "PROMPT", "--model", "haiku"],
+        options: { stdio: ["ignore", "pipe", "pipe"] },
+      });
+      expect(plan).toMatchObject({
+        file: "/usr/bin/claude",
+        args: ["-p", "PROMPT", "--model", "haiku"],
+        stdio: ["ignore", "ignore", "ignore"],
+        shell: false,
+        stdinInput: null,
+      });
+    });
+
+    it("Windows (.cmd shim): prompt rides stdin, stdin piped, shell on", () => {
+      // What buildClaudeInvocation returns for a `.cmd`/`.bat` shim.
+      const plan = planClaudeSpawn({
+        file: "C:/claude.cmd",
+        args: ["-p", "--model", "haiku"],
+        options: { input: "PROMPT", stdio: ["pipe", "pipe", "pipe"], shell: true },
+      });
+      expect(plan).toMatchObject({
+        file: "C:/claude.cmd",
+        stdio: ["pipe", "ignore", "ignore"],
+        shell: true,
+        stdinInput: "PROMPT",
+      });
+    });
+
+    it("shell with a non-string input keeps stdin ignored (no prompt to pipe)", () => {
+      const plan = planClaudeSpawn({
+        file: "claude.cmd",
+        args: [],
+        options: { stdio: ["pipe", "pipe", "pipe"], shell: true },
+      });
+      expect(plan.stdinInput).toBeNull();
+      expect(plan.stdio[0]).toBe("ignore");
+    });
   });
 
   // Exercise the REAL default runClaude (spawn path) via a fake executable

--- a/tests/cli/cli-index.test.ts
+++ b/tests/cli/cli-index.test.ts
@@ -523,7 +523,7 @@ describe("hivemind memory", () => {
 
   it("unknown memory subcommand prints usage and exits 1", async () => {
     await runCli(["memory", "wat"]);
-    expect(stderrText()).toContain("Usage: hivemind memory backfill [--dry-run] [--force] [--n <num|all>] [--window-days N] [--project-only] | flush");
+    expect(stderrText()).toContain("Usage: hivemind memory backfill [--dry-run] [--force] [--n <num|all>] [--window-days N] [--project-only] [--verbose] | flush");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -412,9 +412,9 @@ export default defineConfig({
         // config (e.g. gate-runner 60, build-lock 55, skills-table 70).
         "src/skillify/pending-memory-manifest.ts":    { statements: 90, branches: 85, functions: 90, lines: 90 },
         "src/skillify/backfill-guards.ts":            { statements: 90, branches: 90, functions: 90, lines: 90 },
-        "src/skillify/stage-memory.ts":               { statements: 90, branches: 85, functions: 90, lines: 90 },
+        "src/skillify/stage-memory.ts":               { statements: 90, branches: 90, functions: 90, lines: 90 },
         "src/skillify/spawn-backfill-memory-worker.ts": { statements: 90, branches: 90, functions: 90, lines: 90 },
-        "src/commands/backfill-memory.ts":            { statements: 90, branches: 85, functions: 90, lines: 90 },
+        "src/commands/backfill-memory.ts":            { statements: 90, branches: 90, functions: 90, lines: 90 },
         // branches at 85 (not 90): the residual gaps are defensive catch/??
         // fallbacks, and v8 branch counting drifts a couple points across Node
         // versions (CI measured 88 where local measured 92), so the floor is


### PR DESCRIPTION
Fixes #276 — `hivemind memory backfill` stages `0/N (0 embedded, N failed)` with no surfaced reason.

## What was wrong

### 1. The failure reason was swallowed (the explicit ask)
`stageSession` already computes a precise reason for every outcome — `claude-failed`, `no-summary`, `empty-summary`, `jsonl-missing`, `mkdir-failed` — but it was **dropped at the `StageFn` boundary** (`defaultStageFn` returned only `{ok, embedded}`) and `executeBackfill` just did `summary.failed++`. So the CLI could only print a bare `N failed`.

Now the reason is carried through, tallied per-reason, recorded per-session. The report always prints the breakdown, and `--verbose`/`-v` lists each failing session. A thrown stager is captured as `threw: <message>`.

### 2. Root cause: claude binary not found
The stager resolved claude via `findAgentBin("claude_code")` — a hard-coded candidate-list resolver with no PATH walk, falling back to `~/.claude/local/claude`. When claude lives off that list (e.g. an nvm/npm-global bin — the reporter's macOS+nvm setup), the fallback doesn't exist → every `spawn` ENOENTs → every session is `claude-failed`. The live wiki-worker uses the PATH-aware `resolveCliBin("claude")`; this aligns backfill with it and reuses `buildClaudeInvocation` for the Windows `.cmd` path. (`stage-memory.ts` is in the CLI bundle, not the ClawHub-scanned openclaw worker, so the PATH-free constraint behind `findAgentBin` doesn't apply.)

## Reproduced in isolation

Simulated the reporter's environment (claude on PATH but off every `findAgentBin` candidate, isolated `HOME` so the fallback is absent) and drove the real `stageSession` through both resolvers:

```
OLD findAgentBin   -> <home>/.claude/local/claude   exists: false
                      stageSession -> { ok:false, reason:"claude-failed" }   <- the reporter's "N failed"
NEW resolveCliBin  -> <home>/nvm-bin/claude          exists: true
                      stageSession -> { ok:true }                            <- staged
```

The exact symptom (`0/N, 0 embedded, N failed`) reproduced, the swallowed reason shown to be `claude-failed`, and the fix flipping it to staged. (Repro manipulates `HOME`/`PATH`/`which` — kept as throwaway verification, not a Windows-fragile committed test.)

Caveat: this reproduces the *claude-off-the-candidate-list* case. If a user's claude IS at a candidate path, their failure is a different reason (e.g. `no-summary`) — which the surfacing change now makes visible instead of swallowing.

## Tests & coverage

Pure units extracted (`planClaudeSpawn`, `summarizeExtract`, `renderFailures`, `releaseBackfillLock`); isolated mock files cover the Windows stdin spawn path and the real `defaultEmbed` enabled/disabled branches without spawning claude or an embed daemon.

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `commands/backfill-memory.ts` | 99.3 | 96.6 | 94.7 | 99.2 |
| `skillify/stage-memory.ts` | 100 | 94.7 | 100 | 100 |

Both >=90% on every metric; branch thresholds raised 85->90. Typecheck clean; targeted suites green (58 tests); full suite shows only pre-existing build-artifact failures (unchanged from baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` for memory backfill with richer, per-session failure diagnostics.
  * Memory backfill now supports additional optional backfill flags (`--window-days`, `--project-only`) in the usage message.
* **Bug Fixes**
  * Improved Claude executable resolution to better prevent missing-binary failures.
  * Enhanced Windows-specific Claude invocation handling and safer lock-file cleanup.
* **Tests**
  * Expanded backfill failure-reporting, exit-code, and lock-ownership coverage.
  * Added embedding and Windows stdin/shell staging test coverage.
  * Tightened coverage thresholds for memory backfill and staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->