### PR TITLE
fix(auth): atomic credentials write to stop spurious "not logged in"

### DIFF
--- a/src/commands/auth-creds.ts
+++ b/src/commands/auth-creds.ts
@@ -44,26 +44,33 @@ export interface Credentials {
 // safety. Letting the fs call's own error fall into a try/catch is more
 // correct AND simplifies coverage to a single fall-through path.
 
-export function loadCredentials(): Credentials | null {
-  // Read up to twice. A genuinely-absent file (ENOENT) is final → null with no
-  // retry. But a JSON.parse failure can be a TRANSIENT torn read: another
-  // process rewriting credentials.json at the same instant. saveCredentials()
-  // now writes atomically (temp + rename), so this version can't tear its own
-  // writes — but an older plugin build sharing this machine still might, and a
-  // crashed writer can leave a half-file. One immediate re-read recovers from
-  // that window instead of falsely reporting "not logged in" for the session.
-  for (let attempt = 0; attempt < 2; attempt++) {
+// `readFile` is injectable purely for tests — it lets the retry path below be
+// exercised deterministically (first call throws, second succeeds) without
+// mocking node:fs at the module level, which this file avoids (see the header
+// note on the coverage-flake that mock+reimport caused). Production callers use
+// the default and never pass an argument.
+export function loadCredentials(
+  readFile: (p: string) => string = (p) => readFileSync(p, "utf-8"),
+): Credentials | null {
+  try {
+    return JSON.parse(readFile(credsPath()));
+  } catch (err) {
+    // A genuinely-absent file (ENOENT) is final → null, no retry.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    // Otherwise the failure may be a TRANSIENT torn read: another process
+    // rewriting credentials.json at this instant. saveCredentials() now writes
+    // atomically (temp + rename) so this version can't tear its own writes, but
+    // an older plugin build on the same machine still might, and a crashed
+    // writer can leave a half-file. Re-read once before declaring "not logged
+    // in" for the whole session.
     try {
-      return JSON.parse(readFileSync(credsPath(), "utf-8"));
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
-      if (attempt === 0) continue;
-      // Persistent permission error or malformed JSON — treat as "no usable
+      return JSON.parse(readFile(credsPath()));
+    } catch {
+      // Persistent permission error or malformed JSON → "no usable
       // credentials." Caller treats null as "not logged in."
       return null;
     }
   }
-  return null;
 }
 
 export function saveCredentials(creds: Credentials): void {

--- a/src/commands/auth-creds.ts
+++ b/src/commands/auth-creds.ts
@@ -7,7 +7,7 @@
  * No imports from any module that touches `fetch` belong here.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -45,13 +45,25 @@ export interface Credentials {
 // correct AND simplifies coverage to a single fall-through path.
 
 export function loadCredentials(): Credentials | null {
-  try {
-    return JSON.parse(readFileSync(credsPath(), "utf-8"));
-  } catch {
-    // Missing file (ENOENT), permission error, or malformed JSON — all map
-    // to "no usable credentials." Caller treats null as "not logged in."
-    return null;
+  // Read up to twice. A genuinely-absent file (ENOENT) is final → null with no
+  // retry. But a JSON.parse failure can be a TRANSIENT torn read: another
+  // process rewriting credentials.json at the same instant. saveCredentials()
+  // now writes atomically (temp + rename), so this version can't tear its own
+  // writes — but an older plugin build sharing this machine still might, and a
+  // crashed writer can leave a half-file. One immediate re-read recovers from
+  // that window instead of falsely reporting "not logged in" for the session.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return JSON.parse(readFileSync(credsPath(), "utf-8"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+      if (attempt === 0) continue;
+      // Persistent permission error or malformed JSON — treat as "no usable
+      // credentials." Caller treats null as "not logged in."
+      return null;
+    }
   }
+  return null;
 }
 
 export function saveCredentials(creds: Credentials): void {
@@ -60,7 +72,29 @@ export function saveCredentials(creds: Credentials): void {
   // node:fs docs). Calling it unconditionally removes the existsSync
   // guard without behaviour change.
   mkdirSync(configDir(), { recursive: true, mode: 0o700 });
-  writeFileSync(credsPath(), JSON.stringify({ ...creds, savedAt: new Date().toISOString() }, null, 2), { mode: 0o600 });
+
+  // Atomic write: serialize into a unique temp file in the same directory,
+  // then rename() it over the target. rename(2) is atomic on a POSIX
+  // filesystem, so a concurrent loadCredentials() reader always observes
+  // either the complete previous file or the complete new one — never a
+  // half-written one. A plain writeFileSync truncates-then-writes, so a
+  // reader landing mid-write (common for a power user running many parallel
+  // agent sessions, each of which rewrites creds at SessionStart via
+  // healDriftedOrgToken) gets partial bytes → JSON.parse throws → a spurious
+  // "not logged in / Hivemind unavailable" banner. The temp name is unique
+  // per (process, call) so two concurrent writers never clobber each other's
+  // staging file. Same directory guarantees the rename stays on one fs.
+  const target = credsPath();
+  const tmp = `${target}.${process.pid}.${process.hrtime.bigint()}.tmp`;
+  const body = JSON.stringify({ ...creds, savedAt: new Date().toISOString() }, null, 2);
+  try {
+    writeFileSync(tmp, body, { mode: 0o600 });
+    renameSync(tmp, target);
+  } catch (err) {
+    // Best-effort cleanup so a failed write doesn't leak a staging file.
+    try { unlinkSync(tmp); } catch { /* nothing to clean up */ }
+    throw err;
+  }
 }
 
 export function deleteCredentials(): boolean {

--- a/tests/claude-code/auth-creds.test.ts
+++ b/tests/claude-code/auth-creds.test.ts
@@ -95,6 +95,26 @@ describe("loadCredentials", () => {
     writeFileSync(`${credsPath()}.999999.deadbeef.tmp`, "{ partial");
     expect(loadCredentials()).toMatchObject({ token: "tok", orgId: "org" });
   });
+
+  it("recovers a transient torn read by re-reading once (retry path)", () => {
+    saveCredentials({ token: "tok", orgId: "org", savedAt: "" });
+    let calls = 0;
+    // First read sees a half-written file (mid-rewrite by another process);
+    // the immediate re-read sees the complete file. Inject the reader so the
+    // race is deterministic without mocking node:fs.
+    const flaky = (p: string) => {
+      calls += 1;
+      if (calls === 1) return "{ truncated";          // torn read → JSON.parse throws
+      return readFileSync(p, "utf-8");                  // settled file
+    };
+    expect(loadCredentials(flaky)).toMatchObject({ token: "tok", orgId: "org" });
+    expect(calls).toBe(2);
+  });
+
+  it("returns null when both reads fail (persistent malformed)", () => {
+    const alwaysBad = () => "{ still broken";
+    expect(loadCredentials(alwaysBad)).toBeNull();
+  });
 });
 
 describe("saveCredentials", () => {
@@ -141,6 +161,16 @@ describe("saveCredentials", () => {
     expect(leftovers).toEqual([]);
     // and the committed file is complete, valid JSON
     expect(() => JSON.parse(readFileSync(credsPath(), "utf-8"))).not.toThrow();
+  });
+
+  it.skipIf(process.platform === "win32")("cleans up the temp file and rethrows when the commit fails", () => {
+    // Force renameSync to fail by making credentials.json an existing
+    // directory (rename of a file onto a dir → EISDIR). The staging temp must
+    // be unlinked and the error rethrown — no partial state, no leaked tmp.
+    mkdirSync(credsPath(), { recursive: true, mode: 0o700 });
+    expect(() => saveCredentials(baseCreds)).toThrow();
+    const leftovers = readdirSync(configDir()).filter(f => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 
   it("repeated rewrites never leave a partial/unreadable credentials.json", () => {

--- a/tests/claude-code/auth-creds.test.ts
+++ b/tests/claude-code/auth-creds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, mkdirSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -82,7 +82,18 @@ describe("loadCredentials", () => {
     mkdirSync(configDir(), { recursive: true, mode: 0o700 });
     writeFileSync(credsPath(), "not json {");
     expect(() => loadCredentials()).not.toThrow();
+    // Persistently-malformed file: the read is retried once, then gives up and
+    // returns null (exercises the attempt===0 → continue → attempt===1 path).
     expect(loadCredentials()).toBeNull();
+  });
+
+  it("ignores a stray *.tmp staging file left by a crashed writer", () => {
+    saveCredentials({ token: "tok", orgId: "org", savedAt: "" });
+    // Simulate a previous writer that died after writing the temp but before
+    // rename — a half-written staging file in the same dir must not affect the
+    // real credentials.json read.
+    writeFileSync(`${credsPath()}.999999.deadbeef.tmp`, "{ partial");
+    expect(loadCredentials()).toMatchObject({ token: "tok", orgId: "org" });
   });
 });
 
@@ -122,6 +133,27 @@ describe("saveCredentials", () => {
     writeFileSync(join(configDir(), "sentinel"), "x");
     saveCredentials(baseCreds);
     expect(existsSync(join(configDir(), "sentinel"))).toBe(true);
+  });
+
+  it("writes atomically: leaves no *.tmp staging file behind", () => {
+    saveCredentials(baseCreds);
+    const leftovers = readdirSync(configDir()).filter(f => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+    // and the committed file is complete, valid JSON
+    expect(() => JSON.parse(readFileSync(credsPath(), "utf-8"))).not.toThrow();
+  });
+
+  it("repeated rewrites never leave a partial/unreadable credentials.json", () => {
+    // Each SessionStart can rewrite creds; a heavy concurrent user triggers
+    // many of these. Every committed state must be a complete, loadable file —
+    // and no staging files may accumulate.
+    for (let i = 0; i < 100; i++) {
+      saveCredentials({ token: `tok-${i}`, orgId: "org", savedAt: "" });
+      const got = loadCredentials();
+      expect(got).not.toBeNull();
+      expect(got?.token).toBe(`tok-${i}`);
+    }
+    expect(readdirSync(configDir()).filter(f => f.endsWith(".tmp"))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem

Users intermittently see **"Hivemind: not logged in"** / *"memory search is unavailable this session"* even though their org is healthy and capture is working. Surfaced by a real prod user (Codex, plugin `0.7.105`, ~7k sessions in 5 days): org valid, balance fine, memory writes landing today, 0–1 ms connects — yet the banner appears.

## Root cause — a torn-write race on `credentials.json`

- `loadCredentials()` does `JSON.parse(readFileSync(credentials.json))` and returns `null` on **any** failure (incl. malformed JSON). That `null` is the *only* trigger for the banner — it's purely client-side.
- `saveCredentials()` wrote the file with a plain **non-atomic** `writeFileSync` (truncate-then-write).
- SessionStart rewrites `credentials.json` on nearly every start (`healDriftedOrgToken`, `userName` backfill).

So with **many concurrent agent sessions**, one session's write truncates the file while another session's read lands mid-write → `JSON.parse` throws → `null` → spurious "not logged in". It's intermittent (file is valid ~all the time, hence captures still work) and scales with parallelism — Codex power users hit it hardest because `additionalContext` is user-visible in the Codex TUI. Same shared creds path for Claude/Codex/Cursor/Hermes.

## Fix

- **`saveCredentials`** → write to a unique per-`(pid, call)` temp file in the same dir, then `rename()` over the target. `rename(2)` is atomic on POSIX, so a concurrent reader sees only a complete old/new file. Temp is cleaned up on failure.
- **`loadCredentials`** → re-read once on a non-`ENOENT` failure before returning `null`, so a transient torn read (an older plugin build on the same machine, or a crashed writer's half-file) doesn't downgrade the session. `ENOENT` still returns `null` immediately.

## Tests

`tests/claude-code/auth-creds.test.ts` (12 pass): atomic write leaves no `.tmp` behind; 100 rapid rewrites always stay loadable; a stray `*.tmp` staging file is ignored; persistently-malformed file still returns `null` via the retry path. Codex + claude session-start hook suites (33) still green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Strengthened credential loading to safely handle partially-written or malformed `credentials.json`, including a single recovery re-read for transient read issues.
* Improved credential saving to use atomic temp-file writes and replacement, reducing the chance of corruption during concurrent access.
* Added robust cleanup on write/rename failures, ensuring temporary staging files are removed when errors occur.

## Tests
* Expanded credential file IO coverage for retry behavior, temp-file cleanup, commit-failure scenarios, and repeated save/load stress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->