### PR TITLE
fix(codex): rewrite memory write via PreToolUse allow to stop double exec

### DIFF
--- a/src/hooks/codex/pre-tool-use.ts
+++ b/src/hooks/codex/pre-tool-use.ts
@@ -3,11 +3,19 @@
 /**
  * Codex PreToolUse hook — intercepts Bash commands targeting ~/.deeplake/memory/.
  *
- * Strategy: "block + inject"
- * Codex does not parse JSON hook output here, so the CLI wrapper still maps:
- * - action=pass  -> exit 0, no output
- * - action=guide -> stdout guidance, exit 0
- * - action=block -> stderr content, exit 2
+ * Decision -> wire mapping. Codex >= 0.136 parses PreToolUse JSON on stdout
+ * (verified against codex-rs/hooks/src/events/pre_tool_use.rs, tag rust-v0.136.0):
+ * - action=pass  -> exit 0, no output                (Codex runs the original command)
+ * - action=block -> stderr content, exit 2           (Codex blocks; reason -> model)
+ * - action=allow -> exit 0, stdout JSON carrying
+ *     hookSpecificOutput.permissionDecision="allow" + updatedInput.command
+ *                                                    (Codex runs the REPLACEMENT command)
+ *
+ * `allow` exists for memory writes: the hook performs the VFS/SQL write itself,
+ * then rewrites the host command to a harmless echo so Codex does NOT re-run the
+ * original redirect. A plain exit-0 with no JSON makes Codex run the original
+ * `echo ... > ~/.deeplake/memory/...` against the on-disk mount — the double
+ * execution that errors "No such file or directory" when the subdir is absent (F3).
  *
  * The source logic is exported so tests can exercise it directly without
  * spawning the bundled script in a subprocess.
@@ -56,9 +64,17 @@ export interface CodexPreToolUseInput {
 }
 
 export interface CodexPreToolDecision {
-  action: "pass" | "guide" | "block";
+  action: "pass" | "block" | "allow";
   output?: string;
   rewrittenCommand?: string;
+  /**
+   * Host command Codex should run INSTEAD of the original, delivered via the
+   * PreToolUse `updatedInput.command` rewrite. Set only for action="allow"
+   * (memory writes the hook has already persisted to the VFS). Running a
+   * harmless echo here stops the original redirect from double-executing
+   * against the on-disk mount.
+   */
+  replacementCommand?: string;
 }
 
 export function buildUnsupportedGuidance(): string {
@@ -91,6 +107,7 @@ interface CodexPreToolDeps {
   handleGrepDirectFn?: typeof handleGrepDirect;
   readCachedIndexContentFn?: typeof readCachedIndexContent;
   writeCachedIndexContentFn?: typeof writeCachedIndexContent;
+  runVfsShellFn?: (command: string) => { status: number | null; stdout: string };
   logFn?: (msg: string) => void;
 }
 
@@ -115,6 +132,14 @@ export async function processCodexPreToolUse(
     handleGrepDirectFn = handleGrepDirect,
     readCachedIndexContentFn = readCachedIndexContent,
     writeCachedIndexContentFn = writeCachedIndexContent,
+    runVfsShellFn = (command: string) => {
+      const shellBundle = join(__bundleDir, "shell", "deeplake-shell.js");
+      const proc = spawnSync("node", [shellBundle, "-c", command], {
+        encoding: "utf-8",
+        timeout: 10_000,
+      });
+      return { status: proc.status, stdout: proc.stdout ?? "" };
+    },
     logFn = log,
   } = deps;
 
@@ -135,7 +160,7 @@ export async function processCodexPreToolUse(
   }
 
   if (!isSafe(rewritten)) {
-    // BLOCK (exit 2), not "guide" (exit 0). guide lets Codex run the original
+    // BLOCK (exit 2), never exit 0. Any exit-0 path lets Codex run the original
     // command on the host, so an unsafe memory command — `python … x.py`,
     // backticks, `$()`, `curl` — would still execute and could read/run real
     // files. Block stops it and injects the guidance instead.
@@ -357,33 +382,34 @@ export async function processCodexPreToolUse(
 
   // Nothing matched by the inline fast-path. Route through the VFS shell bundle
   // — a sandboxed Node.js interpreter against the SQL backend, no host access.
-  // We run it synchronously here (spawnSync) so the output is available before
-  // returning the decision.
+  // We run it synchronously here so the output is available before returning the
+  // decision; the write has already landed in the cloud `memory` table by then.
   //
   // Action choice:
-  //   "guide" (exit 0) — Codex treats the command as successful and also runs
-  //     the original on the host. Safe ONLY for write-redirect patterns
-  //     (echo/printf/tee … > /file) where the side-effect on the real
-  //     ~/.deeplake/memory/ disk dir is harmless — VFS reads always query SQL.
-  //   "block" (exit 2) — Codex treats the command as rejected. Used for
-  //     everything else (pipes, finds, reads) to prevent host execution.
-  // Safe to return "guide" (Codex also runs original on host) ONLY for pure
-  // output commands: echo/printf/tee writing to a VFS path. A generic ">>"
-  // check would match mixed commands like `sort /etc/passwd > /vfs/out` which
-  // would then execute on the host and read real files.
+  //   "allow" (exit 0 + updatedInput) — ONLY for write-redirect patterns
+  //     (echo/printf/tee … > /file). The VFS write already happened above, so we
+  //     rewrite the host command to a harmless echo: Codex reports success AND
+  //     never re-runs the original redirect against the on-disk mount (F3).
+  //   "block" (exit 2) — everything else (pipes, finds, reads) to prevent host
+  //     execution and inject the result/guidance via stderr.
+  // The write-redirect guard stays narrow: a generic ">>" check would match mixed
+  // commands like `sort /etc/passwd > /vfs/out`. Anchoring to echo/printf/tee keeps
+  // the rewrite to pure-output commands whose side effect is only the SQL write.
   const isWriteRedirect = /^\s*(echo|printf|tee)\b/.test(rewritten) && /\s>>?\s/.test(rewritten);
-  const shellBundle = join(__bundleDir, "shell", "deeplake-shell.js");
   logFn(`unroutable memory command, falling back to VFS shell: ${rewritten}`);
   try {
-    const proc = spawnSync("node", [shellBundle, "-c", rewritten], {
-      encoding: "utf-8",
-      timeout: 10_000,
-    });
+    const proc = runVfsShellFn(rewritten);
     if (proc.status === 0 || (proc.stdout && proc.stdout.trim())) {
       const output = (proc.stdout?.trim() ?? "") || "(done)";
-      // Write redirects: use "guide" so Codex reports success (not "blocked").
-      // Other commands: keep "block" so the host shell never runs them.
-      return { action: isWriteRedirect ? "guide" : "block", output, rewrittenCommand: rewritten };
+      if (isWriteRedirect) {
+        // Rewrite the host command to echo the VFS result. POSIX single-quote
+        // escaping so arbitrary output can't break out of the quotes.
+        const replacementCommand = `printf '%s\\n' '${output.replace(/'/g, `'\\''`)}'`;
+        return { action: "allow", output, replacementCommand, rewrittenCommand: rewritten };
+      }
+      // Non-write command handled by the VFS shell: block so the host never runs
+      // it; the captured output is injected via stderr.
+      return { action: "block", output, rewrittenCommand: rewritten };
     }
     // Shell exited non-zero (bundle missing or command failed) — fall back to guidance.
     return { action: "block", output: buildUnsupportedGuidance(), rewrittenCommand: rewritten };
@@ -404,8 +430,17 @@ async function main(): Promise<void> {
   const decision = await processCodexPreToolUse(input);
 
   if (decision.action === "pass") return;
-  if (decision.action === "guide") {
-    if (decision.output) process.stdout.write(decision.output);
+  if (decision.action === "allow") {
+    // Codex >= 0.136 honors a PreToolUse `permissionDecision: "allow"` with
+    // `updatedInput.command` and runs the rewritten command instead of the
+    // original. The VFS write already happened in processCodexPreToolUse.
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: decision.replacementCommand ?? "true" },
+      },
+    }));
     process.exit(0);
   }
   if (decision.output) process.stderr.write(decision.output);

--- a/src/hooks/codex/pre-tool-use.ts
+++ b/src/hooks/codex/pre-tool-use.ts
@@ -108,6 +108,7 @@ interface CodexPreToolDeps {
   readCachedIndexContentFn?: typeof readCachedIndexContent;
   writeCachedIndexContentFn?: typeof writeCachedIndexContent;
   runVfsShellFn?: (command: string) => { status: number | null; stdout: string };
+  tryGraphReadFn?: typeof tryGraphRead;
   logFn?: (msg: string) => void;
 }
 
@@ -140,6 +141,7 @@ export async function processCodexPreToolUse(
       });
       return { status: proc.status, stdout: proc.stdout ?? "" };
     },
+    tryGraphReadFn = tryGraphRead,
     logFn = log,
   } = deps;
 
@@ -153,7 +155,7 @@ export async function processCodexPreToolUse(
   // Graph VFS dispatch — a cat/head/tail/ls on the `/graph/*` subtree is
   // answered from the local snapshot, no SQL, no config needed. Runs before
   // the isSafe/grep/shell handling. Shared parser: src/graph/graph-command.ts.
-  const graphBody = tryGraphRead(rewritten, input.cwd ?? process.cwd());
+  const graphBody = tryGraphReadFn(rewritten, input.cwd ?? process.cwd());
   if (graphBody !== null) {
     logFn(`graph vfs intercept: ${rewritten}`);
     return { action: "block", output: graphBody, rewrittenCommand: rewritten };

--- a/src/hooks/codex/pre-tool-use.ts
+++ b/src/hooks/codex/pre-tool-use.ts
@@ -392,10 +392,14 @@ export async function processCodexPreToolUse(
   //     never re-runs the original redirect against the on-disk mount (F3).
   //   "block" (exit 2) — everything else (pipes, finds, reads) to prevent host
   //     execution and inject the result/guidance via stderr.
-  // The write-redirect guard stays narrow: a generic ">>" check would match mixed
-  // commands like `sort /etc/passwd > /vfs/out`. Anchoring to echo/printf/tee keeps
-  // the rewrite to pure-output commands whose side effect is only the SQL write.
-  const isWriteRedirect = /^\s*(echo|printf|tee)\b/.test(rewritten) && /\s>>?\s/.test(rewritten);
+  // The write-redirect guard stays narrow: anchoring to echo/printf/tee keeps the
+  // rewrite to pure-output commands whose side effect is only the SQL write (a bare
+  // ">>" check would match mixed commands like `sort /etc/passwd > /vfs/out`).
+  // The redirect test is whitespace-agnostic — `echo foo>file` is as valid as
+  // `echo foo > file`; requiring spaces would misroute the no-space form to `block`
+  // and re-surface the F3 "write looks failed" symptom. `[^0-9&>]` before the `>`
+  // excludes fd redirects (`2>`, `&>`) so those still fall through to block.
+  const isWriteRedirect = /^\s*(echo|printf|tee)\b/.test(rewritten) && /(^|[^0-9&>])>>?/.test(rewritten);
   logFn(`unroutable memory command, falling back to VFS shell: ${rewritten}`);
   try {
     const proc = runVfsShellFn(rewritten);

--- a/tests/codex/codex-pre-tool-use-branches.test.ts
+++ b/tests/codex/codex-pre-tool-use-branches.test.ts
@@ -419,3 +419,56 @@ describe("processCodexPreToolUse: find + grep + fallback", () => {
     expect(d.output).toContain("not supported");
   });
 });
+
+describe("processCodexPreToolUse: memory write redirect (F3 — no double execution)", () => {
+  const writeCmd = "echo 'hello' > ~/.deeplake/memory/h2h/relay-codex.md";
+
+  function writeDeps(extra: Record<string, any> = {}) {
+    return {
+      ...baseDeps(extra),
+      // Writes are not compiled reads — force the inline fast-path to miss so the
+      // command reaches the VFS-shell fallback (the real production behavior).
+      executeCompiledBashCommandFn: vi.fn(async () => null) as any,
+    };
+  }
+
+  it("a successful VFS write returns action=allow with a rewritten host command, NOT guide/pass", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "(done)" }));
+    const d = await processCodexPreToolUse(toolInput(writeCmd), writeDeps({ runVfsShellFn }));
+
+    // allow ⇒ main() emits permissionDecision:allow + updatedInput so Codex runs
+    // the REPLACEMENT, not the original. pass/guide would let the original redirect
+    // re-run on the host (the F3 "No such file or directory" double execution).
+    expect(d.action).toBe("allow");
+    expect(d.action).not.toBe("pass");
+    expect(runVfsShellFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("the replacement command echoes the VFS result and never re-runs the original redirect", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "(done)" }));
+    const d = await processCodexPreToolUse(toolInput(writeCmd), writeDeps({ runVfsShellFn }));
+
+    expect(d.replacementCommand).toBe("printf '%s\\n' '(done)'");
+    // Negative assertions: the host must NOT re-execute the write. The rewrite
+    // must contain neither a redirect operator nor the memory path.
+    expect(d.replacementCommand).not.toMatch(/>/);
+    expect(d.replacementCommand).not.toContain(".deeplake/memory");
+  });
+
+  it("POSIX-escapes single quotes in the VFS output so it can't break out of the rewrite", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "it's done" }));
+    const d = await processCodexPreToolUse(toolInput(writeCmd), writeDeps({ runVfsShellFn }));
+
+    expect(d.action).toBe("allow");
+    expect(d.replacementCommand).toBe(`printf '%s\\n' 'it'\\''s done'`);
+  });
+
+  it("falls back to block+guidance when the VFS shell fails (non-zero, no stdout)", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 1, stdout: "" }));
+    const d = await processCodexPreToolUse(toolInput(writeCmd), writeDeps({ runVfsShellFn }));
+
+    expect(d.action).toBe("block");
+    expect(d.output).toContain("not supported");
+    expect(d.replacementCommand).toBeUndefined();
+  });
+});

--- a/tests/codex/codex-pre-tool-use-branches.test.ts
+++ b/tests/codex/codex-pre-tool-use-branches.test.ts
@@ -497,3 +497,135 @@ describe("processCodexPreToolUse: memory write redirect (F3 — no double execut
     expect(d.replacementCommand).toBeUndefined();
   });
 });
+
+describe("processCodexPreToolUse: ls / find variants + fallback branches", () => {
+  const noCompiled = () => ({ executeCompiledBashCommandFn: vi.fn(async () => null) as any });
+
+  it("ls -l lists files and subdirs in long format, skipping rows outside the dir", async () => {
+    const listVirtualPathRowsFn = vi.fn(async () => [
+      { path: "/sessions/a.json", size_bytes: 42 },
+      { path: "/sessions/sub/b.json", size_bytes: 10 }, // nested → directory entry
+      { path: "/other/z.json", size_bytes: 5 },          // outside /sessions → skipped
+    ]) as any;
+    const d = await processCodexPreToolUse(
+      toolInput("ls -l ~/.deeplake/memory/sessions"),
+      { ...baseDeps({ listVirtualPathRowsFn }), ...noCompiled() },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toContain("a.json");
+    expect(d.output).toContain("sub/");      // nested path collapses to a dir entry
+    expect(d.output).toMatch(/drwx/);        // long-format directory line
+    expect(d.output).toMatch(/-rw/);         // long-format file line
+    expect(d.output).not.toContain("z.json"); // row outside the prefix is dropped
+  });
+
+  it("ls / (mount root) lists top-level entries", async () => {
+    const listVirtualPathRowsFn = vi.fn(async () => [
+      { path: "/sessions/a.json", size_bytes: 1 },
+      { path: "/index.md", size_bytes: 2 },
+    ]) as any;
+    const d = await processCodexPreToolUse(
+      toolInput("ls ~/.deeplake/memory"),
+      { ...baseDeps({ listVirtualPathRowsFn }), ...noCompiled() },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toContain("sessions/");
+    expect(d.output).toContain("index.md");
+  });
+
+  it("ls on an unknown dir returns 'cannot access'", async () => {
+    const d = await processCodexPreToolUse(
+      toolInput("ls ~/.deeplake/memory/nope"),
+      { ...baseDeps({ listVirtualPathRowsFn: vi.fn(async () => []) as any }), ...noCompiled() },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toContain("cannot access");
+  });
+
+  it("find -name with a double-quoted pattern resolves matches", async () => {
+    const d = await processCodexPreToolUse(
+      toolInput('find ~/.deeplake/memory/sessions -name "*.md"'),
+      { ...baseDeps({ findVirtualPathsFn: vi.fn(async () => ["/sessions/a.md"]) as any }), ...noCompiled() },
+    );
+    expect(d.output).toBe("/sessions/a.md");
+  });
+
+  it("find -name with an unquoted pattern resolves matches", async () => {
+    const d = await processCodexPreToolUse(
+      toolInput("find ~/.deeplake/memory/sessions -name *.md"),
+      { ...baseDeps({ findVirtualPathsFn: vi.fn(async () => ["/sessions/b.md"]) as any }), ...noCompiled() },
+    );
+    expect(d.output).toBe("/sessions/b.md");
+  });
+
+  it("find rooted at the mount (/) normalizes the dir argument to '/'", async () => {
+    const findVirtualPathsFn = vi.fn(async () => ["/x.json"]) as any;
+    const d = await processCodexPreToolUse(
+      toolInput("find ~/.deeplake/memory -name '*.json'"),
+      { ...baseDeps({ findVirtualPathsFn }), ...noCompiled() },
+    );
+    expect(d.output).toBe("/x.json");
+    expect(findVirtualPathsFn).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), "/", expect.anything(),
+    );
+  });
+
+  it("a non-redirect echo handled by the VFS shell stays on block (not allow)", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "echoed" }));
+    const d = await processCodexPreToolUse(
+      toolInput("echo hello ~/.deeplake/memory/note.txt"),
+      { ...baseDeps(), ...noCompiled(), runVfsShellFn },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toBe("echoed");
+    expect(d.replacementCommand).toBeUndefined();
+  });
+
+  it("a write succeeds via stdout even when the VFS shell exits non-zero", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 1, stdout: "still wrote" }));
+    const d = await processCodexPreToolUse(
+      toolInput("echo 'x' > ~/.deeplake/memory/h2h/a.md"),
+      { ...baseDeps(), ...noCompiled(), runVfsShellFn },
+    );
+    expect(d.action).toBe("allow");
+    expect(d.replacementCommand).toBe("printf '%s\\n' 'still wrote'");
+  });
+
+  it("a write with empty stdout defaults the echoed result to (done)", async () => {
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "" }));
+    const d = await processCodexPreToolUse(
+      toolInput("echo 'x' > ~/.deeplake/memory/h2h/a.md"),
+      { ...baseDeps(), ...noCompiled(), runVfsShellFn },
+    );
+    expect(d.action).toBe("allow");
+    expect(d.replacementCommand).toBe("printf '%s\\n' '(done)'");
+  });
+
+  it("a /graph read is answered from the local snapshot (block + body), before any SQL", async () => {
+    const tryGraphReadFn = vi.fn(() => "GRAPH SNAPSHOT BODY") as any;
+    const executeCompiledBashCommandFn = vi.fn(async () => "SHOULD-NOT-RUN") as any;
+    const d = await processCodexPreToolUse(
+      toolInput("cat ~/.deeplake/memory/graph/index.md"),
+      { ...baseDeps({ tryGraphReadFn }), executeCompiledBashCommandFn },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toBe("GRAPH SNAPSHOT BODY");
+    expect(executeCompiledBashCommandFn).not.toHaveBeenCalled(); // graph short-circuits before SQL
+  });
+
+  it("resolves a read using the DEFAULT createApi + log deps (no injection)", async () => {
+    // Omit createApi / logFn / cache deps so their default values run: the default
+    // createApi constructs a DeeplakeApi (no network at construction) and the
+    // module-level `log` executes. The injected read fn keeps it off the network.
+    const d = await processCodexPreToolUse(
+      toolInput("cat ~/.deeplake/memory/sessions/a.json"),
+      {
+        config: BASE_CONFIG as any,
+        executeCompiledBashCommandFn: vi.fn(async () => null) as any,
+        readVirtualPathContentFn: vi.fn(async () => "DEFAULT-DEPS-CONTENT") as any,
+      },
+    );
+    expect(d.action).toBe("block");
+    expect(d.output).toBe("DEFAULT-DEPS-CONTENT");
+  });
+});

--- a/tests/codex/codex-pre-tool-use-branches.test.ts
+++ b/tests/codex/codex-pre-tool-use-branches.test.ts
@@ -463,6 +463,31 @@ describe("processCodexPreToolUse: memory write redirect (F3 — no double execut
     expect(d.replacementCommand).toBe(`printf '%s\\n' 'it'\\''s done'`);
   });
 
+  it("treats a no-space redirect (echo foo>file) as a write → allow, not block", async () => {
+    // CodeRabbit #284: `/\s>>?\s/` missed `echo foo>file`, misrouting it to block
+    // and re-surfacing the F3 "write looks failed" symptom. The relaxed guard
+    // must recognize the redirect regardless of surrounding whitespace.
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "(done)" }));
+    const d = await processCodexPreToolUse(
+      toolInput("echo 'hello'>~/.deeplake/memory/h2h/relay-codex.md"),
+      writeDeps({ runVfsShellFn }),
+    );
+    expect(d.action).toBe("allow");
+    expect(d.replacementCommand).toBe("printf '%s\\n' '(done)'");
+  });
+
+  it("does NOT treat an fd redirect (echo ... 2>file) as a write → stays block", async () => {
+    // `2>`/`&>` are file-descriptor redirects, not memory writes. The `[^0-9&>]`
+    // guard must keep them on the block path (no allow rewrite).
+    const runVfsShellFn = vi.fn(() => ({ status: 0, stdout: "x" }));
+    const d = await processCodexPreToolUse(
+      toolInput("echo hello 2>~/.deeplake/memory/h2h/err.md"),
+      writeDeps({ runVfsShellFn }),
+    );
+    expect(d.action).toBe("block");
+    expect(d.replacementCommand).toBeUndefined();
+  });
+
   it("falls back to block+guidance when the VFS shell fails (non-zero, no stdout)", async () => {
     const runVfsShellFn = vi.fn(() => ({ status: 1, stdout: "" }));
     const d = await processCodexPreToolUse(toolInput(writeCmd), writeDeps({ runVfsShellFn }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,6 +98,15 @@ export default defineConfig({
           functions: 90,
           lines: 90,
         },
+        // PR #284 — fix(codex): PreToolUse allow-rewrite for memory writes (F3).
+        // Branch suite covers the read fast-path, write-redirect allow/block
+        // arms, and the graph/default-deps branches. Held at 90 to lock the gate.
+        "src/hooks/codex/pre-tool-use.ts": {
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
+        },
         "src/hooks/session-queue.ts": {
           statements: 80,
           branches: 80,


### PR DESCRIPTION
## Problem (F3)

A Codex memory write (`echo '...' > <memory-mount>/<dir>/file.md`) surfaced a spurious `/bin/bash: ... No such file or directory` even though the SQL write succeeded.

**Root cause — double execution.** The write-redirect branch returned plain text + exit 0. Codex >= 0.136 treats a PreToolUse exit-0 with no JSON as "allow", so it re-runs the *original* redirect on the host shell against the on-disk mount; when the subdir doesn't exist on disk the host `echo` errors. The VFS/SQL write had already happened in-hook, so the user sees a failure on a write that actually worked.

## Fix

The write-redirect branch now returns `action: "allow"` and the hook emits the PreToolUse JSON Codex honors:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","updatedInput":{"command":"printf '%s\\n' '(done)'"}}}
```

Codex runs the harmless replacement instead of the original redirect — no double execution, no spurious error, no on-disk shadow file. The dead `guide` action (its only producer) is removed.

The contract was verified against the installed Codex (0.136.0): `codex-rs/hooks/src/events/pre_tool_use.rs` test `permission_decision_allow_can_update_input` (tag `rust-v0.136.0`) proves this exact JSON rewrites the Bash command.

## Tests

`tests/codex/codex-pre-tool-use-branches.test.ts`: allow-shape on success, POSIX single-quote escaping, negative assertions that the rewrite contains neither a redirect operator nor the memory path (proves no host re-execution), and failure -> block fallback. Full codex suite green (180/180); tsc clean.

## Not verified

Live `codex exec` round-trip — gated on model credentials + non-prod tables (same gate as the original cross-agent pass). Covered by source-contract + unit + bundle checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Codex pre-tool-use permissions to add an explicit **“allow”** path for safe memory write-redirect handling, including host command rewriting to prevent unintended re-execution.

* **Bug Fixes**
  * Refined redirect detection so only safe memory-write patterns are eligible, while file-descriptor redirects are handled as unsupported.

* **Tests**
  * Expanded Vitest branch coverage for memory write-redirects and additional `ls`/`find` and fallback behaviors, including success, failure, and quoting/escaping edge cases.

* **Chores**
  * Increased per-file coverage thresholds for the pre-tool-use hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->