### PR TITLE
feat: --ref affiliate referral code on install and login

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -15,14 +15,16 @@ export function isLoggedIn(): boolean {
   return existsSync(CREDS_PATH) && loadCredentials() !== null;
 }
 
-export async function ensureLoggedIn(): Promise<boolean> {
+// ref carries an affiliate campaign code from `--ref <code>`. It only matters on
+// a genuinely new signup; the backend ignores it for already-registered users.
+export async function ensureLoggedIn(ref?: string): Promise<boolean> {
   if (isLoggedIn()) return true;
 
   log("");
   log("No Deeplake credentials found. Starting login...");
 
   try {
-    await login(resolveApiUrl());
+    await login(resolveApiUrl(), ref);
   } catch (err) {
     warn(`Login failed: ${(err as Error).message}`);
     return false;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -201,7 +201,11 @@ function parseRef(args: string[]): string | undefined {
   const idx = args.findIndex(a => a === "--ref" || a.startsWith("--ref="));
   if (idx === -1) return undefined;
   const raw = args[idx].includes("=") ? args[idx].split("=", 2)[1] : args[idx + 1];
-  return raw && raw.length > 0 ? raw : undefined;
+  // A bare `--ref` followed by another flag (e.g. `--ref --skip-auth`) must not
+  // swallow that flag as the code. Reject anything that looks like a flag.
+  if (!raw || raw.startsWith("--")) return undefined;
+  const code = raw.trim();
+  return code.length > 0 ? code : undefined;
 }
 
 function hasEnvToken(): boolean {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,12 +46,15 @@ hivemind — one brain for every agent on your team
 
 Usage:
   hivemind install   [--only <platforms>] [--skip-auth] [--token <value>]
+                     [--ref <code>]
       Auto-detect assistants on this machine and install hivemind into each.
       --only takes a comma-separated list: ${allPlatformIds().join(",")}
       --token, or env HIVEMIND_TOKEN, signs in non-interactively (useful
       for CI / scripted installs). Without it, a TTY install shows a
       consent prompt; a headless install skips auth and prints a hint
       for 'hivemind login'.
+      --ref <code> attributes a NEW signup to an affiliate/referrer code
+      (e.g. --ref mario). Ignored for already-registered users.
 
   hivemind uninstall [--only <platforms>]
       Auto-detect installed assistants and remove hivemind from each.
@@ -65,7 +68,9 @@ Usage:
   hivemind pi      install | uninstall
       Install or remove hivemind for a specific assistant.
 
-  hivemind login            Run device-flow login (open browser).
+  hivemind login [--ref <code>]
+                            Run device-flow login (open browser). --ref
+                            attributes a new signup to a referrer code.
   hivemind status           Show which assistants are wired up.
   hivemind update [--dry-run]
       Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
@@ -190,6 +195,15 @@ function parseToken(args: string[]): string | undefined {
   return raw && raw.length > 0 ? raw : undefined;
 }
 
+// Affiliate referral code from `--ref <code>` / `--ref=<code>`. Carried into the
+// device flow so a NEW signup can be attributed to the referring influencer.
+function parseRef(args: string[]): string | undefined {
+  const idx = args.findIndex(a => a === "--ref" || a.startsWith("--ref="));
+  if (idx === -1) return undefined;
+  const raw = args[idx].includes("=") ? args[idx].split("=", 2)[1] : args[idx + 1];
+  return raw && raw.length > 0 ? raw : undefined;
+}
+
 function hasEnvToken(): boolean {
   return Boolean(process.env.HIVEMIND_TOKEN);
 }
@@ -296,7 +310,7 @@ async function runAuthGate(args: string[]): Promise<void> {
 
   let signedIn = false;
   if (yes) {
-    signedIn = await ensureLoggedIn();
+    signedIn = await ensureLoggedIn(parseRef(args));
     if (!signedIn) {
       warn("Login did not complete.");
     }
@@ -441,7 +455,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (cmd === "login") { await ensureLoggedIn(); return; }
+  if (cmd === "login") { await ensureLoggedIn(parseRef(args.slice(1))); return; }
   if (cmd === "status") { runStatus(); return; }
   if (cmd === "update") {
     const code = await runUpdate({ dryRun: hasFlag(args.slice(1), "--dry-run") });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -91,13 +91,24 @@ async function apiDelete(path: string, token: string, apiUrl: string, orgId?: st
 
 // ── Device Flow ──────────────────────────────────────────────────────────────
 
-export async function requestDeviceCode(apiUrl = DEFAULT_API_URL): Promise<DeviceCodeResponse> {
+// Returns `{ "X-Hivemind-Referrer": "<code>" }` for spreading into a headers
+// object, or `{}` when there is no referral. The backend parks this code against
+// the device flow and attributes the signup if a NEW user registers. Trimmed
+// here; the backend lowercases + validates against its affiliate registry.
+export function hivemindReferrerHeader(ref?: string): Record<string, string> {
+  const code = ref?.trim();
+  if (!code) return {};
+  return { "X-Hivemind-Referrer": code };
+}
+
+export async function requestDeviceCode(apiUrl = DEFAULT_API_URL, ref?: string): Promise<DeviceCodeResponse> {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...deeplakeClientHeader(),
       ...hivemindInstallIDHeader(),
+      ...hivemindReferrerHeader(ref),
     },
   });
   if (!resp.ok) throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
@@ -136,8 +147,8 @@ function openBrowser(url: string): boolean {
   }
 }
 
-export async function deviceFlowLogin(apiUrl = DEFAULT_API_URL): Promise<{ token: string; expiresIn: number }> {
-  const code = await requestDeviceCode(apiUrl);
+export async function deviceFlowLogin(apiUrl = DEFAULT_API_URL, ref?: string): Promise<{ token: string; expiresIn: number }> {
+  const code = await requestDeviceCode(apiUrl, ref);
 
   const opened = openBrowser(code.verification_uri_complete);
   const msg = [
@@ -415,7 +426,7 @@ export async function saveCredentialsFromToken(
   return creds;
 }
 
-export async function login(apiUrl = DEFAULT_API_URL): Promise<Credentials> {
-  const { token: authToken } = await deviceFlowLogin(apiUrl);
+export async function login(apiUrl = DEFAULT_API_URL, ref?: string): Promise<Credentials> {
+  const { token: authToken } = await deviceFlowLogin(apiUrl, ref);
   return saveCredentialsFromToken(authToken, apiUrl, { skipTokenMint: false });
 }

--- a/tests/cli/affiliate-ref.test.ts
+++ b/tests/cli/affiliate-ref.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hivemindReferrerHeader, requestDeviceCode } from "../../src/commands/auth.js";
+
+// The affiliate referral code (--ref) must reach the backend as the
+// X-Hivemind-Referrer header on /auth/device/code. These tests pin both the
+// pure header construction and the fact that requestDeviceCode actually puts it
+// on the wire — that header is the entire CLI side of the attribution contract.
+
+describe("hivemindReferrerHeader", () => {
+  it("emits the header for a code", () => {
+    expect(hivemindReferrerHeader("mario")).toEqual({ "X-Hivemind-Referrer": "mario" });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(hivemindReferrerHeader("  mario  ")).toEqual({ "X-Hivemind-Referrer": "mario" });
+  });
+
+  it("omits the header when there is no referral", () => {
+    expect(hivemindReferrerHeader(undefined)).toEqual({});
+    expect(hivemindReferrerHeader("")).toEqual({});
+    expect(hivemindReferrerHeader("   ")).toEqual({});
+  });
+});
+
+describe("requestDeviceCode referral header", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let prevHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    // Sandbox HOME so the install-id helper writes to throwaway state, not the
+    // developer's real ~/.deeplake.
+    prevHome = process.env.HOME;
+    tmpHome = mkdtempSync(join(tmpdir(), "hivemind-ref-home-"));
+    process.env.HOME = tmpHome;
+
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        device_code: "dc", user_code: "uc",
+        verification_uri: "https://v", verification_uri_complete: "https://v?c=uc",
+        expires_in: 600, interval: 5,
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function sentHeaders(): Record<string, string> {
+    return mockFetch.mock.calls[0][1].headers as Record<string, string>;
+  }
+
+  it("sends X-Hivemind-Referrer when a ref is given", async () => {
+    await requestDeviceCode("https://api.example.com", "mario");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(sentHeaders()["X-Hivemind-Referrer"]).toBe("mario");
+  });
+
+  it("does not send the header when no ref is given", async () => {
+    await requestDeviceCode("https://api.example.com");
+    expect(sentHeaders()).not.toHaveProperty("X-Hivemind-Referrer");
+  });
+});

--- a/tests/cli/cli-auth.test.ts
+++ b/tests/cli/cli-auth.test.ts
@@ -125,7 +125,8 @@ describe("ensureLoggedIn", () => {
     const { ensureLoggedIn } = await importFresh();
     expect(await ensureLoggedIn()).toBe(true);
     expect(loginMock).toHaveBeenCalledTimes(1);
-    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai");
+    // Second arg is the affiliate --ref code, undefined when none was passed.
+    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai", undefined);
   });
 
   it("HIVEMIND_API_URL is used when set, otherwise default", async () => {
@@ -135,7 +136,7 @@ describe("ensureLoggedIn", () => {
     });
     const { ensureLoggedIn } = await importFresh();
     await ensureLoggedIn();
-    expect(loginMock).toHaveBeenCalledWith("https://hm.example");
+    expect(loginMock).toHaveBeenCalledWith("https://hm.example", undefined);
   });
 
   it("DEEPLAKE_API_URL env is NOT honored (legacy name removed)", async () => {
@@ -145,7 +146,16 @@ describe("ensureLoggedIn", () => {
     });
     const { ensureLoggedIn } = await importFresh();
     await ensureLoggedIn();
-    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai");
+    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai", undefined);
+  });
+
+  it("threads the affiliate --ref code through to login()", async () => {
+    loginMock.mockImplementation(async () => {
+      writeCreds({ token: "t", orgId: "o", savedAt: "" });
+    });
+    const { ensureLoggedIn } = await importFresh();
+    await ensureLoggedIn("mario");
+    expect(loginMock).toHaveBeenCalledWith("https://api.deeplake.ai", "mario");
   });
 
   it("returns false (and writes to stderr) when login() rejects", async () => {

--- a/tests/cli/cli-index.test.ts
+++ b/tests/cli/cli-index.test.ts
@@ -459,6 +459,16 @@ describe("hivemind login / status", () => {
     expect(ensureLoggedInMock).toHaveBeenCalledTimes(1);
   });
 
+  it("'login --ref <code>' passes the affiliate code to ensureLoggedIn", async () => {
+    await runCli(["login", "--ref", "mario"]);
+    expect(ensureLoggedInMock).toHaveBeenCalledWith("mario");
+  });
+
+  it("'login --ref' does not swallow a following flag as the code", async () => {
+    await runCli(["login", "--ref", "--skip-auth"]);
+    expect(ensureLoggedInMock).toHaveBeenCalledWith(undefined);
+  });
+
   it("'status' prints version, login state, and detected platforms", async () => {
     detectPlatformsMock.mockReturnValue([{ id: "claude", markerDir: "/x/.claude" }]);
     isLoggedInMock.mockReturnValue(true);


### PR DESCRIPTION
## What

Adds a `--ref <code>` flag to `hivemind install` and `hivemind login` that
carries an affiliate/influencer campaign code so a **new signup** can be
attributed to the referrer.

```
npm install -g @deeplake/hivemind && hivemind install --ref mario
```

The code only matters for a genuinely new registration; the backend ignores it
for already-registered users.

## Changes

- `src/cli/index.ts` — `parseRef()` (mirrors `parseToken`), threads the code
  into the install and login paths, documents the flag in `USAGE`.
- `src/cli/auth.ts` — `ensureLoggedIn(ref)` passes it to `login`.
- `src/commands/auth.ts` — sends it as the `X-Hivemind-Referrer` header on
  `POST /auth/device/code` (same pattern as `X-Hivemind-Install-Id`). Trimmed
  here; the backend lowercases + validates against its affiliate registry.

The header is omitted entirely when no `--ref` is given.

## Tests

- `tests/cli/affiliate-ref.test.ts` — header construction (trim / omit) and that
  `requestDeviceCode` puts `X-Hivemind-Referrer` on the wire only when a ref is
  given.
- `tests/cli/cli-auth.test.ts` — asserts the ref threads through to `login()`.
- Full `tsc`, `npm run build`, and the `cli` suite stay green.

## Pairs with

The deeplake-api PR that parks the code at `/auth/device/code` and records the
signup attribution. The flag is inert until that backend ships and codes exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for affiliate/referrer codes via an optional `--ref <code>` flag for authentication commands (e.g., `hivemind install --ref <code>` and `hivemind login --ref <code>`), applying the code during the login flow.

* **Tests**
  * Added/updated test coverage to verify `--ref` parsing/forwarding and that the referral header is sent (or omitted) correctly during device-code authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->