### PR TITLE
feat(codex): proactive memory via managed ~/.codex/AGENTS.md block

### DIFF
--- a/src/cli/agents-md.ts
+++ b/src/cli/agents-md.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared AGENTS.md hivemind-block management.
+ *
+ * AGENTS.md is the global agent-instructions file that several harnesses
+ * auto-load into the model's context every session — SILENTLY, with no
+ * user-visible TUI cell:
+ *   - pi    → `~/.pi/agent/AGENTS.md`
+ *   - Codex → `~/.codex/AGENTS.md`
+ *
+ * We manage only a marker-fenced block and never touch the user's own
+ * content. The marker pair is shared across harnesses (they write to
+ * different files, so there is no collision).
+ */
+
+export const HIVEMIND_BLOCK_START = "<!-- BEGIN hivemind-memory -->";
+export const HIVEMIND_BLOCK_END = "<!-- END hivemind-memory -->";
+
+/**
+ * Insert or replace the hivemind block in `existing`. `block` is the full
+ * marker-fenced block (START … END). Idempotent: a prior block (matched on
+ * the marker pair) is stripped before re-appending, so repeated installs
+ * leave exactly one block. User content outside the markers is preserved.
+ */
+export function upsertMarkedBlock(
+  existing: string | null,
+  block: string,
+  start: string = HIVEMIND_BLOCK_START,
+  end: string = HIVEMIND_BLOCK_END,
+): string {
+  if (!existing) return `${block}\n`;
+  const startIdx = existing.indexOf(start);
+  if (startIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  const endIdx = existing.indexOf(end, startIdx);
+  // Malformed prior block (no END) — append fresh and let the user clean up.
+  if (endIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  const before = existing.slice(0, startIdx).trimEnd();
+  const after = existing.slice(endIdx + end.length).replace(/^\n+/, "");
+  const rest = after ? `\n\n${after}` : "";
+  return `${before ? before + "\n\n" : ""}${block}\n${rest}`;
+}
+
+/** Remove the hivemind block from `existing`, preserving surrounding content. */
+export function stripMarkedBlock(
+  existing: string,
+  start: string = HIVEMIND_BLOCK_START,
+  end: string = HIVEMIND_BLOCK_END,
+): string {
+  const startIdx = existing.indexOf(start);
+  if (startIdx === -1) return existing;
+  const endIdx = existing.indexOf(end, startIdx);
+  if (endIdx === -1) return existing;
+  const before = existing.slice(0, startIdx).trimEnd();
+  const after = existing.slice(endIdx + end.length).replace(/^\n+/, "");
+  if (!before && !after) return "";
+  if (!before) return after;
+  if (!after) return `${before}\n`;
+  return `${before}\n\n${after}`;
+}

--- a/src/cli/agents-md.ts
+++ b/src/cli/agents-md.ts
@@ -28,18 +28,16 @@ export function upsertMarkedBlock(
   end: string = HIVEMIND_BLOCK_END,
 ): string {
   if (!existing) return `${block}\n`;
-  const startIdx = existing.indexOf(start);
-  if (startIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  const endIdx = existing.indexOf(end, startIdx);
-  // Malformed prior block (a BEGIN with no END anywhere) — don't risk
-  // truncating user content; append a fresh block. stripMarkedBlock can still
-  // remove it later (it scans past the malformed marker for well-formed pairs).
-  if (endIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  // Replace the FIRST block IN PLACE — keeping its position relative to the
-  // user's own notes so their overrides keep their precedence — and strip any
+  const first = findFirstBlock(existing, start, end);
+  // No well-formed block (none at all, or only a stray/unclosed BEGIN) — append
+  // a fresh one. We never pair a stray BEGIN with our block's END, so user text
+  // under a half-written marker is preserved.
+  if (!first) return `${existing.trimEnd()}\n\n${block}\n`;
+  // Replace the first WELL-FORMED block IN PLACE — keeping its position relative
+  // to the user's own notes so their overrides keep precedence — and strip any
   // DUPLICATE blocks from the tail (bad merge / manual paste collapse to one).
-  const before = existing.slice(0, startIdx).trimEnd();
-  const after = stripMarkedBlock(existing.slice(endIdx + end.length), start, end)
+  const before = existing.slice(0, first.startIdx).trimEnd();
+  const after = stripMarkedBlock(existing.slice(first.endIdx + end.length), start, end)
     .replace(/^\n+/, "")
     .trimEnd();
   const head = before ? `${before}\n\n` : "";
@@ -49,9 +47,9 @@ export function upsertMarkedBlock(
 
 /**
  * Remove EVERY hivemind block from `existing`, preserving surrounding content.
- * Loops so duplicate marker pairs are all removed; stops at a malformed
- * (BEGIN-without-END) block and leaves the remainder untouched so user data
- * after a half-written marker is never truncated.
+ * Loops so duplicate marker pairs are all removed; skips stray/unclosed BEGIN
+ * markers (never pairing them with a later block's END) so user data under a
+ * half-written marker is never truncated.
  */
 export function stripMarkedBlock(
   existing: string,
@@ -59,30 +57,41 @@ export function stripMarkedBlock(
   end: string = HIVEMIND_BLOCK_END,
 ): string {
   let text = existing;
-  let searchFrom = 0;
   for (;;) {
-    const startIdx = text.indexOf(start, searchFrom);
-    if (startIdx === -1) return text;
-    const endIdx = text.indexOf(end, startIdx);
-    // A BEGIN with no END anywhere after it — leave the remainder intact so a
-    // user's half-written marker (and the text under it) is never truncated.
-    if (endIdx === -1) return text;
-    // A stray/unclosed BEGIN: another BEGIN appears before this one's END, so
-    // this END actually belongs to a *later* block. Pairing them would delete
-    // the user's content in between (data loss). Skip this BEGIN and resume the
-    // scan after it — only well-formed BEGIN..END pairs (no intervening BEGIN)
-    // are removed.
-    const nextStart = text.indexOf(start, startIdx + start.length);
-    if (nextStart !== -1 && nextStart < endIdx) {
-      searchFrom = startIdx + start.length;
-      continue;
-    }
-    const before = text.slice(0, startIdx).trimEnd();
-    const after = text.slice(endIdx + end.length).replace(/^\n+/, "");
+    const block = findFirstBlock(text, start, end);
+    if (!block) return text;
+    const before = text.slice(0, block.startIdx).trimEnd();
+    const after = text.slice(block.endIdx + end.length).replace(/^\n+/, "");
     if (!before && !after) text = "";
     else if (!before) text = after;
     else if (!after) text = `${before}\n`;
     else text = `${before}\n\n${after}`;
-    searchFrom = 0; // text shifted — rescan from the top
+  }
+}
+
+/**
+ * Locate the first WELL-FORMED block: a BEGIN whose matching END has no other
+ * BEGIN before it. Stray/unclosed BEGIN markers (another BEGIN appears before
+ * the next END, or there is no END at all) are skipped so they're never paired
+ * with a later block's END — the shared guard both upsert and strip rely on to
+ * avoid deleting user content between a stray marker and our block.
+ */
+function findFirstBlock(
+  text: string,
+  start: string,
+  end: string,
+): { startIdx: number; endIdx: number } | null {
+  let from = 0;
+  for (;;) {
+    const startIdx = text.indexOf(start, from);
+    if (startIdx === -1) return null;
+    const endIdx = text.indexOf(end, startIdx);
+    if (endIdx === -1) return null;
+    const nextStart = text.indexOf(start, startIdx + start.length);
+    if (nextStart !== -1 && nextStart < endIdx) {
+      from = startIdx + start.length;
+      continue;
+    }
+    return { startIdx, endIdx };
   }
 }

--- a/src/cli/agents-md.ts
+++ b/src/cli/agents-md.ts
@@ -30,14 +30,21 @@ export function upsertMarkedBlock(
   if (!existing) return `${block}\n`;
   const startIdx = existing.indexOf(start);
   if (startIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  const endIdx = existing.indexOf(end, startIdx);
   // Malformed prior block (a BEGIN with no END anywhere) — don't risk
-  // truncating user content; append a fresh block and let the user clean up.
-  if (existing.indexOf(end, startIdx) === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  // Strip every existing block (handles duplicates from a bad merge / manual
-  // paste), then re-append exactly one — guaranteeing the "single block"
-  // contract is idempotent even for already-duplicated files.
-  const cleaned = stripMarkedBlock(existing, start, end).trimEnd();
-  return cleaned ? `${cleaned}\n\n${block}\n` : `${block}\n`;
+  // truncating user content; append a fresh block. stripMarkedBlock can still
+  // remove it later (it scans past the malformed marker for well-formed pairs).
+  if (endIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  // Replace the FIRST block IN PLACE — keeping its position relative to the
+  // user's own notes so their overrides keep their precedence — and strip any
+  // DUPLICATE blocks from the tail (bad merge / manual paste collapse to one).
+  const before = existing.slice(0, startIdx).trimEnd();
+  const after = stripMarkedBlock(existing.slice(endIdx + end.length), start, end)
+    .replace(/^\n+/, "")
+    .trimEnd();
+  const head = before ? `${before}\n\n` : "";
+  const tail = after ? `\n\n${after}` : "";
+  return `${head}${block}${tail}\n`;
 }
 
 /**
@@ -56,6 +63,9 @@ export function stripMarkedBlock(
     const startIdx = text.indexOf(start);
     if (startIdx === -1) return text;
     const endIdx = text.indexOf(end, startIdx);
+    // A BEGIN with no END after it — stop here, leaving the remainder intact so
+    // a user's half-written marker (and any text under it) is never truncated.
+    // Well-formed blocks earlier in the file have already been removed by now.
     if (endIdx === -1) return text;
     const before = text.slice(0, startIdx).trimEnd();
     const after = text.slice(endIdx + end.length).replace(/^\n+/, "");

--- a/src/cli/agents-md.ts
+++ b/src/cli/agents-md.ts
@@ -30,29 +30,38 @@ export function upsertMarkedBlock(
   if (!existing) return `${block}\n`;
   const startIdx = existing.indexOf(start);
   if (startIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  const endIdx = existing.indexOf(end, startIdx);
-  // Malformed prior block (no END) — append fresh and let the user clean up.
-  if (endIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  const before = existing.slice(0, startIdx).trimEnd();
-  const after = existing.slice(endIdx + end.length).replace(/^\n+/, "");
-  const rest = after ? `\n\n${after}` : "";
-  return `${before ? before + "\n\n" : ""}${block}\n${rest}`;
+  // Malformed prior block (a BEGIN with no END anywhere) — don't risk
+  // truncating user content; append a fresh block and let the user clean up.
+  if (existing.indexOf(end, startIdx) === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  // Strip every existing block (handles duplicates from a bad merge / manual
+  // paste), then re-append exactly one — guaranteeing the "single block"
+  // contract is idempotent even for already-duplicated files.
+  const cleaned = stripMarkedBlock(existing, start, end).trimEnd();
+  return cleaned ? `${cleaned}\n\n${block}\n` : `${block}\n`;
 }
 
-/** Remove the hivemind block from `existing`, preserving surrounding content. */
+/**
+ * Remove EVERY hivemind block from `existing`, preserving surrounding content.
+ * Loops so duplicate marker pairs are all removed; stops at a malformed
+ * (BEGIN-without-END) block and leaves the remainder untouched so user data
+ * after a half-written marker is never truncated.
+ */
 export function stripMarkedBlock(
   existing: string,
   start: string = HIVEMIND_BLOCK_START,
   end: string = HIVEMIND_BLOCK_END,
 ): string {
-  const startIdx = existing.indexOf(start);
-  if (startIdx === -1) return existing;
-  const endIdx = existing.indexOf(end, startIdx);
-  if (endIdx === -1) return existing;
-  const before = existing.slice(0, startIdx).trimEnd();
-  const after = existing.slice(endIdx + end.length).replace(/^\n+/, "");
-  if (!before && !after) return "";
-  if (!before) return after;
-  if (!after) return `${before}\n`;
-  return `${before}\n\n${after}`;
+  let text = existing;
+  for (;;) {
+    const startIdx = text.indexOf(start);
+    if (startIdx === -1) return text;
+    const endIdx = text.indexOf(end, startIdx);
+    if (endIdx === -1) return text;
+    const before = text.slice(0, startIdx).trimEnd();
+    const after = text.slice(endIdx + end.length).replace(/^\n+/, "");
+    if (!before && !after) text = "";
+    else if (!before) text = after;
+    else if (!after) text = `${before}\n`;
+    else text = `${before}\n\n${after}`;
+  }
 }

--- a/src/cli/agents-md.ts
+++ b/src/cli/agents-md.ts
@@ -59,19 +59,30 @@ export function stripMarkedBlock(
   end: string = HIVEMIND_BLOCK_END,
 ): string {
   let text = existing;
+  let searchFrom = 0;
   for (;;) {
-    const startIdx = text.indexOf(start);
+    const startIdx = text.indexOf(start, searchFrom);
     if (startIdx === -1) return text;
     const endIdx = text.indexOf(end, startIdx);
-    // A BEGIN with no END after it — stop here, leaving the remainder intact so
-    // a user's half-written marker (and any text under it) is never truncated.
-    // Well-formed blocks earlier in the file have already been removed by now.
+    // A BEGIN with no END anywhere after it — leave the remainder intact so a
+    // user's half-written marker (and the text under it) is never truncated.
     if (endIdx === -1) return text;
+    // A stray/unclosed BEGIN: another BEGIN appears before this one's END, so
+    // this END actually belongs to a *later* block. Pairing them would delete
+    // the user's content in between (data loss). Skip this BEGIN and resume the
+    // scan after it — only well-formed BEGIN..END pairs (no intervening BEGIN)
+    // are removed.
+    const nextStart = text.indexOf(start, startIdx + start.length);
+    if (nextStart !== -1 && nextStart < endIdx) {
+      searchFrom = startIdx + start.length;
+      continue;
+    }
     const before = text.slice(0, startIdx).trimEnd();
     const after = text.slice(endIdx + end.length).replace(/^\n+/, "");
     if (!before && !after) text = "";
     else if (!before) text = after;
     else if (!after) text = `${before}\n`;
     else text = `${before}\n\n${after}`;
+    searchFrom = 0; // text shifted — rescan from the top
   }
 }

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -3,12 +3,32 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { HOME, pkgRoot, ensureDir, copyDir, writeJson, writeJsonIfChanged, symlinkForce, writeVersionStamp, log, warn } from "./util.js";
 import { getVersion } from "./version.js";
+import { upsertMarkedBlock, stripMarkedBlock, HIVEMIND_BLOCK_START, HIVEMIND_BLOCK_END } from "./agents-md.js";
 
 const CODEX_HOME = join(HOME, ".codex");
 const PLUGIN_DIR = join(CODEX_HOME, "hivemind");
 const HOOKS_PATH = join(CODEX_HOME, "hooks.json");
 const AGENTS_SKILLS_DIR = join(HOME, ".agents", "skills");
 const SKILL_LINK = join(AGENTS_SKILLS_DIR, "hivemind-memory");
+// Codex auto-loads ~/.codex/AGENTS.md into the model context every session,
+// SILENTLY (no user-visible TUI cell — verified empirically). This is the
+// proactive-memory channel Codex's user-visible `additionalContext` can't be:
+// the managed block instructs the model to consult team memory + pull rules /
+// goals before starting work, without clobbering the TUI. We own only the
+// marker-fenced block; the user's own AGENTS.md content is preserved.
+const AGENTS_MD = join(CODEX_HOME, "AGENTS.md");
+const CODEX_AGENTS_BLOCK = `${HIVEMIND_BLOCK_START}
+## Hivemind Memory
+
+You have global team memory at \`~/.deeplake/memory/\`, shared across all sessions, users, and agents in your org. Proactively consult it before starting a task — and whenever the user asks you to recall, look up, or remember anything:
+
+- Team rules: \`hivemind rules list\`
+- Your open goals: \`hivemind goal list --mine\`
+- Past sessions: start at \`~/.deeplake/memory/index.md\`, then read \`~/.deeplake/memory/summaries/<user>/<session>.md\`; only fall back to raw \`~/.deeplake/memory/sessions/<user>/*.jsonl\` when a summary lacks the detail.
+- Keyword search: \`grep -ri "keyword" ~/.deeplake/memory/summaries/\` (use \`grep\`, NOT \`rg\`/ripgrep — it may not be installed).
+
+Use only bash builtins (cat, ls, grep, jq, head, tail, sed, awk, wc, sort, find) to read this filesystem — rg/ripgrep, node, python, curl are not available there. Do not spawn subagents to read memory.
+${HIVEMIND_BLOCK_END}`;
 
 function hookCmd(bundleFile: string, timeout: number, matcher?: string): Record<string, unknown> {
   const block: Record<string, unknown> = {
@@ -227,6 +247,31 @@ function stripLegacyCodexHooksKey(): void {
   }
 }
 
+// Idempotent upsert of the hivemind block into ~/.codex/AGENTS.md. Only
+// writes when the content actually changes, preserving the user's own
+// AGENTS.md content outside the markers.
+function writeCodexAgentsBlock(): void {
+  const prior = existsSync(AGENTS_MD) ? readFileSync(AGENTS_MD, "utf-8") : null;
+  const next = upsertMarkedBlock(prior, CODEX_AGENTS_BLOCK);
+  if (next === prior) return;
+  writeFileSync(AGENTS_MD, next);
+  log(`  Codex          AGENTS.md memory block ${prior ? "updated" : "created"} -> ${AGENTS_MD}`);
+}
+
+function removeCodexAgentsBlock(): void {
+  if (!existsSync(AGENTS_MD)) return;
+  const prior = readFileSync(AGENTS_MD, "utf-8");
+  const stripped = stripMarkedBlock(prior);
+  if (stripped === prior) return;
+  if (stripped.trim().length === 0) {
+    rmSync(AGENTS_MD, { force: true });
+    log(`  Codex          removed empty ${AGENTS_MD}`);
+  } else {
+    writeFileSync(AGENTS_MD, stripped);
+    log(`  Codex          stripped hivemind block from ${AGENTS_MD}`);
+  }
+}
+
 export function installCodex(): void {
   const srcBundle = join(pkgRoot(), "harnesses", "codex", "bundle");
   const srcSkills = join(pkgRoot(), "harnesses", "codex", "skills");
@@ -271,6 +316,8 @@ export function installCodex(): void {
     symlinkForce(embedDepsNm, pluginNm);
   }
 
+  writeCodexAgentsBlock();
+
   writeVersionStamp(PLUGIN_DIR, getVersion());
   log(`  Codex          installed -> ${PLUGIN_DIR}`);
 }
@@ -310,5 +357,6 @@ export function uninstallCodex(): void {
     unlinkSync(SKILL_LINK);
     log(`  Codex          removed ${SKILL_LINK}`);
   }
+  removeCodexAgentsBlock();
   log(`  Codex          plugin files kept at ${PLUGIN_DIR}`);
 }

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -247,9 +247,11 @@ function stripLegacyCodexHooksKey(): void {
   }
 }
 
-// Idempotent upsert of the hivemind block into ~/.codex/AGENTS.md. Only
-// writes when the content actually changes, preserving the user's own
-// AGENTS.md content outside the markers.
+/**
+ * Idempotently upsert the hivemind block into ~/.codex/AGENTS.md, the file
+ * Codex auto-loads into model context every session. Writes only when the
+ * content actually changes, preserving any user content outside the markers.
+ */
 function writeCodexAgentsBlock(): void {
   const prior = existsSync(AGENTS_MD) ? readFileSync(AGENTS_MD, "utf-8") : null;
   const next = upsertMarkedBlock(prior, CODEX_AGENTS_BLOCK);
@@ -258,6 +260,10 @@ function writeCodexAgentsBlock(): void {
   log(`  Codex          AGENTS.md memory block ${prior ? "updated" : "created"} -> ${AGENTS_MD}`);
 }
 
+/**
+ * Strip the hivemind block from ~/.codex/AGENTS.md on uninstall, deleting the
+ * file when nothing else remains and otherwise preserving the user's content.
+ */
 function removeCodexAgentsBlock(): void {
   if (!existsSync(AGENTS_MD)) return;
   const prior = readFileSync(AGENTS_MD, "utf-8");

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -252,8 +252,21 @@ function stripLegacyCodexHooksKey(): void {
  * Codex auto-loads into model context every session. Writes only when the
  * content actually changes, preserving any user content outside the markers.
  */
+// Read a file, returning null when it does not exist. Reads directly and
+// catches ENOENT rather than existsSync()-then-read, which is a TOCTOU race
+// (the file can vanish between the check and the read — flagged by CodeQL
+// js/file-system-race).
+function readFileOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
 function writeCodexAgentsBlock(): void {
-  const prior = existsSync(AGENTS_MD) ? readFileSync(AGENTS_MD, "utf-8") : null;
+  const prior = readFileOrNull(AGENTS_MD);
   const next = upsertMarkedBlock(prior, CODEX_AGENTS_BLOCK);
   if (next === prior) return;
   writeFileSync(AGENTS_MD, next);
@@ -265,8 +278,8 @@ function writeCodexAgentsBlock(): void {
  * file when nothing else remains and otherwise preserving the user's content.
  */
 function removeCodexAgentsBlock(): void {
-  if (!existsSync(AGENTS_MD)) return;
-  const prior = readFileSync(AGENTS_MD, "utf-8");
+  const prior = readFileOrNull(AGENTS_MD);
+  if (prior === null) return;
   const stripped = stripMarkedBlock(prior);
   if (stripped === prior) return;
   if (stripped.trim().length === 0) {

--- a/src/cli/install-pi.ts
+++ b/src/cli/install-pi.ts
@@ -2,6 +2,12 @@ import { existsSync, writeFileSync, rmSync, readFileSync, copyFileSync } from "n
 import { join } from "node:path";
 import { HOME, pkgRoot, ensureDir, writeVersionStamp, log } from "./util.js";
 import { getVersion } from "./version.js";
+import {
+  upsertMarkedBlock,
+  stripMarkedBlock,
+  HIVEMIND_BLOCK_START,
+  HIVEMIND_BLOCK_END,
+} from "./agents-md.js";
 
 // pi (badlogic/pi-mono `packages/coding-agent`) integration — Tier 1.
 //
@@ -53,9 +59,6 @@ const AUTOPULL_WORKER_PATH = join(WIKI_WORKER_DIR, "autopull-worker.js");
 // can't import the raw-.ts trigger so it shells this bundle. Sibling of the others.
 const SKILLOPT_WORKER_PATH = join(WIKI_WORKER_DIR, "skillopt-worker.js");
 
-const HIVEMIND_BLOCK_START = "<!-- BEGIN hivemind-memory -->";
-const HIVEMIND_BLOCK_END = "<!-- END hivemind-memory -->";
-
 const HIVEMIND_BLOCK_BODY = `${HIVEMIND_BLOCK_START}
 ## Hivemind Memory
 
@@ -75,33 +78,11 @@ rg/ripgrep, node, python, curl are not available there.
 ${HIVEMIND_BLOCK_END}`;
 
 export function upsertHivemindBlock(existing: string | null): string {
-  const block = HIVEMIND_BLOCK_BODY;
-  if (!existing) return `${block}\n`;
-  // Strip any pre-existing hivemind block, then re-append.
-  const startIdx = existing.indexOf(HIVEMIND_BLOCK_START);
-  if (startIdx === -1) return `${existing.trimEnd()}\n\n${block}\n`;
-  const endIdx = existing.indexOf(HIVEMIND_BLOCK_END, startIdx);
-  if (endIdx === -1) {
-    // Malformed prior block — append fresh and let the user clean up.
-    return `${existing.trimEnd()}\n\n${block}\n`;
-  }
-  const before = existing.slice(0, startIdx).trimEnd();
-  const after = existing.slice(endIdx + HIVEMIND_BLOCK_END.length).replace(/^\n+/, "");
-  const rest = after ? `\n\n${after}` : "";
-  return `${before ? before + "\n\n" : ""}${block}\n${rest}`;
+  return upsertMarkedBlock(existing, HIVEMIND_BLOCK_BODY);
 }
 
 export function stripHivemindBlock(existing: string): string {
-  const startIdx = existing.indexOf(HIVEMIND_BLOCK_START);
-  if (startIdx === -1) return existing;
-  const endIdx = existing.indexOf(HIVEMIND_BLOCK_END, startIdx);
-  if (endIdx === -1) return existing;
-  const before = existing.slice(0, startIdx).trimEnd();
-  const after = existing.slice(endIdx + HIVEMIND_BLOCK_END.length).replace(/^\n+/, "");
-  if (!before && !after) return "";
-  if (!before) return after;
-  if (!after) return `${before}\n`;
-  return `${before}\n\n${after}`;
+  return stripMarkedBlock(existing);
 }
 
 export function installPi(): void {

--- a/src/hooks/codex/session-start.ts
+++ b/src/hooks/codex/session-start.ts
@@ -113,16 +113,15 @@ async function main(): Promise<void> {
   // memory tiers via `hivemind --help` and `ls ~/.deeplake/memory/` on demand.
   // We therefore emit only login-state + version here, and trust the model
   // to bootstrap the rest.
-  // Codex DOES NOT receive the HIVEMIND RULES + GOALS inject block.
-  // additionalContext is user-visible in Codex (rendered as
-  // `hook context: <text>` in the TUI history cell), so a multi-line
-  // rules+goals block on every SessionStart would clobber the user's
-  // view. Codex agents discover rules/goals via `hivemind rules list`
-  // / `hivemind goal list --mine` on demand — same pattern as the
-  // DEEPLAKE MEMORY block already deliberately excluded from Codex
-  // above. Tracked as an Open Question: "how to surface rules+goals
-  // to Codex without clobbering the TUI" (model-only injection
-  // channel, or a compact opt-in banner).
+  // The proactive memory instruction (check team memory + pull rules/goals)
+  // is NOT injected here. Codex has no model-only channel — every
+  // additionalContext byte is also rendered to the user as a `hook context:`
+  // cell, so a per-session block would be visible noise. Instead that guidance
+  // lives in the managed hivemind block of `~/.codex/AGENTS.md` (written by
+  // install-codex.ts), which Codex auto-loads into the model context every
+  // session SILENTLY — no TUI cell. Empirically verified: a sentinel placed in
+  // ~/.codex/AGENTS.md reaches the model without surfacing in the transcript.
+  // So additionalContext stays minimal: login-state + version only.
 
   // Async auto-pull of the latest cloud snapshot for HEAD. Detached and
   // truly fire-and-forget — see src/graph/spawn-pull-worker.ts and

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -386,7 +386,64 @@ describe("installCodex — happy path", () => {
   });
 });
 
+const BEGIN = "<!-- BEGIN hivemind-memory -->";
+const END = "<!-- END hivemind-memory -->";
+
+describe("installCodex — AGENTS.md memory block", () => {
+  const agentsPath = (): string => join(tmpHome, ".codex", "AGENTS.md");
+
+  it("creates ~/.codex/AGENTS.md with exactly one hivemind block carrying the proactive instruction", async () => {
+    const { installCodex } = await importInstaller();
+    installCodex();
+    const md = readFileSync(agentsPath(), "utf-8");
+    expect((md.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
+    expect(md).toContain(END);
+    // The whole point: proactive memory + rules/goals guidance is injected
+    // here (silent model context), not in the user-visible session-start hook.
+    expect(md).toContain("Proactively consult");
+    expect(md).toContain("hivemind rules list");
+    expect(md).toContain("hivemind goal list --mine");
+  });
+
+  it("preserves a user's pre-existing AGENTS.md content; appends the block once", async () => {
+    writeFileSync(agentsPath(), "# My Codex notes\nUser content here.\n");
+    const { installCodex } = await importInstaller();
+    installCodex();
+    const md = readFileSync(agentsPath(), "utf-8");
+    expect(md).toContain("# My Codex notes");
+    expect(md).toContain("User content here.");
+    expect((md.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
+  });
+
+  it("is idempotent: re-running installCodex 5x leaves exactly one block", async () => {
+    const { installCodex } = await importInstaller();
+    for (let i = 0; i < 5; i++) installCodex();
+    const md = readFileSync(agentsPath(), "utf-8");
+    expect((md.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
+    expect((md.match(new RegExp(END, "g")) ?? []).length).toBe(1);
+  });
+});
+
 describe("uninstallCodex", () => {
+  it("strips the hivemind block from AGENTS.md while preserving user content", async () => {
+    const agentsPath = join(tmpHome, ".codex", "AGENTS.md");
+    writeFileSync(agentsPath, `# Header\nuser line\n\n${BEGIN}\nstale\n${END}\n\n## After\nmore user\n`);
+    const { uninstallCodex } = await importInstaller();
+    uninstallCodex();
+    const md = readFileSync(agentsPath, "utf-8");
+    expect(md).not.toContain(BEGIN);
+    expect(md).toContain("# Header");
+    expect(md).toContain("more user");
+  });
+
+  it("removes AGENTS.md entirely when only our block existed", async () => {
+    const { installCodex, uninstallCodex } = await importInstaller();
+    installCodex();
+    expect(existsSync(join(tmpHome, ".codex", "AGENTS.md"))).toBe(true);
+    uninstallCodex();
+    expect(existsSync(join(tmpHome, ".codex", "AGENTS.md"))).toBe(false);
+  });
+
   it("removes hooks.json and the agentskills symlink, but keeps the plugin payload", async () => {
     const { installCodex, uninstallCodex } = await importInstaller();
     installCodex();

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
@@ -31,7 +31,9 @@ vi.mock("node:child_process", () => ({
 }));
 
 beforeEach(() => {
-  tmpRoot = join(tmpdir(), `hm-codex-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  // mkdtempSync creates a securely-unique temp dir (vs join(tmpdir(), predictable)),
+  // satisfying CodeQL js/insecure-temporary-file for the writes underneath it.
+  tmpRoot = mkdtempSync(join(tmpdir(), "hm-codex-"));
   tmpHome = join(tmpRoot, "home");
   tmpPkg = join(tmpRoot, "pkg");
 

--- a/tests/cli/cli-install-codex-fs.test.ts
+++ b/tests/cli/cli-install-codex-fs.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, u
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
+import { HIVEMIND_BLOCK_START, HIVEMIND_BLOCK_END } from "../../src/cli/agents-md.js";
 
 /**
  * Tests for the disk-side of src/cli/install-codex.ts.
@@ -386,8 +387,9 @@ describe("installCodex — happy path", () => {
   });
 });
 
-const BEGIN = "<!-- BEGIN hivemind-memory -->";
-const END = "<!-- END hivemind-memory -->";
+// Reuse the source-of-truth markers so the test tracks any format change.
+const BEGIN = HIVEMIND_BLOCK_START;
+const END = HIVEMIND_BLOCK_END;
 
 describe("installCodex — AGENTS.md memory block", () => {
   const agentsPath = (): string => join(tmpHome, ".codex", "AGENTS.md");

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -330,6 +330,17 @@ describe("upsertHivemindBlock", () => {
     expect(stripHivemindBlock(out)).toBe("# Header\n\n## Mid\n\n## Tail\n");
   });
 
+  it("on reinstall, does NOT delete user text under a preexisting stray BEGIN (data-loss guard)", () => {
+    // A file that already has a stray BEGIN followed by our block (e.g. a prior
+    // install over a half-written marker). Reinstall must replace OUR block in
+    // place without swallowing the user's text under the stray marker.
+    const prior = `# Notes\n${BEGIN}\nuser text under stray marker\n\n${BEGIN}\nold block\n${END}\n`;
+    const out = upsertHivemindBlock(prior);
+    expect(out).toContain("user text under stray marker"); // preserved
+    expect(out).not.toContain("old block"); // our block replaced
+    expect((out.match(new RegExp(END, "g")) ?? []).length).toBe(1); // one well-formed block
+  });
+
   it("keeps the block IN PLACE on reinstall — does not relocate it below later user notes", () => {
     const prior = `# Top\n\n${BEGIN}\nold\n${END}\n\n## My overrides\nkeep last`;
     const out = upsertHivemindBlock(prior);

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -317,6 +317,19 @@ describe("upsertHivemindBlock", () => {
     // And there's a complete marker pair somewhere.
     expect(out).toContain(END);
   });
+
+  it("collapses DUPLICATE blocks (bad merge / manual paste) down to exactly one", () => {
+    const prior = `# Header\n\n${BEGIN}\nfirst\n${END}\n\n## Mid\n\n${BEGIN}\nsecond\n${END}\n\n## Tail`;
+    const out = upsertHivemindBlock(prior);
+    expect((out.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
+    expect((out.match(new RegExp(END, "g")) ?? []).length).toBe(1);
+    // Both stale bodies gone; surrounding user content preserved.
+    expect(out).not.toContain("first");
+    expect(out).not.toContain("second");
+    expect(out).toContain("# Header");
+    expect(out).toContain("## Mid");
+    expect(out).toContain("## Tail");
+  });
 });
 
 describe("stripHivemindBlock", () => {
@@ -352,6 +365,18 @@ describe("stripHivemindBlock", () => {
   it("malformed (BEGIN without END) → input returned unchanged (don't truncate user data)", () => {
     const prior = `# Header\n${BEGIN}\nbroken — no end marker\nuser stuff after\n`;
     expect(stripHivemindBlock(prior)).toBe(prior);
+  });
+
+  it("removes EVERY block when the file has duplicate marker pairs", () => {
+    const prior = `# Before\n\n${BEGIN}\none\n${END}\n\n## Mid\n\n${BEGIN}\ntwo\n${END}\n\n## After\n`;
+    const out = stripHivemindBlock(prior);
+    expect(out).not.toContain(BEGIN);
+    expect(out).not.toContain(END);
+    expect(out).not.toContain("one");
+    expect(out).not.toContain("two");
+    expect(out).toContain("# Before");
+    expect(out).toContain("## Mid");
+    expect(out).toContain("## After");
   });
 });
 

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -329,6 +329,16 @@ describe("upsertHivemindBlock", () => {
     expect(out).not.toContain("second");
     expect(stripHivemindBlock(out)).toBe("# Header\n\n## Mid\n\n## Tail\n");
   });
+
+  it("keeps the block IN PLACE on reinstall — does not relocate it below later user notes", () => {
+    const prior = `# Top\n\n${BEGIN}\nold\n${END}\n\n## My overrides\nkeep last`;
+    const out = upsertHivemindBlock(prior);
+    // Block stays between "# Top" and the user's overrides (precedence kept),
+    // not appended at EOF.
+    expect(out.indexOf(BEGIN)).toBeLessThan(out.indexOf("## My overrides"));
+    expect(out.endsWith("## My overrides\nkeep last\n")).toBe(true);
+    expect((out.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
+  });
 });
 
 describe("stripHivemindBlock", () => {

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -323,12 +323,11 @@ describe("upsertHivemindBlock", () => {
     const out = upsertHivemindBlock(prior);
     expect((out.match(new RegExp(BEGIN, "g")) ?? []).length).toBe(1);
     expect((out.match(new RegExp(END, "g")) ?? []).length).toBe(1);
-    // Both stale bodies gone; surrounding user content preserved.
+    // Both stale bodies gone; the surviving scaffold is exactly the user's
+    // content with a single block (asserted via strip → exact remainder).
     expect(out).not.toContain("first");
     expect(out).not.toContain("second");
-    expect(out).toContain("# Header");
-    expect(out).toContain("## Mid");
-    expect(out).toContain("## Tail");
+    expect(stripHivemindBlock(out)).toBe("# Header\n\n## Mid\n\n## Tail\n");
   });
 });
 
@@ -370,13 +369,8 @@ describe("stripHivemindBlock", () => {
   it("removes EVERY block when the file has duplicate marker pairs", () => {
     const prior = `# Before\n\n${BEGIN}\none\n${END}\n\n## Mid\n\n${BEGIN}\ntwo\n${END}\n\n## After\n`;
     const out = stripHivemindBlock(prior);
-    expect(out).not.toContain(BEGIN);
-    expect(out).not.toContain(END);
-    expect(out).not.toContain("one");
-    expect(out).not.toContain("two");
-    expect(out).toContain("# Before");
-    expect(out).toContain("## Mid");
-    expect(out).toContain("## After");
+    // Exact remainder: both blocks removed, user scaffold intact.
+    expect(out).toBe("# Before\n\n## Mid\n\n## After\n");
   });
 });
 

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -376,18 +376,19 @@ describe("stripHivemindBlock", () => {
     expect(stripHivemindBlock(prior)).toBe(prior);
   });
 
-  it("install→uninstall round-trip removes our block even when a stray malformed BEGIN preexists", () => {
-    // Codex edge case: the user's AGENTS.md already has a half-written BEGIN
-    // (no END). Install appends a well-formed block; uninstall must still
-    // remove it (not orphaned). Because our appended block supplies an END,
-    // strip pairs the first BEGIN with it and removes through — never bailing
-    // while a well-formed marker pair survives.
+  it("install→uninstall round-trip removes our block AND preserves user content past a stray BEGIN", () => {
+    // Codex data-loss edge case: the user's AGENTS.md already has a half-written
+    // BEGIN (no END). Install appends a well-formed block; uninstall must remove
+    // OUR block without deleting the user's lines between their stray marker and
+    // our block. Strip must NOT pair the stray BEGIN with our block's END.
     const userFile = `# Notes\n${BEGIN}\nuser half-wrote this, no end\n`;
     const installed = upsertHivemindBlock(userFile);
     expect(installed).toContain(END); // a well-formed block was added
     const uninstalled = stripHivemindBlock(installed);
-    expect(uninstalled).not.toContain(END); // our block is gone, not orphaned
+    expect(uninstalled).not.toContain(END); // our block is gone
     expect(uninstalled).not.toContain("Hivemind Memory");
+    // User content is NOT truncated — this is the data-loss guard.
+    expect(uninstalled).toContain("user half-wrote this, no end");
   });
 
   it("removes EVERY block when the file has duplicate marker pairs", () => {

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -396,10 +396,9 @@ describe("stripHivemindBlock", () => {
     const installed = upsertHivemindBlock(userFile);
     expect(installed).toContain(END); // a well-formed block was added
     const uninstalled = stripHivemindBlock(installed);
-    expect(uninstalled).not.toContain(END); // our block is gone
-    expect(uninstalled).not.toContain("Hivemind Memory");
-    // User content is NOT truncated — this is the data-loss guard.
-    expect(uninstalled).toContain("user half-wrote this, no end");
+    // Uninstall round-trips EXACTLY back to the user's original file: our block
+    // removed, their stray marker and text fully preserved (no data loss).
+    expect(uninstalled).toBe(userFile);
   });
 
   it("removes EVERY block when the file has duplicate marker pairs", () => {

--- a/tests/cli/install-helpers.test.ts
+++ b/tests/cli/install-helpers.test.ts
@@ -376,6 +376,20 @@ describe("stripHivemindBlock", () => {
     expect(stripHivemindBlock(prior)).toBe(prior);
   });
 
+  it("install→uninstall round-trip removes our block even when a stray malformed BEGIN preexists", () => {
+    // Codex edge case: the user's AGENTS.md already has a half-written BEGIN
+    // (no END). Install appends a well-formed block; uninstall must still
+    // remove it (not orphaned). Because our appended block supplies an END,
+    // strip pairs the first BEGIN with it and removes through — never bailing
+    // while a well-formed marker pair survives.
+    const userFile = `# Notes\n${BEGIN}\nuser half-wrote this, no end\n`;
+    const installed = upsertHivemindBlock(userFile);
+    expect(installed).toContain(END); // a well-formed block was added
+    const uninstalled = stripHivemindBlock(installed);
+    expect(uninstalled).not.toContain(END); // our block is gone, not orphaned
+    expect(uninstalled).not.toContain("Hivemind Memory");
+  });
+
   it("removes EVERY block when the file has duplicate marker pairs", () => {
     const prior = `# Before\n\n${BEGIN}\none\n${END}\n\n## Mid\n\n${BEGIN}\ntwo\n${END}\n\n## After\n`;
     const out = stripHivemindBlock(prior);

--- a/tests/codex/codex-session-start-hook.test.ts
+++ b/tests/codex/codex-session-start-hook.test.ts
@@ -122,6 +122,18 @@ describe("codex session-start hook — guards", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toContain("workspace: default");
   });
 
+  it("keeps additionalContext minimal — no rules/goals block (that lives in AGENTS.md)", async () => {
+    const out = await runHook();
+    const parsed = JSON.parse(out!.trim());
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    // Codex has no model-only channel: additionalContext is user-visible, so
+    // the proactive memory instruction lives in the silent ~/.codex/AGENTS.md
+    // block (install-codex.ts), not here. Guard against regressing to an
+    // in-context block that would clobber the TUI.
+    expect(ctx).not.toContain("hivemind rules list");
+    expect(ctx).not.toContain("Team memory is active");
+  });
+
   it("falls back to orgId when orgName is missing", async () => {
     loadCredsMock.mockReturnValue({
       token: "tok", orgId: "org-uuid-123", userName: "alice", workspaceId: "staging",

--- a/tests/codex/codex-session-start-hook.test.ts
+++ b/tests/codex/codex-session-start-hook.test.ts
@@ -122,16 +122,18 @@ describe("codex session-start hook — guards", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toContain("workspace: default");
   });
 
-  it("keeps additionalContext minimal — no rules/goals block (that lives in AGENTS.md)", async () => {
+  it("keeps additionalContext minimal — login line only, no rules/goals block (that lives in AGENTS.md)", async () => {
     const out = await runHook();
     const parsed = JSON.parse(out!.trim());
     const ctx = parsed.hookSpecificOutput.additionalContext;
     // Codex has no model-only channel: additionalContext is user-visible, so
     // the proactive memory instruction lives in the silent ~/.codex/AGENTS.md
-    // block (install-codex.ts), not here. Guard against regressing to an
-    // in-context block that would clobber the TUI.
-    expect(ctx).not.toContain("hivemind rules list");
-    expect(ctx).not.toContain("Team memory is active");
+    // block (install-codex.ts), not here. Assert the EXACT logged-in context
+    // (login line + optional version notice) so any leaked block — or extra
+    // line that would clobber the TUI — fails the test.
+    expect(ctx).toMatch(
+      /^Hivemind: logged in as org acme \(workspace: default\)\.(\nHivemind v.+)?$/,
+    );
   });
 
   it("falls back to orgId when orgName is missing", async () => {


### PR DESCRIPTION
## What

Gives the **Codex** harness proactive memory use — consult team memory + pull rules/goals before starting — the way claude-code and cursor already have it, but through the channel that actually fits Codex.

## Why AGENTS.md (not an in-context banner)

Codex has **no model-only context channel**: anything the SessionStart hook puts in `additionalContext` is *also* rendered to the user as a `hook context:` cell. So pushing a rules/goals block in-context would be visible noise on every session (the reason it was never added).

`~/.codex/AGENTS.md` solves this: Codex auto-loads it into the model context every session **silently** — no TUI cell. Empirically verified with a sentinel:

```
$ printf '...If asked for the codeword, reply exactly: KIWI_GLOBAL_AGENTS_2026' > ~/.codex/AGENTS.md
$ codex exec --sandbox read-only "What is the codeword?"
codex
KIWI_GLOBAL_AGENTS_2026          # reached the model, never shown as a hook cell
```

## How

- **`src/cli/agents-md.ts`** (new): shared `upsertMarkedBlock` / `stripMarkedBlock` for the marker-fenced hivemind block. `install-pi.ts` refactored to delegate (removes its duplicated copy — net deletion).
- **`install-codex.ts`**: idempotent upsert of the hivemind block into `~/.codex/AGENTS.md` on install, strip on uninstall. The user's own AGENTS.md content outside the `<!-- BEGIN/END hivemind-memory -->` markers is always preserved.
- The block instructs the model to consult `~/.deeplake/memory/` and run `hivemind rules list` / `hivemind goal list --mine` before starting work.
- **`session-start.ts`**: `additionalContext` stays minimal (login + version). No user-visible banner.

## Tests

- Codex AGENTS.md: cold-create (one marker pair, carries the instruction), preserves pre-existing user content, idempotent across 5 installs, uninstall strips block while keeping user content, removes the file when only our block existed.
- session-start guard: asserts no rules/goals block leaks into the user-visible `additionalContext`.
- pi + shared-helper suites stay green after the refactor.
- `tsc --noEmit` clean. (Pre-existing local failures in cli-index/install-consent are an unrelated missing optional dep, `tree-sitter-python` — red on main too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex installation now manages a single, idempotent “memory” marker block in `~/.codex/AGENTS.md` (inserted only once) and removes it on uninstall while preserving any existing user content.
  * The Codex session hook continues to emit minimal additional context, preventing the proactive memory/rules-goals banner from appearing.
* **Tests**
  * Added/expanded guard and filesystem tests to verify minimal-context behavior, idempotent insert/remove, duplicate-marker collapse/removal, and `AGENTS.md` cleanup when empty.
  * Improved temp directory fixtures for more secure, reliable filesystem tests.
  * Added unit coverage for marker upsert/strip behavior, including unpaired markers.
* **Maintenance**
  * Consolidated marker-block handling so both Codex and Pi flows use consistent single-block behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->